### PR TITLE
feat(vr): constrain held guns against level geometry

### DIFF
--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -265,11 +265,57 @@ fn split_at_terminal_joint(
         .partition(|vertex| rigid_joint(vertex) == Some(terminal_joint))
 }
 
-fn weapon_geometry(mesh: &SystemShockContentModel) -> Option<VrHeldWeaponGeometry> {
-    let SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) = mesh else {
-        return None;
-    };
+/// The weapon-only geometry of an LGMD first-person model (the 25AE gun `_h`
+/// meshes, and any classic world model wielded as-is).
+///
+/// These carry no skeleton of their own: the "joints" are the sub-object
+/// hierarchy, which is how a slide or a magazine moves, and the renderer poses
+/// them through exactly the skeleton [`ss2_bin_obj_loader::obj_skeleton`]
+/// builds. The weapon/arm split is by material rather than by terminal joint -
+/// a gun's arm is not a joint, it is `ND-arm*` geometry that can ride any
+/// sub-object (see [`is_first_person_arm_material`]).
+///
+/// Like both skinned branches below, this measures the *authored* geometry: the
+/// renderer additionally drops any slot whose texture will not resolve, and
+/// this fit does not. A model missing a texture would therefore be fitted
+/// slightly larger than it draws - which is the safe direction (the weapon
+/// stops short rather than sinking in), and is how the melee fit has always
+/// behaved.
+fn obj_weapon_geometry(obj: &SystemShock2ObjectMesh) -> Option<VrHeldWeaponGeometry> {
+    let mut vertices = Vec::new();
+    let mut arm_vertices = Vec::new();
+    for (material, run) in ss2_bin_obj_loader::to_vertices_by_material(obj) {
+        if is_first_person_arm_material(&material) {
+            arm_vertices.extend(run);
+        } else {
+            vertices.extend(run);
+        }
+    }
 
+    (!vertices.is_empty()).then(|| VrHeldWeaponGeometry {
+        vertices,
+        arm_vertices,
+        skeleton: Rc::new(ss2_bin_obj_loader::obj_skeleton(obj)),
+        bind: None,
+    })
+}
+
+fn weapon_geometry(mesh: &SystemShockContentModel) -> Option<VrHeldWeaponGeometry> {
+    match mesh {
+        SystemShockContentModel::Obj(obj) => obj_weapon_geometry(obj),
+        SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) => {
+            skinned_weapon_geometry(ai_mesh, skeleton, pmnm)
+        }
+    }
+}
+
+/// The weapon-only geometry of an LGMM skinned first-person model - the melee
+/// `_h` rigs, with or without a 25AE high-detail `PMNM` chunk.
+fn skinned_weapon_geometry(
+    ai_mesh: &SystemShock2AIMesh,
+    skeleton: &Rc<Skeleton>,
+    pmnm: &Option<crate::ss2_bin_pmnm::PmnmMesh>,
+) -> Option<VrHeldWeaponGeometry> {
     if let Some(pmnm) = pmnm {
         let runs = pmnm.to_skinned_vertices();
         let has_named_arm = runs

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -124,10 +124,8 @@ pub fn to_scene_objects(
         .into_iter()
         .collect::<Vec<(u16, Vec<VertexPositionTextureSkinnedNormal>)>>();
 
-    let mut bones = Vec::new();
-    build_skeleton_for_obj_mesh(&mesh, 0, None, &mut bones);
-    let is_skinned = bones.len() > 1;
-    let skeleton = Skeleton::create_from_bones(bones);
+    let skeleton = obj_skeleton(mesh);
+    let is_skinned = skeleton.bone_count() > 1;
 
     let mut mesh_objects = vertices
         .into_iter()
@@ -659,6 +657,31 @@ pub fn sub_object_bounds(
                 });
             }
             (name, bounds)
+        })
+        .collect()
+}
+
+/// [`to_vertices`] keyed by material name rather than by slot, so a caller can
+/// select geometry the way the 25AE authors it - by material - without
+/// re-deriving the slot table. Ordered by slot, and slots with no material
+/// entry are dropped (nothing can draw them either).
+pub fn to_vertices_by_material(
+    mesh: &SystemShock2ObjectMesh,
+) -> Vec<(String, Vec<VertexPositionTextureSkinnedNormal>)> {
+    let mut by_slot = to_vertices(mesh).into_iter().collect::<Vec<_>>();
+    by_slot.sort_by_key(|(slot, _)| *slot);
+    by_slot
+        .into_iter()
+        .filter_map(|(slot, vertices)| {
+            // Last entry wins on a duplicated slot, matching the map
+            // `to_scene_objects` builds - so a caller selecting geometry by
+            // material selects what the renderer draws with.
+            let material = mesh
+                .materials
+                .iter()
+                .filter(|material| material.slot_num as u16 == slot)
+                .next_back()?;
+            Some((material.name.clone(), vertices))
         })
         .collect()
 }
@@ -1301,6 +1324,34 @@ mod tests {
         assert_eq!(transforms[0].1.w.truncate(), vec3(1.0, 0.0, 0.0));
         assert_eq!(transforms[1].0, "child");
         assert_eq!(transforms[1].1.w.truncate(), vec3(1.0, 1.0, 0.0));
+    }
+
+    /// Fitting a collider to a first-person model's *weapon* means selecting
+    /// geometry by material (the arm is `ND-arm*`), so the vertex runs have to
+    /// come back labelled with the material that draws them.
+    #[test]
+    fn vertices_come_back_grouped_by_their_material() {
+        let mut mesh = mesh_with(
+            vec![
+                material_in_slot("ND-ar15.psd", 0),
+                material_in_slot("ND-arm.psd", 1),
+            ],
+            vec![polygon_in_slot(0), polygon_in_slot(1)],
+        );
+        mesh.vertices = vec![
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        ];
+
+        let runs = to_vertices_by_material(&mesh);
+
+        let names = runs
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["ND-ar15.psd", "ND-arm.psd"]);
+        assert!(runs.iter().all(|(_, vertices)| vertices.len() == 3));
     }
 
     #[test]

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -59,6 +59,13 @@ headset comfort.
   not a claim about original System Shock 2. Preserve the original Agility,
   Still Hand and aiming-implant behavior when establishing parity; tune how
   Strength combines with it after that baseline is measurable.
+- **Two hands use the authored recoil baseline; one hand adds a spring recoil
+  penalty.** Preserve Agility, Still Hand and aiming-implant modifiers in the
+  baseline. Strength is a separate VR control multiplier on that baseline and
+  reduces the additional one-handed penalty. Both components can use springs.
+  Support-grip changes alter future impulses; they never reset accumulated
+  recoil or snap the weapon back. Evaluate pistol and AR at Strength 1/3/6
+  with one and two hands, recording muzzle motion separately from bullet spread.
 - Weapon skill governs authored inaccuracy, but shipped `SKILLPARAM` sets that
   inaccuracy to zero. Strength does not enter this calculation. Preserve Sharpshooter's original
   ranged-damage benefit; an accuracy bonus is not part of the accepted baseline.
@@ -590,3 +597,23 @@ not recordings of gameplay timing. Coincident impacts are not visually jittered.
 [AR eligibility/results](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/ar-results.png) and
 [matched runtime screenshots](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/runtime-comparison.png)
 complete the evaluation.
+
+
+## Physical-held foundation (current recoil stack)
+
+Adapt #1142 behind `--experimental physical_held_items` in VR. Held guns
+use inert bodies: translation sweeps stop at world geometry, while projectile
+rays and physics projectiles cannot hit the held gun. Melee retains its hitbox
+contacts. Calibrated glove colliders use the fitted weapon-only triangles and
+item scale; legacy held models use their posed geometry, including left-hand
+reflection. Drop and refused backpack storage restore ordinary loose physics.
+
+This increment constrains **translation only**. Orientation follows the tracked
+pose, so rotating a stationary long barrel can intersect a wall. It does not
+claim rotational collision clearance or implement recoil yet. The subsequent
+spring layer must use the constrained body for the rendered gun and muzzle;
+headset feel and rotational clearance remain explicit validation boundaries.
+
+Validation: 1,634 gameplay tests, 172 Dark tests, warning-denied desktop/debug
+checks, and three SDK cases (left/right wall contact and firing, withdrawal,
+drop, and full-backpack release). [Before/after evidence](https://gist.github.com/tommy-xr/7e0d0b99cfebcb5cae09724ee16e5376).

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -279,7 +279,7 @@ struct HeldGrip {
 }
 
 impl HeldGrip {
-    /// Undo the contact-origin split on the collision-resolved melee body.
+    /// Resolve the physical weapon pose, undoing melee's contact-origin split.
     fn physical_model_pose(&self, world: &World) -> Option<GripPose> {
         use shipyard::{Get, View};
         let grip = self.resolved.as_ref()?;
@@ -290,7 +290,13 @@ impl HeldGrip {
             )>()
             .ok()?;
         let position = positions.get(self.entity).ok()?;
-        let contact = offsets.get(self.entity).ok()?.0;
+        let contact = match offsets.get(self.entity) {
+            Ok(offset) => offset.0,
+            Err(_) => {
+                crate::mission::mission_core::held_item_collision_group(world, self.entity)?;
+                Vector3::new(0.0, 0.0, 0.0)
+            }
+        };
         let pose = GripPose {
             position: position.position
                 - position.rotation.rotate_vector(contact * grip.item_scale),
@@ -868,14 +874,16 @@ impl PlayerInteraction for VrInteraction {
                             && e.authored
                             && resolved.as_ref() == Some(&e.grip)
                     });
-                if crate::vr_weapon_grip::is_melee(&model) {
+                if crate::mission::mission_core::held_item_collision_group(world, entity).is_some()
+                {
                     if let (Some(grip), Some(geometry), Some(contact)) = (
                         resolved.as_ref(),
                         geometry,
                         world
                             .borrow::<View<crate::runtime_props::RuntimePropVrGripOffset>>()
                             .ok()
-                            .and_then(|v| v.get(entity).ok().map(|p| p.0)),
+                            .and_then(|v| v.get(entity).ok().map(|p| p.0))
+                            .or(Some(cgmath::vec3(0.0, 0.0, 0.0))),
                     ) {
                         let mut min = cgmath::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
                         let mut max = -min;
@@ -886,7 +894,7 @@ impl PlayerInteraction for VrInteraction {
                                 max[axis] = max[axis].max(p[axis]);
                             }
                         }
-                        effects.push(VirtualHandEffect::FitHeldMelee {
+                        effects.push(VirtualHandEffect::FitHeldItem {
                             entity_id: entity,
                             size: max - min,
                             center: (min + max) * 0.5,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1776,6 +1776,14 @@ pub struct DebugOptions {
 #[derive(Unique, Clone, Copy)]
 pub struct GlobalPresentationMode(pub crate::PresentationMode);
 
+/// Whether `--experimental physical_held_items` is on: a VR-held gun keeps a
+/// swept body, like a held melee weapon, so it stops at the level's geometry
+/// instead of passing through it. Accessible from the paths that establish
+/// held-item physics without `GameOptions` in hand (the restore path, the
+/// virtual-hand effects).
+#[derive(Unique, Clone, Copy)]
+pub struct GlobalPhysicalHeldItems(pub bool);
+
 /// Pathfinding service accessible from scripts (steering strategies) via
 /// UniqueView. None when the mission has no AIPATH data (e.g. debug scenes).
 #[derive(Unique, Clone)]
@@ -2344,6 +2352,11 @@ impl MissionCore {
             debug_ai: game_options.debug_ai,
         });
         world.add_unique(GlobalPresentationMode(game_options.presentation_mode));
+        world.add_unique(GlobalPhysicalHeldItems(
+            game_options
+                .experimental_features
+                .contains("physical_held_items"),
+        ));
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
         world.add_unique(
@@ -8895,7 +8908,7 @@ impl MissionCore {
                                                         "wield '{model_name}': baked arm unmeasured"
                                                     ),
                                                 }
-                                                self.physics.fit_held_melee_cuboid(
+                                                self.physics.fit_held_item_cuboid(
                                                     entity_id,
                                                     bounds.size,
                                                     bounds.center,
@@ -8919,6 +8932,53 @@ impl MissionCore {
                             }
                         } else if was_vr_held && !new_model.is_animated() {
                             self.id_to_animation_player.remove(&entity_id);
+                        }
+
+                        // A physically held gun (`physical_held_items`) is
+                        // swept against the level with a cuboid fitted to the
+                        // *rendered* view model, exactly as a melee weapon is.
+                        // Without this it would keep the loose-prop box, which
+                        // is the size of the WORLD model and centred on the
+                        // grip rather than on the barrel - so the weapon would
+                        // stop at the wrong distance from a wall, in both
+                        // directions. Guns author no grip correction (their
+                        // offset moves the entity, not the mesh), so model
+                        // space is the body's own frame and the fit needs no
+                        // transform. Melee took its own fit above, with the
+                        // posed arm's correction.
+                        let is_physical_gun = vr_held
+                            && !glove_weapon
+                            && self.interaction.is_holding(entity_id)
+                            && self
+                                .held_item_collision_group(entity_id)
+                                .is_some_and(|group| group.is_inert());
+                        if is_physical_gun {
+                            // The same player the model is rendered with, so
+                            // the fit measures the pose the player sees.
+                            let player = self
+                                .id_to_animation_player
+                                .get(&entity_id)
+                                .cloned()
+                                .unwrap_or_else(AnimationPlayer::empty);
+                            if let Some(bounds) = vr_held_source.as_ref().and_then(|source| {
+                                source.posed_weapon_bounds(&player, hand.gun_mirror())
+                            }) {
+                                let cm = crate::METERS_PER_WORLD_UNIT * 100.0;
+                                tracing::info!(
+                                    "wield '{model_name}': rendered weapon {:.0}x{:.0}x{:.0} cm, center ({:.3}, {:.3}, {:.3})",
+                                    bounds.size.x * cm,
+                                    bounds.size.y * cm,
+                                    bounds.size.z * cm,
+                                    bounds.center.x,
+                                    bounds.center.y,
+                                    bounds.center.z,
+                                );
+                                self.physics.fit_held_item_cuboid(
+                                    entity_id,
+                                    bounds.size,
+                                    bounds.center,
+                                );
+                            }
                         }
                         self.id_to_model.insert(entity_id, new_model);
                         self.world
@@ -11865,8 +11925,8 @@ impl MissionCore {
             // `HoldItem`, so establish the melee contact body here
             // too - otherwise a weapon equipped this way is held
             // without a collider and never reports contacts.
-            if self.is_vr_melee_weapon(entity_id) {
-                self.attach_held_melee_physics(entity_id);
+            if let Some(group) = self.held_item_collision_group(entity_id) {
+                self.attach_held_item_physics(entity_id, group);
             }
 
             // Let the scripts know we are now holding the item..
@@ -11994,12 +12054,12 @@ impl MissionCore {
                     }
                     self.set_entity_position_rotation(entity_id, position, rotation, scale);
                 }
-                VirtualHandEffect::FitHeldMelee {
+                VirtualHandEffect::FitHeldItem {
                     entity_id,
                     size,
                     center,
                 } => {
-                    self.physics.fit_held_melee_cuboid(entity_id, size, center);
+                    self.physics.fit_held_item_cuboid(entity_id, size, center);
                 }
                 VirtualHandEffect::SpawnEntity {
                     template_id,
@@ -12018,13 +12078,13 @@ impl MissionCore {
                 VirtualHandEffect::HoldItem { entity_id } => {
                     self.world
                         .remove::<crate::runtime_props::RuntimePropHolstered>(entity_id);
-                    if self.is_vr_melee_weapon(entity_id) {
-                        // Held guns/items stay unphysical, but a VR melee
-                        // weapon needs its authored collider to report genuine
-                        // contacts. A joint motor drives its dynamic body
-                        // toward the tracked hand while world contact can hold
-                        // the rendered weapon back.
-                        self.attach_held_melee_physics(entity_id);
+                    // Most held items stay unphysical and pass through
+                    // everything. A VR melee weapon needs its collider to
+                    // report genuine contacts; with `physical_held_items` a
+                    // held gun keeps one too, purely so world geometry can
+                    // hold the rendered weapon back.
+                    if let Some(group) = self.held_item_collision_group(entity_id) {
+                        self.attach_held_item_physics(entity_id, group);
                     } else {
                         self.make_un_physical(entity_id);
                     }
@@ -12143,7 +12203,7 @@ impl MissionCore {
         if !restore_live_entity_world_refs(&mut self.world, entity_id) {
             return;
         }
-        if self.is_vr_melee_weapon(entity_id) {
+        if self.held_item_collision_group(entity_id).is_some() {
             // Recreate from authored physics so the released item is an
             // ordinary dynamic, harmless loose prop again.
             self.make_un_physical(entity_id);
@@ -12169,14 +12229,16 @@ impl MissionCore {
     /// release was claimed but then lost the room race), and must be
     /// restored rather than vanish.
     fn restore_refused_store_to_world(&mut self, entity_id: EntityId) {
-        if self.id_to_physics.contains_key(&entity_id) {
+        if self.id_to_physics.contains_key(&entity_id) && !self.physics.is_held_item(entity_id) {
             return;
         }
         self.drop_held_item_into_world(entity_id);
     }
 
-    fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
-        is_vr_melee_weapon(&self.world, entity_id)
+    /// The collision group this entity is held with, or `None` when it is
+    /// held with no body (see [`held_item_collision_group`]).
+    fn held_item_collision_group(&self, entity_id: EntityId) -> Option<CollisionGroup> {
+        held_item_collision_group(&self.world, entity_id)
     }
 
     /// Undo a computed grip offset before a released item becomes a loose prop
@@ -12226,12 +12288,13 @@ impl MissionCore {
         self.set_entity_position_rotation(entity_id, hand, rotation, vec3(1.0, 1.0, 1.0));
     }
 
-    /// Give a held melee weapon the contact body the VR damage window needs.
-    /// Idempotent: `make_physical` no-ops when the body already exists, so this
-    /// is safe on both a fresh grab and a restore.
-    fn attach_held_melee_physics(&mut self, entity_id: EntityId) {
+    /// Give a held item the swept body its wield needs - the contact volume a
+    /// melee weapon damages with, or the inert one that keeps a gun out of the
+    /// level's geometry. Idempotent: `make_physical` no-ops when the body
+    /// already exists, so this is safe on both a fresh grab and a restore.
+    fn attach_held_item_physics(&mut self, entity_id: EntityId, group: CollisionGroup) {
         self.make_physical(entity_id);
-        self.physics.set_held_melee(entity_id);
+        self.physics.set_held_item_physical(entity_id, group);
     }
 
     /// Queue an entity to be triggered after scripts are initialized
@@ -12698,6 +12761,44 @@ pub fn is_melee_weapon(world: &World, entity_id: EntityId) -> bool {
         .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
 }
 
+/// How this entity behaves physically while held in a VR hand, or `None` if it
+/// is held with no body at all (which is what every held item did before the
+/// melee weapons needed contacts).
+///
+/// Two cases, and the difference is what the body is *for*:
+/// - a melee weapon's body is its damage volume, so it must generate contacts;
+/// - a gun's body only has to stop the weapon travelling into the level, so it
+///   takes part in no collision at all (see [`CollisionGroup::held_inert`]).
+///   Opt-in, because a weapon the world can hold back is a change to how
+///   aiming and firing feel, not just to how the wield looks.
+///
+/// A gun additionally has to be one VR actually wields as a first-person `_h`
+/// model, which is the same condition `InternalSwitchHeldModelScript` swaps on.
+/// On a classic install VR deliberately keeps the *world* model, so no `_h`
+/// wield happens and there is nothing to fit a collider to - the gun would
+/// sweep the inherited loose-pickup box, sized and centred for a different
+/// mesh, and stop at the wrong distance from every wall. No fit, no body.
+pub fn held_item_collision_group(world: &World, entity_id: EntityId) -> Option<CollisionGroup> {
+    if is_vr_melee_weapon(world, entity_id) {
+        return Some(CollisionGroup::held_melee());
+    }
+
+    let is_vr = world
+        .borrow::<UniqueView<GlobalPresentationMode>>()
+        .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr);
+    let physical_held_items = world
+        .borrow::<UniqueView<GlobalPhysicalHeldItems>>()
+        .is_ok_and(|enabled| enabled.0);
+    let is_gun = world
+        .borrow::<View<dark::properties::PropPlayerGun>>()
+        .is_ok_and(|guns| guns.get(entity_id).is_ok());
+    let wields_a_view_model = crate::is_25th_anniversary_install()
+        && crate::scripts::internal_switch_held_model::get_raw_view_model(world, entity_id)
+            .is_some_and(|model| crate::vr_config::is_vr_view_model(&model));
+
+    (is_vr && physical_held_items && is_gun && wields_a_view_model).then(CollisionGroup::held_inert)
+}
+
 /// Physics for an item restored into a hand by save/load or a level change.
 ///
 /// The restore path cannot reuse `VirtualHandEffect::HoldItem` - only a fresh
@@ -12711,10 +12812,9 @@ fn restore_held_item_physics(
     physics: &mut PhysicsWorld,
     entity_id: EntityId,
 ) {
-    if is_vr_melee_weapon(world, entity_id) {
-        physics.set_held_melee(entity_id);
-    } else {
-        make_un_physical2(id_to_physics, physics, entity_id);
+    match held_item_collision_group(world, entity_id) {
+        Some(group) => physics.set_held_item_physical(entity_id, group),
+        None => make_un_physical2(id_to_physics, physics, entity_id),
     }
 }
 
@@ -16090,5 +16190,95 @@ impl crate::game_scene::GameScene for MissionCore {
 
     fn wants_pointer(&self) -> bool {
         self.wants_pointer()
+    }
+}
+
+#[cfg(test)]
+mod held_item_physics_tests {
+    use super::*;
+    use dark::properties::{PropLimbModel, PropPlayerGun};
+
+    fn world_with(mode: crate::PresentationMode, physical_held_items: bool) -> World {
+        let world = World::new();
+        world.add_unique(GlobalPresentationMode(mode));
+        world.add_unique(GlobalPhysicalHeldItems(physical_held_items));
+        world
+    }
+
+    fn gun(world: &mut World) -> EntityId {
+        world.add_entity((PropPlayerGun {
+            flags: 0,
+            hand_model: "atek_h".to_owned(),
+            icon_file: String::new(),
+            model_offset: cgmath::Vector3::new(0.0, 0.0, 0.0),
+            fire_offset: cgmath::Vector3::new(0.0, 0.0, 0.0),
+            heading: 0,
+            reload_pitch: 0,
+            reload_rate: 0,
+            gun_type: 0,
+        },))
+    }
+
+    fn melee(world: &mut World) -> EntityId {
+        world.add_entity((PropLimbModel("wrench_h".to_owned()),))
+    }
+
+    /// The shipped behavior: a VR-held gun has no body at all, so it passes
+    /// through the level exactly as it always has.
+    #[test]
+    fn a_held_gun_is_unphysical_without_the_experimental_flag() {
+        let mut world = world_with(crate::PresentationMode::Vr, false);
+        let gun = gun(&mut world);
+
+        assert!(held_item_collision_group(&world, gun).is_none());
+    }
+
+    /// With the flag, it gets a body - and an *inert* one: the point is world
+    /// geometry holding the weapon back, not the weapon touching anything.
+    #[test]
+    fn a_held_gun_takes_an_inert_body_with_the_experimental_flag() {
+        let mut world = world_with(crate::PresentationMode::Vr, true);
+        let gun = gun(&mut world);
+
+        let group = held_item_collision_group(&world, gun);
+
+        // The swept body needs a collider fitted to the `_h` view model, which
+        // only a 25AE install wields - so on a classic install the correct
+        // answer is still "no body", and this asserts that rather than
+        // skipping.
+        assert_eq!(
+            group.is_some(),
+            crate::is_25th_anniversary_install(),
+            "a held gun is swept exactly when VR wields its view model"
+        );
+        if let Some(group) = group {
+            assert!(group.is_inert(), "a held gun must not generate contacts");
+        }
+    }
+
+    /// A melee weapon is unaffected by the flag in either direction: its body
+    /// is its damage volume and must keep reporting contacts.
+    #[test]
+    fn a_held_melee_weapon_keeps_its_contact_body_either_way() {
+        for physical_held_items in [false, true] {
+            let mut world = world_with(crate::PresentationMode::Vr, physical_held_items);
+            let wrench = melee(&mut world);
+
+            let group = held_item_collision_group(&world, wrench)
+                .expect("a held melee weapon always takes a contact body");
+            assert!(!group.is_inert());
+        }
+    }
+
+    /// Flat swings and flat shots are raycasts against the world; nothing in
+    /// the flat presentation wants a body in the player's hand.
+    #[test]
+    fn nothing_is_held_physically_in_the_flat_presentation() {
+        let mut world = world_with(crate::PresentationMode::Flat, true);
+        let gun = gun(&mut world);
+        let wrench = melee(&mut world);
+
+        assert!(held_item_collision_group(&world, gun).is_none());
+        assert!(held_item_collision_group(&world, wrench).is_none());
     }
 }

--- a/shock2vr/src/physics/held_item_drive.rs
+++ b/shock2vr/src/physics/held_item_drive.rs
@@ -37,7 +37,7 @@ use super::{
 
 /// A wrench-scale fitted melee volume. The body origin sits on the rendered
 /// weapon head and the fitted cuboid extends back over the handle, which is
-/// what production builds via `fit_held_melee_cuboid`; the offset, elongated
+/// what production builds via `fit_held_item_cuboid`; the offset, elongated
 /// shape is the inertia-awkward case a drive has to hold.
 const WEAPON_HALF_EXTENTS: Vector3<f32> = Vector3::new(0.045, 0.30, 0.045);
 const WEAPON_COLLIDER_CENTER: Vector3<f32> = Vector3::new(0.0, -0.30, 0.0);
@@ -126,8 +126,8 @@ fn spawn_held_wrench(world: &mut PhysicsWorld, at: Vector3<f32>) -> (EntityId, R
         false,
         DynamicPhysicsOptions::default(),
     );
-    world.set_held_melee(weapon);
-    world.fit_held_melee_cuboid(weapon, WEAPON_HALF_EXTENTS * 2.0, WEAPON_COLLIDER_CENTER);
+    world.set_held_item_physical(weapon, CollisionGroup::held_melee());
+    world.fit_held_item_cuboid(weapon, WEAPON_HALF_EXTENTS * 2.0, WEAPON_COLLIDER_CENTER);
     (weapon, handle)
 }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2302,6 +2302,23 @@ impl CollisionGroup {
         })
     }
 
+    /// An inert held gun: the drive queries world geometry, but the body
+    /// neither blocks projectiles nor generates physical contacts.
+    pub fn held_inert() -> CollisionGroup {
+        Self::solid(InteractionGroups {
+            memberships: Group::empty(),
+            filter: Group::empty(),
+            test_mode: Default::default(),
+        })
+    }
+
+    /// Whether this group takes part in no collision at all.
+    pub fn is_inert(&self) -> bool {
+        [self.collision, self.solver]
+            .iter()
+            .all(|groups| groups.memberships.is_empty() && groups.filter.is_empty())
+    }
+
     /// Collision behavior for a living creature capsule. It collides exactly
     /// like an ordinary physical entity, but its distinct membership lets
     /// interaction-only fixtures and unsimulated movable debris opt out of
@@ -2726,7 +2743,7 @@ pub struct PlayerHandle {
 /// target out of `entity_id_to_body` makes the weapon remain the entity's one
 /// authoritative rendered/contact body.
 #[derive(Clone, Copy)]
-struct HeldMeleeDrive {
+struct HeldItemDrive {
     target: RigidBodyHandle,
     /// The weapon's own entity, so a swept blow can be reported without
     /// digging it back out of the body's user data every frame.
@@ -2816,7 +2833,7 @@ impl PlayerHandle {
 
 /// Clearance the held-melee sweep stops short of a surface by, so a weapon
 /// resting against one does not re-report a zero-distance hit every frame.
-const HELD_MELEE_SKIN: f32 = 0.01;
+const HELD_ITEM_SKIN: f32 = 0.01;
 
 pub struct PhysicsWorld {
     gravity: Vector<Real>,
@@ -2867,7 +2884,7 @@ pub struct PhysicsWorld {
     // Dynamic held-melee bodies driven toward invisible controller targets by
     // Rapier joint motors. Keyed by the weapon body handle so the normal
     // set_position_rotation path can redirect hand poses to the target.
-    held_melee_drives: HashMap<RigidBodyHandle, HeldMeleeDrive>,
+    held_item_drives: HashMap<RigidBodyHandle, HeldItemDrive>,
 
     // The player's travel over the previous frame, in world units per second,
     // and where they were when it was sampled. A held weapon rides the player,
@@ -3054,7 +3071,7 @@ impl PhysicsWorld {
             vector: vec_to_nvec(position),
         };
 
-        if let Some(drive) = self.held_melee_drives.get(&handle).copied() {
+        if let Some(drive) = self.held_item_drives.get(&handle).copied() {
             let mut just_seated = false;
             if !drive.seated {
                 if let Some(weapon) = self.rigid_body_set.get_mut(handle) {
@@ -3062,7 +3079,7 @@ impl PhysicsWorld {
                     weapon.set_linvel(Vector::zeros(), true);
                     weapon.set_angvel(Vector::zeros(), true);
                 }
-                if let Some(drive) = self.held_melee_drives.get_mut(&handle) {
+                if let Some(drive) = self.held_item_drives.get_mut(&handle) {
                     drive.seated = true;
                 }
                 just_seated = true;
@@ -3207,19 +3224,24 @@ impl PhysicsWorld {
         }
     }
 
-    /// Turn an existing loose-prop body into a swept kinematic contact shape
-    /// while a melee weapon is held in VR.
+    /// Turn an existing loose-prop body into a swept kinematic shape while the
+    /// item is held in VR, so it cannot travel through the level.
+    ///
+    /// `group` decides what the held body is to everything else: a melee
+    /// weapon takes [`CollisionGroup::held_melee`] (contacts, so the
+    /// trigger-gated damage script sees them), a merely physical held item
+    /// takes [`CollisionGroup::held_inert`].
     ///
     /// The hand pose drives an invisible kinematic target; each step the
     /// visible weapon is *shape-cast* from where it is toward that target and
     /// stopped at the first world surface in the way (see
-    /// [`Self::drive_held_melee`]). Kinematic, not dynamic: a dynamic weapon
+    /// [`Self::drive_held_items`]). Kinematic, not dynamic: a dynamic weapon
     /// is subject to contact impulses, and a contact against a body whose
     /// origin sits out on the weapon head torques it - which in a headset
     /// read as the weapon spinning out of the player's hand the moment it
     /// touched anything. A swept kinematic body cannot be spun by the solver,
     /// cannot tunnel, and still reports every contact.
-    pub fn set_held_melee(&mut self, entity_id: EntityId) {
+    pub fn set_held_item_physical(&mut self, entity_id: EntityId, group: CollisionGroup) {
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
@@ -3234,15 +3256,15 @@ impl PhysicsWorld {
             (*body.position(), body.colliders().to_vec())
         };
 
-        if !self.held_melee_drives.contains_key(&handle) {
+        if !self.held_item_drives.contains_key(&handle) {
             let target = self.rigid_body_set.insert(
                 RigidBodyBuilder::kinematic_position_based()
                     .pose(pose)
                     .build(),
             );
-            self.held_melee_drives.insert(
+            self.held_item_drives.insert(
                 handle,
-                HeldMeleeDrive {
+                HeldItemDrive {
                     target,
                     weapon_entity: EntityId::from_inner(
                         self.rigid_body_set
@@ -3268,7 +3290,14 @@ impl PhysicsWorld {
                 );
             }
         }
-        self.set_collision_group(entity_id, CollisionGroup::held_melee());
+        self.set_collision_group(entity_id, group);
+    }
+
+    /// Whether this body is currently driven by a held-item target.
+    pub fn is_held_item(&self, entity_id: EntityId) -> bool {
+        self.entity_id_to_body
+            .get(&entity_id)
+            .is_some_and(|handle| self.held_item_drives.contains_key(handle))
     }
 
     /// Replace a held melee body's inherited loose-pickup box with the local
@@ -3277,20 +3306,20 @@ impl PhysicsWorld {
     /// The rigid-body target stays controller-driven at the authored weapon
     /// joint; the collider's parent-relative center covers the rest of the
     /// handle/blade without moving the rendered model or the motor target.
-    pub fn fit_held_melee_cuboid(
+    pub fn fit_held_item_cuboid(
         &mut self,
         entity_id: EntityId,
         size: Vector3<f32>,
         center: Vector3<f32>,
     ) {
-        let size = sanitize_collider_size(entity_id, "fit_held_melee_cuboid", size);
+        let size = sanitize_collider_size(entity_id, "fit_held_item_cuboid", size);
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
         let Some(body) = self.rigid_body_set.get(handle) else {
             return;
         };
-        if !self.held_melee_drives.contains_key(&handle) {
+        if !self.held_item_drives.contains_key(&handle) {
             return;
         }
 
@@ -3442,7 +3471,7 @@ impl PhysicsWorld {
     ) {
         let previous =
             nvec_to_cgmath(*self.rigid_body_set[player_handle.character_handle].translation());
-        self.translate_held_melee_for_player_relocation(position - previous);
+        self.translate_held_items_for_player_relocation(position - previous);
         player_handle.top_out = None;
         // Relocated, so they are no longer hanging off anything: the stance
         // they are in is now an ordinary crouch, undone feet-planted.
@@ -3485,13 +3514,13 @@ impl PhysicsWorld {
     /// tries to motor across the entire level through every wall in between.
     /// Ordinary hand motion remains motor-driven because it never calls the
     /// player relocation seam.
-    fn translate_held_melee_for_player_relocation(&mut self, delta: Vector3<f32>) {
+    fn translate_held_items_for_player_relocation(&mut self, delta: Vector3<f32>) {
         if delta.magnitude2() <= f32::EPSILON {
             return;
         }
         let delta = vec_to_nvec(delta);
         let pairs = self
-            .held_melee_drives
+            .held_item_drives
             .iter()
             .map(|(weapon, drive)| (*weapon, drive.target))
             .collect::<Vec<_>>();
@@ -4145,7 +4174,7 @@ impl PhysicsWorld {
         point: Vector3<f32>,
     ) -> Option<Vector3<f32>> {
         let handle = self.entity_id_to_body.get(&entity_id)?;
-        let target = self.held_melee_drives.get(handle)?.target;
+        let target = self.held_item_drives.get(handle)?.target;
         self.body_velocity_at_point(target, point)
     }
 
@@ -4551,7 +4580,10 @@ impl PhysicsWorld {
     /// Rotational sweeps are expensive and ill-defined against thin geometry,
     /// and the failure they would prevent (turning the blade into a wall) is
     /// far milder than the one taking the hand's rotation prevents (a weapon
-    /// whose angle is not the angle of the hand holding it).
+    /// whose angle is not the angle of the hand holding it). A held gun makes
+    /// that more visible than a wrench does - a long barrel can be *turned*
+    /// into a wall it cannot be *pushed* into - but the tradeoff is the same
+    /// one, and the same choice.
     ///
     /// World geometry blocks, and so do a creature's hitboxes - the limbs a
     /// swing can see. Its actor capsule deliberately does not: that is a
@@ -4575,11 +4607,11 @@ impl PhysicsWorld {
         self.last_player_translation = Some(translation);
     }
 
-    fn drive_held_melee(&mut self) {
+    fn drive_held_items(&mut self) {
         let max_step = crate::dev_params::get(crate::dev_params::MELEE_MAX_SPEED)
             * self.integration_parameters.dt;
         let pairs = self
-            .held_melee_drives
+            .held_item_drives
             .iter()
             .map(|(weapon, drive)| (*weapon, drive.target))
             .collect::<Vec<_>>();
@@ -4608,7 +4640,7 @@ impl PhysicsWorld {
             // how a fast hand walks the weapon through a wall, and "fast" is
             // not a rare case in a test or a hitched frame. A genuine
             // teleport does not need the bypass either: it carries both motor
-            // endpoints together (`translate_held_melee_for_player_relocation`),
+            // endpoints together (`translate_held_items_for_player_relocation`),
             // so the error the drive sees is already near zero.
             let step = distance.min(max_step);
             let allowed = if distance <= 1.0e-6 {
@@ -4616,7 +4648,7 @@ impl PhysicsWorld {
             } else {
                 let direction = delta / distance;
                 let (fraction, stop) =
-                    self.held_melee_sweep_fraction(weapon, &current, direction, step);
+                    self.held_item_sweep_fraction(weapon, &current, direction, step);
                 sweep_stop = stop;
                 step * fraction
             };
@@ -4635,7 +4667,7 @@ impl PhysicsWorld {
             // frame the weapon leans on it, and a swing is a swing, not a
             // per-frame billing.
             let (weapon_entity, previous) = self
-                .held_melee_drives
+                .held_item_drives
                 .get(&weapon)
                 .map(|drive| (drive.weapon_entity, drive.stopped_on))
                 .unwrap_or((None, None));
@@ -4679,7 +4711,7 @@ impl PhysicsWorld {
                         }),
                     });
             }
-            if let Some(drive) = self.held_melee_drives.get_mut(&weapon) {
+            if let Some(drive) = self.held_item_drives.get_mut(&weapon) {
                 drive.stopped_on = sweep_stop.map(|stop| stop.limb);
             }
         }
@@ -4687,7 +4719,7 @@ impl PhysicsWorld {
 
     /// How far along `direction * distance` this weapon's colliders may travel
     /// before one of them meets world geometry, as a fraction in `0..=1`.
-    fn held_melee_sweep_fraction(
+    fn held_item_sweep_fraction(
         &self,
         weapon: RigidBodyHandle,
         current: &Isometry<Real>,
@@ -4709,7 +4741,19 @@ impl PhysicsWorld {
                 // by its actor capsule, which is a movement volume wider than
                 // the creature: stopping on that would halt the weapon in the
                 // air beside it.
-                (InternalCollisionGroups::WORLD.bits | InternalCollisionGroups::HITBOX.bits).into(),
+                (InternalCollisionGroups::WORLD.bits
+                    | if body.colliders().iter().any(|handle| {
+                        self.collider_set.get(*handle).is_some_and(|collider| {
+                            collider.collision_groups().memberships.bits()
+                                & InternalCollisionGroups::HELD_MELEE.bits
+                                != 0
+                        })
+                    }) {
+                        InternalCollisionGroups::HITBOX.bits
+                    } else {
+                        0
+                    })
+                .into(),
                 Default::default(),
             ))
             .exclude_rigid_body(weapon)
@@ -4740,7 +4784,7 @@ impl PhysicsWorld {
                     max_time_of_impact: distance,
                     // Leave a hair of clearance so a weapon resting on a
                     // surface does not re-report a zero-distance hit forever.
-                    target_distance: HELD_MELEE_SKIN,
+                    target_distance: HELD_ITEM_SKIN,
                     // An already-penetrating start must not pin the weapon in
                     // place; let it keep sweeping out.
                     stop_at_penetration: false,
@@ -4798,7 +4842,7 @@ impl PhysicsWorld {
         });
         let drives_to_remove = bodies_to_remove
             .iter()
-            .filter_map(|handle| self.held_melee_drives.remove(handle))
+            .filter_map(|handle| self.held_item_drives.remove(handle))
             .collect::<Vec<_>>();
         for drive in drives_to_remove {
             self.rigid_body_set.remove(
@@ -5063,7 +5107,7 @@ impl PhysicsWorld {
             live_creature_sweep_recovery: HashMap::new(),
             pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
-            held_melee_drives: HashMap::new(),
+            held_item_drives: HashMap::new(),
             player_velocity: Vector3::new(0.0, 0.0, 0.0),
             last_player_translation: None,
 
@@ -5450,7 +5494,7 @@ impl PhysicsWorld {
         // matching Dark's source->destination attachment flow.
         self.update_kinematic_attachments();
         self.sample_player_velocity(player_handle);
-        self.drive_held_melee();
+        self.drive_held_items();
 
         // Attribute any non-finite body state to its entity before the step
         // consumes it (see report_nonfinite_rigid_body_state) - by the time
@@ -7556,7 +7600,7 @@ fn collision_group_names(bits: u32) -> Vec<String> {
 }
 
 #[cfg(test)]
-mod held_melee_drive;
+mod held_item_drive;
 
 #[cfg(test)]
 mod tests {
@@ -7642,7 +7686,7 @@ mod tests {
             DynamicPhysicsOptions::default(),
         );
 
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let body = world
             .debug_list_bodies()
@@ -7694,7 +7738,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         world.set_position_rotation2(weapon, vec3(-2.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(0.0, 1.0, 0.0), identity_quat());
@@ -7706,7 +7750,7 @@ mod tests {
             (weapon_x - 0.0).abs() < 0.02,
             "the weapon should arrive on the tracked hand: x={weapon_x}"
         );
-        let target = world.held_melee_drives[&handle].target;
+        let target = world.held_item_drives[&handle].target;
         assert!((world.get_position(target).unwrap().x - 0.0).abs() < 1.0e-4);
     }
 
@@ -7727,22 +7771,22 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let tracked_pose = vec3(3.0, 1.0, -4.0);
         world.set_position_rotation2(weapon, tracked_pose, identity_quat());
 
-        let drive = world.held_melee_drives[&handle];
+        let drive = world.held_item_drives[&handle];
         assert!(drive.seated);
         assert!((world.get_position(handle).unwrap() - tracked_pose).magnitude() < 1.0e-4);
         assert!((world.get_position(drive.target).unwrap() - tracked_pose).magnitude() < 1.0e-4);
         assert!(world.get_velocity(weapon).unwrap().magnitude() < 1.0e-4);
     }
 
-    /// World solver contact must win over the hand motor, then releasing that
-    /// obstruction must let the weapon return to the tracked pose.
-    #[test]
-    fn held_melee_weapon_stops_at_world_geometry_then_springs_back() {
+    /// Drive a held body of `group` from x=-1 at a fixed wall at x=0, then let
+    /// the hand retreat. Shared by the melee and inert cases: what the level
+    /// does to a held body must not depend on which group it is held with.
+    fn held_item_pushed_into_a_wall_then_withdrawn(group: CollisionGroup) {
         let (mut world, mut player) = world_with_floor();
         world.add_collider(
             EntityId::from_inner(2).unwrap(),
@@ -7761,7 +7805,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, group);
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(1.0, 1.0, 0.0), identity_quat());
@@ -7771,7 +7815,7 @@ mod tests {
         let blocked_x = world.get_position(handle).unwrap().x;
         assert!(
             blocked_x < -0.20,
-            "the dynamic weapon crossed the fixed wall instead of stopping: x={blocked_x}"
+            "the held body crossed the fixed wall instead of stopping: x={blocked_x}"
         );
 
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
@@ -7779,7 +7823,92 @@ mod tests {
         let returned_x = world.get_position(handle).unwrap().x;
         assert!(
             returned_x < -0.8,
-            "the weapon did not spring back after the target cleared the wall: x={returned_x}"
+            "the held body did not spring back after the target cleared the wall: x={returned_x}"
+        );
+    }
+
+    /// World solver contact must win over the hand motor, then releasing that
+    /// obstruction must let the weapon return to the tracked pose.
+    #[test]
+    fn held_melee_weapon_stops_at_world_geometry_then_springs_back() {
+        held_item_pushed_into_a_wall_then_withdrawn(CollisionGroup::held_melee());
+    }
+
+    /// The `physical_held_items` case: a held gun only has to stop travelling
+    /// into the level, so it is held with no collision membership and no
+    /// filter at all. The sweep that stops it runs its own query, which does
+    /// not consult the body's groups - this is the test that says so, because
+    /// the whole design rests on it.
+    #[test]
+    fn an_inert_held_item_is_still_stopped_by_world_geometry() {
+        held_item_pushed_into_a_wall_then_withdrawn(CollisionGroup::held_inert());
+    }
+
+    /// ...and it touches nothing while it does. A held gun swept through a
+    /// creature must report no contact: contact is what bills melee damage
+    /// (`TriggeredMeleeWeapon`), and a gun that bludgeons by touch would be a
+    /// nasty surprise from a change that is only about walls. The same sweep
+    /// with `held_melee` reports the contact (see
+    /// `held_melee_contacts_live_actor_without_solver_launch`).
+    #[test]
+    fn an_inert_held_item_touches_nothing_it_sweeps_through() {
+        let (mut world, mut player) = world_with_floor();
+        let gun = EntityId::from_inner(2).unwrap();
+        let actor = EntityId::from_inner(3).unwrap();
+
+        world.add_dynamic(
+            actor,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Capsule {
+                height: 0.8,
+                radius: 0.4,
+            },
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_enabled_rotations(actor, false, false, false);
+        world.add_dynamic(
+            gun,
+            vec3(-2.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.3, 0.1, 0.1)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_held_item_physical(gun, CollisionGroup::held_inert());
+
+        world.set_position_rotation2(gun, vec3(-2.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 1);
+        world.set_position_rotation2(gun, vec3(0.0, 1.0, 0.0), identity_quat());
+        let mut events = Vec::new();
+        for _ in 0..30 {
+            let (_, mut frame_events) = world.update(vec3(0.0, 0.0, 0.0), &mut player);
+            events.append(&mut frame_events);
+        }
+
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                CollisionEvent::CollisionStarted {
+                    entity1_id,
+                    entity2_id,
+                    ..
+                } if *entity1_id == gun || *entity2_id == gun
+            )),
+            "an inert held item reported a contact"
         );
     }
 
@@ -7800,8 +7929,8 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
-        let target_handle = world.held_melee_drives[&weapon_handle].target;
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
+        let target_handle = world.held_item_drives[&weapon_handle].target;
         let weapon_before = world.get_position(weapon_handle).unwrap();
         let target_before = world.get_position(target_handle).unwrap();
         let player_before = world.get_player_translation(&player);
@@ -7836,11 +7965,11 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let rendered_size = vec3(0.24, 1.02, 0.18);
         let rendered_center = vec3(0.0, -0.51, 0.01);
-        world.fit_held_melee_cuboid(weapon, rendered_size, rendered_center);
+        world.fit_held_item_cuboid(weapon, rendered_size, rendered_center);
 
         assert_eq!(world.cuboid_full_size(handle), Some(rendered_size));
         let collider = &world.collider_set[world.rigid_body_set[handle].colliders()[0]];
@@ -7899,7 +8028,7 @@ mod tests {
                 friction: 0.0,
             },
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         // Seat the just-held body at its first tracked pose, establish the
         // broad phase, then put only the hand target beyond the actor. The
@@ -7982,9 +8111,9 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         let held_handle = world.entity_id_to_body[&weapon];
-        let target_handle = world.held_melee_drives[&held_handle].target;
+        let target_handle = world.held_item_drives[&held_handle].target;
         let held_collider = &world.collider_set[world.rigid_body_set[held_handle].colliders()[0]];
         assert!(!held_collider.solver_groups().test(actor.solver));
 

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -107,7 +107,9 @@ impl Script for InternalSwitchHeldModelScript {
 
 /// The entity's authored first-person model name, unfiltered:
 /// `PropPlayerGun.hand_model` for guns, `PropLimbModel` for melee.
-fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
+/// The first-person model this weapon authors, whether or not VR will wield it
+/// (`PropPlayerGun.hand_model` for a gun, `PropLimbModel` for melee).
+pub(crate) fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
     let v_player_gun = world.borrow::<View<PropPlayerGun>>().unwrap();
     let v_melee_weapon = world.borrow::<View<PropLimbModel>>().unwrap();
 

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -40,7 +40,7 @@ mod internal_keycard_script;
 mod internal_nanites_script;
 pub(crate) mod internal_radiation_source;
 mod internal_simple_health;
-mod internal_switch_held_model;
+pub(crate) mod internal_switch_held_model;
 mod laser_shot;
 mod level_change_button;
 pub mod maintenance;

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -77,7 +77,7 @@ pub enum VirtualHandEffect {
         torque: Vector3<f32>,
     },
     /// Refit contact geometry once when a prepared melee grip is acquired.
-    FitHeldMelee {
+    FitHeldItem {
         entity_id: EntityId,
         size: Vector3<f32>,
         center: Vector3<f32>,

--- a/tools/shock2-sdk/test/physical-held-guns.e2e.test.ts
+++ b/tools/shock2-sdk/test/physical-held-guns.e2e.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer, HttpError } from "../src/index.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+for (const hand of ["left", "right"] as const) {
+  test(
+    `physical ${hand} gun follows the controller, stops at a wall, and drops`,
+    {
+      skip: process.env.SHOCK2_E2E !== "1",
+      timeout: 180_000,
+    },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "debug_weapons",
+        debugFlags: ["--vr", "--experimental", "physical_held_items"],
+      });
+      await game.step({ frames: 10 });
+      const gun = await cycleToWeapon(game, (e) => e.template_id === -18, {
+        settleFrames: 90,
+      });
+      await aimVrHandAt(game, gun.position!, 0.45, 1, 0, { hand });
+      await game.step({ frames: 8 });
+      const heldId = async () => {
+        const player = (await game.info()).player;
+        return hand === "right"
+          ? player.right_hand_entity_id
+          : player.wielded_entity_id;
+      };
+      assert.equal(await heldId(), gun.id);
+      await game.input.set("head.rotation", [0, 0, 0, 1]);
+      await game.input.set(`${hand}_hand.position`, [0, 1, 0]);
+      await game.input.set(`${hand}_hand.rotation`, [
+        0,
+        Math.SQRT1_2,
+        0,
+        Math.SQRT1_2,
+      ]);
+      await game.step({ frames: 90 });
+      const body = async () => {
+        const bodies = (await game.physics.bodies({ entityId: gun.id })).bodies;
+        assert.equal(
+          bodies.length,
+          1,
+          "the held gun retains one physical body",
+        );
+        return bodies[0]!;
+      };
+      const raised = await body();
+      assert.equal(raised.body_type, "kinematic");
+      assert.ok(
+        raised.position[1] > 2,
+        "actual pickup must lift the gun from its floor pose",
+      );
+      assert.ok(
+        Math.abs(raised.position[0]) < 0.6,
+        "gun follows the controller in free space",
+      );
+
+      await game.player.teleport({ x: -9, y: 1.244, z: 0 });
+      await game.step({ frames: 30 });
+      const clear = await body();
+      for (let i = 1; i <= 24; i++) {
+        await game.input.set(`${hand}_hand.position`, [(-2.8 * i) / 24, 1, 0]);
+        await game.step({ frames: 3 });
+      }
+      await game.step({ frames: 30 });
+      const blocked = await body();
+      assert.ok(
+        blocked.position[0] < clear.position[0] - 0.3,
+        "gun advances toward the wall",
+      );
+      assert.ok(
+        blocked.position[0] > -11.5,
+        "body origin remains in front of the wall despite controller penetration",
+      );
+      const draws = (await game.scene.objects({ entityId: gun.id })).objects;
+      assert.ok(draws.length > 0);
+      for (const draw of draws) {
+        assert.ok(
+          Math.hypot(...draw.position.map((v, i) => v - blocked.position[i]!)) <
+            0.001,
+          "rendered gun follows its stopped physics body",
+        );
+      }
+      const ammoBefore = ammoOf(await game.entities.detail(gun.id));
+      const healthBefore = (await game.info()).player.hit_points;
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      await game.step({ frames: 15 });
+      assert.ok(
+        ammoOf(await game.entities.detail(gun.id)) < ammoBefore,
+        "the blocked physical gun still fires through the actual holding hand",
+      );
+      assert.equal(
+        (await game.info()).player.hit_points,
+        healthBefore,
+        "firing the held gun must not damage its owner",
+      );
+      await game.input.set(`${hand}_hand.position`, [0, 1, 0]);
+      await game.step({ frames: 90 });
+      const withdrawn = await body();
+      assert.ok(
+        Math.hypot(
+          ...withdrawn.position.map((v, i) => v - clear.position[i]!),
+        ) < 0.1,
+        "withdrawing the controller frees the gun from the wall",
+      );
+      await game.input.set(`${hand}_hand.squeeze`, 0);
+      await game.step({ frames: 30 });
+      assert.notEqual(await heldId(), gun.id);
+      assert.equal(
+        (await body()).body_type,
+        "dynamic",
+        "drop restores ordinary world physics",
+      );
+    },
+  );
+}
+
+test(
+  "a full backpack returns a refused physical gun deposit to dynamic world physics",
+  {
+    skip: process.env.SHOCK2_E2E !== "1",
+    timeout: 180_000,
+  },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr", "--experimental", "physical_held_items"],
+    });
+    await game.step({ frames: 10 });
+    let refused = false;
+    for (let i = 0; i < 40; i++) {
+      try {
+        await game.player.spawnItem(-928);
+      } catch (error) {
+        assert.ok(error instanceof HttpError && error.status === 400);
+        refused = true;
+        break;
+      }
+    }
+    assert.ok(refused, "nonstacking wrenches must fill the backpack");
+    const gun = await cycleToWeapon(game, (e) => e.template_id === -18, {
+      settleFrames: 90,
+    });
+    await aimVrHandAt(game, gun.position!, 0.45, 1);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player.right_hand_entity_id, gun.id);
+    assert.equal(
+      (await game.physics.bodies({ entityId: gun.id })).bodies[0]?.body_type,
+      "kinematic",
+    );
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const pose = (await game.ui.state()).panel_pose;
+    assert.ok(pose);
+    await aimVrHandAtCanvas(game, pose, [320, 60], { squeeze: 1 });
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === gun.id,
+      ),
+    );
+    const bodies = (await game.physics.bodies({ entityId: gun.id })).bodies;
+    assert.equal(bodies.length, 1);
+    assert.equal(
+      bodies[0]!.body_type,
+      "dynamic",
+      "refusal must remove the held drive from the existing body",
+    );
+  },
+);


### PR DESCRIPTION
## Change

With `--experimental physical_held_items`, a VR gun now stops when pushed into level geometry and returns to the hand when withdrawn. The inert held body cannot intercept its own projectiles. Both gloves follow the resolved gun pose, and dropping or refusing a backpack deposit restores ordinary loose physics.

Adapts #1142 to the current calibrated glove/support-grip code: fitted colliders use weapon-only geometry at the actual grip scale, and legacy held-model bounds include left-hand reflection. Existing melee hitbox sweeps and player-projectile filtering are preserved.

The workstream now records the agreed recoil design: authored baseline with two hands, additional spring recoil with one hand, and a separate Strength modifier on both, preserving original Agility/Still Hand/aiming-implant behavior. Recoil and the #1153 collision-sound adaptation follow in separate layers.

## Validation

- Gameplay: 1,634 passed, 2 diagnostic tests ignored; Dark: 172 passed.
- Warning-denied checks passed for Dark, gameplay, desktop and debug runtimes.
- SDK: actual left/right VR pickup, wall blocking, renderer/body agreement, withdrawal and dynamic drop; full-backpack release also restores a dynamic body.
- Independent agent and Codex CLI review; addressed refused-storage and glove-pose findings. Duplication names/index/source checks completed; token-clone tool unavailable (jscpd ENOENT).

## Limits

Translation is swept; orientation still follows tracking directly. A stationary wrist rotation can turn a long barrel into geometry. Headless VR establishes geometry and behavior, not Quest comfort or feel. The experiment remains opt-in.

## Visual evidence

![Physical gun wall contact](https://gist.githubusercontent.com/tommy-xr/7e0d0b99cfebcb5cae09724ee16e5376/raw/physical-held-comparison.gif)

![Before and after](https://gist.githubusercontent.com/tommy-xr/7e0d0b99cfebcb5cae09724ee16e5376/raw/physical-held-comparison.png)

Matched deterministic VR capture: raise the acquired gun, push into the wall, withdraw, and drop. [Left-hand contact](https://gist.githubusercontent.com/tommy-xr/7e0d0b99cfebcb5cae09724ee16e5376/raw/left-hand-blocked.png).
