### PR TITLE
feat(mfd): browse campaign research progress and reports

### DIFF
--- a/dark/src/font.rs
+++ b/dark/src/font.rs
@@ -334,6 +334,10 @@ impl Font {
         mesh::create(vertices)
     }
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> Font {
+        Self::read_tinted(reader, [255, 255, 255])
+    }
+
+    pub fn read_tinted<T: io::Read + io::Seek>(reader: &mut T, tint: [u8; 3]) -> Font {
         let font_bitmap = FontBitmap::read(reader);
         let metrics = &font_bitmap.metrics;
 
@@ -352,7 +356,12 @@ impl Font {
             // White glyphs; the bitmap only carries coverage.
             let img: ImageBuffer<image::Rgba<u8>, std::vec::Vec<u8>> =
                 image::ImageBuffer::from_fn(width as u32, metrics.height as u32, |x, y| {
-                    image::Rgba([255, 255, 255, alpha[(y as usize) * width + x as usize]])
+                    image::Rgba([
+                        tint[0],
+                        tint[1],
+                        tint[2],
+                        alpha[(y as usize) * width + x as usize],
+                    ])
                 });
 
             let texture_pack_result = texture_packer.pack(&img);

--- a/dark/src/importers/font_importer.rs
+++ b/dark/src/importers/font_importer.rs
@@ -6,6 +6,17 @@ use crate::font::Font;
 pub static FONT_IMPORTER: Lazy<AssetImporter<Box<dyn engine::Font>, Box<dyn engine::Font>, ()>> =
     Lazy::new(|| AssetImporter::define(load_font, |font, _cache, _config| font));
 
+pub static TINTED_FONT_IMPORTER: Lazy<
+    AssetImporter<Box<dyn engine::Font>, Box<dyn engine::Font>, [u8; 3]>,
+> = Lazy::new(|| {
+    AssetImporter::define(
+        |_name, reader, _cache, tint| {
+            Box::new(Font::read_tinted(reader, *tint)) as Box<dyn engine::Font>
+        },
+        |font, _cache, _config| font,
+    )
+});
+
 fn load_font(
     _name: String,
     reader: &mut Box<dyn engine::assets::asset_paths::ReadableAndSeekable>,

--- a/engine/src/font.rs
+++ b/engine/src/font.rs
@@ -33,6 +33,38 @@ pub fn measure_text_width(font: &dyn Font, text: &str, font_size: f32) -> f32 {
         .sum()
 }
 
+/// Wrap without discarding text, using the same advances as rendering.
+/// Paragraph gaps are retained; an overlong word continues on the next line.
+pub fn wrap_text_to_width(font: &dyn Font, text: &str, font_size: f32, width: f32) -> Vec<String> {
+    let mut lines = Vec::new();
+    for paragraph in text.split('\n') {
+        let mut line = String::new();
+        for word in paragraph.split_whitespace() {
+            let candidate = if line.is_empty() {
+                word.to_owned()
+            } else {
+                format!("{line} {word}")
+            };
+            if measure_text_width(font, &candidate, font_size) <= width {
+                line = candidate;
+                continue;
+            }
+            if !line.is_empty() {
+                lines.push(std::mem::take(&mut line));
+            }
+            for ch in word.chars() {
+                let candidate = format!("{line}{ch}");
+                if !line.is_empty() && measure_text_width(font, &candidate, font_size) > width {
+                    lines.push(std::mem::take(&mut line));
+                }
+                line.push(ch);
+            }
+        }
+        lines.push(line);
+    }
+    lines
+}
+
 /// Shorten `text` until it fits `max_width`, marking the cut with a trailing
 /// ellipsis. Returns `text` unchanged when it already fits.
 ///
@@ -103,6 +135,27 @@ mod tests {
         fn get_half_pixel(&self) -> f32 {
             0.0
         }
+    }
+
+    #[test]
+    fn wrapping_keeps_paragraphs_and_every_glyph_within_width() {
+        let font = StubFont {
+            advance: 4.0,
+            base_height: 10.0,
+        };
+        let input = "one two\n\nlongwordhere 25%";
+        let lines = wrap_text_to_width(&font, input, 10.0, 20.0);
+        assert!(lines.iter().any(String::is_empty));
+        assert!(
+            lines
+                .iter()
+                .all(|line| measure_text_width(&font, line, 10.0) <= 20.0)
+        );
+        assert_eq!(
+            lines.concat().replace(' ', ""),
+            input.split_whitespace().collect::<String>()
+        );
+        assert!(!lines.iter().any(|line| line.contains("...")));
     }
 
     #[test]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -22,7 +22,7 @@ pub mod util;
 pub use crate::builtin_font::{BuiltinFont, shared_builtin_font};
 pub use crate::engine::Engine;
 pub use crate::engine::EngineRenderContext;
-pub use crate::font::{Font, FontCharacterInfo, ellipsize, measure_text_width};
+pub use crate::font::{Font, FontCharacterInfo, ellipsize, measure_text_width, wrap_text_to_width};
 
 pub fn opengl() -> Box<dyn Engine> {
     let engine = gl_engine::init_gl();

--- a/projects/astra-debug-interactions.md
+++ b/projects/astra-debug-interactions.md
@@ -4,7 +4,7 @@ Start the scene with `cargo dbgr --mission debug_interactions --vr`, or select
 `debug_interactions` from the Developer scene launcher on desktop or Quest.
 The scene also loads in flat presentation for inspecting its layout.
 
-Forty-four fixtures stand on labeled pedestals along a clear aisle: coffee mug,
+Fifty fixtures stand on labeled pedestals along a clear aisle: coffee mug,
 printed magazine, basketball, wrench, pistol, shotgun, fusion cannon, worm
 launcher, standard ammo clip, psi amp, four hypos, maintenance tool,
 French-Epstein device, auto-repair unit, an inert card grip sample, and security
@@ -77,3 +77,13 @@ Underside provide close views of the contact seams even on oversized models.
 Use Explorer’s [VR Grips editor](astra-vr-grip-editor.md) to adjust position,
 rotation, finger amounts, and uniform item scale, then save the selected pickup
 or weapon resource directly. The gallery remains useful for sharing reviews.
+
+## Research fixtures
+
+The rack includes Monkey Brain (-148), Hybrid Organ (-1095), and Toxin-A
+(-1341), plus Fermium (-20), Antimony (-145), and Vanadium (-139). Use the
+specimen normally to begin research; use the requested chemical to advance it.
+Antimony has two doses for Toxin-A's two gates. Debug stats already include
+Research 6. The RES utility is a read-only journal: active projects show their
+chemical gate, and completed reports remain readable after the specimen is gone.
+DebugReloadLevel resets specimens, chemicals and research together.

--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -41,35 +41,20 @@ in canvas pixels; these are new layout rectangles, not guessed BIN indices.
 
 ### Research overview
 
-RES reads campaign research projects without starting or resuming them. Active
-work comes first, with progress and any required chemical; suspended projects
-and completed reports remain browsable with the reader's page controls.
-Completed descriptions resolve from archetype metadata, so destroying or using
-the original inventory item does not erase the report. Metadata is cached while
-the reader is open; progress remains live. The overview offers no research-use
-actions and makes no changes to campaign research state.
+RES opens the retail PDA-style research list in the left MFD. Active projects
+open the RESEARCH status layout; completed entries open RESREP with the
+portrait, flask icon and report text from RESEARCH.STR, not OBJLOOKS. Reports
+are selected from collected report bits and survive the original specimen.
+Opening or paging the journal never changes research or consumes chemicals.
+The live specimen panel exposes REPORTS and SUSPEND through normal effects.
 
-Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
+Layout references are `shkrsrch.cpp`, `shkpda.cpp`, and `shkemail.cpp` in the
+original Dark engine: the progress well is (15,267), the specimen slot is
+(15,14,138,109), and report body starts at (15,105). Retail MAINAA is loaded
+explicitly from `fonts/` and tinted cyan; the alternate `iface/fonts` copy is
+not suitable. Specimens currently use their inventory artwork in the preview;
+a rotating 3D specimen is still a separate rendering increment.
 
-A weapon-pinned ammo display remains a separate optional grip-editor placement mode. The psi amp keeps its authored forearm and needs its own mount; glove-mounted wrist plates deliberately skip it.
-
-## Shoulder assignments in the inventory
-
-The first MFD increment marks the existing backpack weapon icon with L or R.
-The idle item-name line explains `L / R: shoulder recall`; hovering an assigned
-weapon prefixes its name with `Left shoulder:` or `Right shoulder:`. These are
-shoulder recall assignments, independent of controller handedness.
-
-The assignment list comes from the same live backpack-membership query used by
-shoulder retrieval. There are no duplicate weapon slots or extra grab targets.
-The normal item click/grab behavior stays on the original icon, including under
-the badge. A cursor lift hides both icon and badge; recall/world removal hides
-the badge when the item leaves the backpack. Returning an assigned weapon to
-the backpack restores its mark. Reassigning a shoulder marks its new weapon.
-
-Layout is emitted once in the shared interface canvas for flat and VR. This
-increment makes existing assignments visible; editing assignments from the MFD
-is a follow-up interaction, alongside the retail utility controls above.
 
 ### Mirrored arm layout prototype
 

--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -39,6 +39,16 @@ Utility buttons occupy a dedicated row below the reserved right MFD slot and
 above the ammo readout. Their drawing, input and debug rectangles are shared
 in canvas pixels; these are new layout rectangles, not guessed BIN indices.
 
+### Research overview
+
+RES reads campaign research projects without starting or resuming them. Active
+work comes first, with progress and any required chemical; suspended projects
+and completed reports remain browsable with the reader's page controls.
+Completed descriptions resolve from archetype metadata, so destroying or using
+the original inventory item does not erase the report. Metadata is cached while
+the reader is open; progress remains live. The overview offers no research-use
+actions and makes no changes to campaign research state.
+
 Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
 
 A weapon-pinned ammo display remains a separate optional grip-editor placement mode. The psi amp keeps its authored forearm and needs its own mount; glove-mounted wrist plates deliberately skip it.

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -16,6 +16,11 @@ impl<TEvent> GuiComponent<TEvent>
 where
     TEvent: Clone,
 {
+    pub fn with_rect(self, rect: Rect) -> Self {
+        self.with_position(vec2(rect.x, rect.y))
+            .with_size(vec2(rect.w, rect.h))
+    }
+
     pub fn with_position(self, new_position: Vector2<f32>) -> GuiComponent<TEvent> {
         match self {
             Self::Image {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -213,8 +213,8 @@ pub fn is_25th_anniversary_install() -> bool {
 /// This is the same precedence the classic `.crf` mount list uses: `obj` first
 /// so a model material resolves to a model texture, `iface` and friends after.
 const RESOURCE_FAMILIES: &[&str] = &[
-    "obj", "bitmap", "book", "fam", "iface", "intrface", "mesh", "motions", "objicon", "snd",
-    "snd2", "song", "strings",
+    "obj", "bitmap", "book", "fam", "fonts", "iface", "intrface", "mesh", "motions", "objicon",
+    "snd", "snd2", "song", "strings",
 ];
 
 /// The 25AE mod stack, highest priority first, exactly as

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -641,6 +641,9 @@ impl FlatUiHost {
     /// Bind the MFD to `entity` (the original's `gOverlayObj`). Opening a
     /// second panel replaces the first - one panel per (left) slot.
     pub fn open(&mut self, entity: EntityId) {
+        if self.utilities.is_research() {
+            self.utilities = Default::default();
+        }
         if self.active_panel != Some(entity) {
             self.components.clear();
             self.panel_size_px = None;
@@ -906,6 +909,9 @@ impl FlatUiHost {
                 .utilities
                 .update(canvas_pos, pressed_edge || grab_edge, candidate)
             {
+                if self.utilities.is_research() {
+                    self.close();
+                }
                 self.hover_close = false;
                 return (Vec::new(), Vec::new());
             }

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -34,6 +34,16 @@ pub(crate) struct MfdUtilities {
 }
 
 impl MfdUtilities {
+    pub(crate) fn is_research(&self) -> bool {
+        self.research
+    }
+    pub(crate) fn open_research(&mut self, template: Option<i32>) {
+        *self = Self::default();
+        self.research = true;
+        if let Some(id) = template {
+            self.research_catalog.select_project(id);
+        }
+    }
     pub(crate) fn is_inspecting(&self) -> bool {
         self.inspecting
     }
@@ -46,7 +56,7 @@ impl MfdUtilities {
             Rect::new(488.0, 382.0, 36.0, 26.0),
             "RES",
         ));
-        if self.inspecting || self.selected.is_some() || self.research {
+        if self.inspecting || self.selected.is_some() {
             controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
             if self.page > 0 {
                 controls.push((Control::Previous, Rect::new(458.0, 346.0, 28.0, 20.0), "<"));
@@ -94,6 +104,13 @@ impl MfdUtilities {
             }
             return true;
         }
+        if self.research {
+            let consumed = self.research_catalog.contains(point);
+            if self.research_catalog.update(point, pressed) {
+                *self = Self::default();
+            }
+            return consumed;
+        }
         if self.inspecting {
             if pressed && let Some(entity) = candidate {
                 self.selected = Some(entity);
@@ -123,8 +140,7 @@ impl MfdUtilities {
         info: &dark::ss2_entity_info::SystemShock2EntityInfo,
     ) {
         if self.research {
-            let body = self.research_catalog.body(world, assets, info);
-            self.set_content("Research overview".into(), body);
+            self.research_catalog.refresh(world, assets, info);
             return;
         }
         let Some(entity) = self.selected else {
@@ -144,7 +160,10 @@ impl MfdUtilities {
     }
 
     pub(crate) fn draw(&self, canvas: &mut UiCanvas) {
-        if self.inspecting || self.selected.is_some() || self.research {
+        if self.research {
+            self.research_catalog.draw(canvas);
+        }
+        if self.inspecting || self.selected.is_some() {
             canvas.image(PANEL, "IFBTN00.PCX");
             canvas.text_native_fit(
                 Rect::new(458.0, 130.0, 172.0, 16.0),
@@ -196,6 +215,11 @@ impl MfdUtilities {
                 entity_id: None,
                 rect: [r.x, r.y, r.w, r.h],
                 screen_rect: [r.x, r.y, r.w, r.h],
+            })
+            .chain(if self.research {
+                self.research_catalog.elements()
+            } else {
+                Vec::new()
             })
             .chain(self.visible_lines().map(|(rect, line)| {
                 let r = [rect.x, rect.y, rect.w, rect.h];

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -16,6 +16,7 @@ const PAGE_LINES: usize = 16;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Control {
     Inspect,
+    Research,
     Close,
     Previous,
     Next,
@@ -24,6 +25,8 @@ enum Control {
 #[derive(Default)]
 pub(crate) struct MfdUtilities {
     inspecting: bool,
+    research: bool,
+    research_catalog: super::research_overview::ResearchCatalog,
     selected: Option<EntityId>,
     title: String,
     lines: Vec<String>,
@@ -38,7 +41,12 @@ impl MfdUtilities {
         // Dedicated utility row below the reserved right MFD slot, clear of
         // the bottom ammo readout. New utilities fill the row incrementally.
         let mut controls = vec![(Control::Inspect, Rect::new(450.0, 382.0, 36.0, 26.0), "?")];
-        if self.inspecting || self.selected.is_some() {
+        controls.push((
+            Control::Research,
+            Rect::new(488.0, 382.0, 36.0, 26.0),
+            "RES",
+        ));
+        if self.inspecting || self.selected.is_some() || self.research {
             controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
             if self.page > 0 {
                 controls.push((Control::Previous, Rect::new(458.0, 346.0, 28.0, 20.0), "<"));
@@ -69,10 +77,15 @@ impl MfdUtilities {
                         if self.inspecting {
                             *self = Self::default();
                         } else {
+                            self.research = false;
                             self.inspecting = true;
                             self.selected = None;
                             self.set_content("Item information".into(), "Select an inventory or held item to inspect. Select ? again to cancel.".into());
                         }
+                    }
+                    Control::Research => {
+                        *self = Self::default();
+                        self.research = true;
                     }
                     Control::Close => *self = Self::default(),
                     Control::Previous => self.page = self.page.saturating_sub(1),
@@ -89,7 +102,7 @@ impl MfdUtilities {
             }
             return true;
         }
-        self.selected.is_some() && PANEL.contains(point)
+        (self.selected.is_some() || self.research) && PANEL.contains(point)
     }
 
     fn set_content(&mut self, title: String, body: String) {
@@ -103,7 +116,17 @@ impl MfdUtilities {
         }
     }
 
-    pub(crate) fn refresh(&mut self, world: &World, assets: &mut AssetCache) {
+    pub(crate) fn refresh(
+        &mut self,
+        world: &World,
+        assets: &mut AssetCache,
+        info: &dark::ss2_entity_info::SystemShock2EntityInfo,
+    ) {
+        if self.research {
+            let body = self.research_catalog.body(world, assets, info);
+            self.set_content("Research overview".into(), body);
+            return;
+        }
         let Some(entity) = self.selected else {
             return;
         };
@@ -121,7 +144,7 @@ impl MfdUtilities {
     }
 
     pub(crate) fn draw(&self, canvas: &mut UiCanvas) {
-        if self.inspecting || self.selected.is_some() {
+        if self.inspecting || self.selected.is_some() || self.research {
             canvas.image(PANEL, "IFBTN00.PCX");
             canvas.text_native_fit(
                 Rect::new(458.0, 130.0, 172.0, 16.0),
@@ -131,6 +154,10 @@ impl MfdUtilities {
                 VAlign::Middle,
             );
             for (rect, line) in self.visible_lines() {
+                // Paragraph gaps occupy a line but have no glyph mesh.
+                if line.trim().is_empty() {
+                    continue;
+                }
                 canvas.text_native_fit(rect, line, FONT, HAlign::Left, VAlign::Middle);
             }
         }
@@ -159,6 +186,7 @@ impl MfdUtilities {
                 label: Some(
                     match control {
                         Control::Inspect => "inspect",
+                        Control::Research => "research_overview",
                         Control::Close => "utility_close",
                         Control::Previous => "utility_previous",
                         Control::Next => "utility_next",
@@ -211,6 +239,18 @@ fn item_description(
 mod tests {
     use super::*;
     use cgmath::vec2;
+
+    #[test]
+    fn paragraph_spacing_does_not_emit_empty_text_meshes() {
+        let mut ui = MfdUtilities::default();
+        ui.inspecting = true;
+        ui.set_content("Title".into(), "First\n\nSecond".into());
+        let mut canvas = UiCanvas::new(Vector2::new(640.0, 480.0));
+        ui.draw(&mut canvas);
+        assert!(canvas.elements().iter().all(|element| !matches!(element, crate::ui::UiElement::Text { text, .. } if text.trim().is_empty())));
+        let lines: Vec<_> = ui.visible_lines().collect();
+        assert_eq!(lines[2].0.y - lines[0].0.y, 22.0);
+    }
 
     #[test]
     fn pages_cover_every_line_and_clamp_when_content_shrinks() {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7390,7 +7390,34 @@ impl MissionCore {
                     }
                 }
 
+                Effect::OpenResearchReports => {
+                    if !self.player_is_alive() {
+                        continue;
+                    }
+                    self.gui.close_panel(
+                        &mut self.world,
+                        &mut self.physics,
+                        &mut self.script_world,
+                        &mut self.id_to_physics,
+                    );
+                    if !self.use_mode {
+                        effects.push_front(
+                            self.enter_use_mode(crate::ui::entry_ramp::DEFAULT_ENTRY_EXIT),
+                        );
+                        self.reset_vr_use_mode_placement();
+                    }
+                    self.flat_ui.close();
+                    self.flat_ui.utilities.open_research(None);
+                }
+                Effect::SuspendResearch => {
+                    if let Ok(mut quests) = self.world.borrow::<UniqueViewMut<QuestInfo>>() {
+                        quests.research_mut().suspend();
+                    }
+                }
                 Effect::OpenPanel { entity } => {
+                    if self.flat_ui.utilities.is_research() {
+                        self.flat_ui.utilities = Default::default();
+                    }
                     // Bind the presentation's single object-panel slot to the
                     // frobbed entity (the original's frob-script -> overlay
                     // flow). Flat docks it in the MFD; default VR creates a

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4725,7 +4725,9 @@ impl MissionCore {
             .map(|inventory| super::shoulder_backpack::weapons(&self.world, inventory))
             .unwrap_or([None; 2]);
         self.flat_ui.set_shoulder_weapons(shoulder_weapons);
-        self.flat_ui.utilities.refresh(&self.world, asset_cache);
+        self.flat_ui
+            .utilities
+            .refresh(&self.world, asset_cache, &self.entity_info);
         // Resolve physical ownership through the interaction boundary: flat's
         // internal left slot represents the visibly right-handed viewmodel.
         let held = self.interaction.held_entities();

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -12,6 +12,7 @@ pub mod pathfinding_debug;
 pub mod pathfinding_test;
 pub mod player_footsteps;
 pub(crate) mod reload;
+mod research_overview;
 mod shoulder_backpack;
 pub mod spatial_query;
 mod spawn_location;

--- a/shock2vr/src/mission/research_overview.rs
+++ b/shock2vr/src/mission/research_overview.rs
@@ -1,0 +1,124 @@
+//! Read-only research journal, resolved by archetype rather than live item.
+
+use crate::{
+    quest_info::QuestInfo, research::ResearchState,
+    scripts::script_util::hydrate_template_component,
+};
+use dark::{
+    properties::{
+        PropChemicalNeeded, PropObjLookString, PropObjName, PropResearchTime, PropSymName,
+    },
+    ss2_entity_info::SystemShock2EntityInfo,
+};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{UniqueView, World};
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub(super) struct ResearchCatalog(HashMap<i32, Project>);
+
+struct Project {
+    name: String,
+    seconds: f32,
+    chemicals: Option<PropChemicalNeeded>,
+    report: String,
+}
+
+impl ResearchCatalog {
+    pub(super) fn body(
+        &mut self,
+        world: &World,
+        assets: &mut AssetCache,
+        info: &SystemShock2EntityInfo,
+    ) -> String {
+        let Ok(quests) = world.borrow::<UniqueView<QuestInfo>>() else {
+            return "No research projects yet.".into();
+        };
+        for id in quests.research().project_template_ids() {
+            self.0.entry(id).or_insert_with(|| {
+                let name = hydrate_template_component::<PropObjName>(id, info).map(|p| p.0);
+                let symbol = hydrate_template_component::<PropSymName>(id, info).map(|p| p.0);
+                let look = hydrate_template_component::<PropObjLookString>(id, info).map(|p| p.0);
+                let names = assets.get(&dark::importers::STRINGS_IMPORTER, "objname.str");
+                let title = name
+                    .as_deref()
+                    .map(|name| dark::importers::resolve_localized_property_string(name, &names))
+                    .or(symbol.clone())
+                    .unwrap_or_else(|| "Research project".into());
+                let descriptions = assets.get(&dark::importers::STRINGS_IMPORTER, "objlooks.str");
+                Project {
+                    name: title,
+                    seconds: hydrate_template_component::<PropResearchTime>(id, info)
+                        .map(|p| p.0.max(1) as f32)
+                        .unwrap_or(1.0),
+                    chemicals: hydrate_template_component::<PropChemicalNeeded>(id, info),
+                    report: dark::importers::resolve_object_description(
+                        look.as_deref(),
+                        name.as_deref(),
+                        symbol.as_deref(),
+                        &descriptions,
+                    )
+                    .unwrap_or_else(|| "Research complete. No written report available.".into()),
+                }
+            });
+        }
+        self.describe(quests.research(), |name| {
+            crate::scripts::gui::chemical_display_name(world, name)
+        })
+    }
+
+    fn describe(&self, state: &ResearchState, chemical_name: impl Fn(&str) -> String) -> String {
+        let ids = state.project_template_ids();
+        if ids.is_empty() {
+            return "No research projects yet. Use a researchable item to begin a project. Opening this overview does not start research.".into();
+        }
+        let mut body = String::new();
+        for id in ids {
+            let Some(project) = self.0.get(&id) else {
+                continue;
+            };
+            let status = state.status(id, project.chemicals.as_ref());
+            body.push_str(&format!("{}\n", project.name));
+            if status.complete {
+                body.push_str(&format!("Complete\nReport: {}\n\n", project.report));
+            } else {
+                let fraction =
+                    (status.authored_seconds / project.seconds * 100.0).clamp(0.0, 100.0);
+                body.push_str(&format!(
+                    "{}: {fraction:.0} percent\n",
+                    if status.active { "Active" } else { "Suspended" }
+                ));
+                if let Some(chemical) = status.needed_chemical {
+                    body.push_str(&format!("Chemical needed: {}\n", chemical_name(&chemical)));
+                }
+                body.push('\n');
+            }
+        }
+        body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn completed_report_survives_without_a_live_item_and_reading_is_pure() {
+        let mut state = ResearchState::default();
+        state.begin(-42, 1, 1);
+        state.advance(-42, 10.0, 1, 1.0, 1.0, None, 1);
+        let before = serde_json::to_value(&state).unwrap();
+        let catalog = ResearchCatalog(HashMap::from([(
+            -42,
+            Project {
+                name: "Sample".into(),
+                seconds: 1.0,
+                chemicals: None,
+                report: "Findings preserved.".into(),
+            },
+        )]));
+        let body = catalog.describe(&state, str::to_owned);
+        assert!(body.contains("Complete"));
+        assert!(body.contains("Findings preserved."));
+        assert_eq!(serde_json::to_value(&state).unwrap(), before);
+    }
+}

--- a/shock2vr/src/mission/research_overview.rs
+++ b/shock2vr/src/mission/research_overview.rs
@@ -1,12 +1,18 @@
-//! Read-only research journal, resolved by archetype rather than live item.
-
+//! Research journal: retail PDA list, RESEARCH status and RESREP report reader.
+//! Coordinates follow shkrsrch.cpp, shkpda.cpp and shkemail.cpp. All UI is
+//! resolved once on the shared canvas; reports are collected, not live items.
+use crate::scripts::gui::research::layout;
 use crate::{
-    quest_info::QuestInfo, research::ResearchState,
-    scripts::script_util::hydrate_template_component,
+    game_scene::DebugUiElement,
+    quest_info::QuestInfo,
+    scripts::{gui::wrap_text, script_util::hydrate_template_component},
+    ui::{HAlign, MFD_FONT, Rect, UiCanvas, VAlign},
 };
+use cgmath::Vector2;
 use dark::{
     properties::{
-        PropChemicalNeeded, PropObjLookString, PropObjName, PropResearchTime, PropSymName,
+        PropChemicalNeeded, PropObjIcon, PropObjName, PropResearchText, PropResearchTime,
+        PropSymName,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -14,87 +20,421 @@ use engine::assets::asset_cache::AssetCache;
 use shipyard::{UniqueView, World};
 use std::collections::HashMap;
 
+const PANEL: Rect = Rect::new(2.0, 124.0, 188.0, 296.0);
+const PAGE_LINES: usize = 14;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Selection {
+    Project(i32),
+    Report(u32),
+}
 #[derive(Default)]
-pub(super) struct ResearchCatalog(HashMap<i32, Project>);
-
+pub(super) struct ResearchCatalog {
+    projects: HashMap<i32, Project>,
+    reports: HashMap<u32, Report>,
+    rows: Vec<(Selection, String)>,
+    selected: Option<Selection>,
+    page: usize,
+    font: Option<std::rc::Rc<Box<dyn engine::Font>>>,
+}
 struct Project {
     name: String,
     seconds: f32,
     chemicals: Option<PropChemicalNeeded>,
-    report: String,
+    icon: Option<String>,
+    description: String,
+    status: String,
+    fraction: f32,
+    complete: bool,
+}
+struct Report {
+    name: String,
+    text: String,
+    header: String,
+    portrait: Option<String>,
+    icon: Option<String>,
 }
 
 impl ResearchCatalog {
-    pub(super) fn body(
+    pub(super) fn refresh(
         &mut self,
         world: &World,
         assets: &mut AssetCache,
         info: &SystemShock2EntityInfo,
-    ) -> String {
+    ) {
         let Ok(quests) = world.borrow::<UniqueView<QuestInfo>>() else {
-            return "No research projects yet.".into();
+            return;
         };
+        let strings = assets.get(&dark::importers::STRINGS_IMPORTER, "research.str");
+        self.font = Some(crate::ui::resolve_font(assets, MFD_FONT));
+        self.rows.clear();
         for id in quests.research().project_template_ids() {
-            self.0.entry(id).or_insert_with(|| {
+            let project = self.projects.entry(id).or_insert_with(|| {
                 let name = hydrate_template_component::<PropObjName>(id, info).map(|p| p.0);
                 let symbol = hydrate_template_component::<PropSymName>(id, info).map(|p| p.0);
-                let look = hydrate_template_component::<PropObjLookString>(id, info).map(|p| p.0);
                 let names = assets.get(&dark::importers::STRINGS_IMPORTER, "objname.str");
-                let title = name
-                    .as_deref()
-                    .map(|name| dark::importers::resolve_localized_property_string(name, &names))
-                    .or(symbol.clone())
-                    .unwrap_or_else(|| "Research project".into());
-                let descriptions = assets.get(&dark::importers::STRINGS_IMPORTER, "objlooks.str");
+                let text = hydrate_template_component::<PropResearchText>(id, info).map(|p| p.0);
+                let texts = assets.get(&dark::importers::STRINGS_IMPORTER, "rsrchtxt.str");
                 Project {
-                    name: title,
+                    name: name
+                        .as_deref()
+                        .map(|n| dark::importers::resolve_localized_property_string(n, &names))
+                        .or(symbol)
+                        .unwrap_or_else(|| "Research project".into()),
                     seconds: hydrate_template_component::<PropResearchTime>(id, info)
                         .map(|p| p.0.max(1) as f32)
                         .unwrap_or(1.0),
                     chemicals: hydrate_template_component::<PropChemicalNeeded>(id, info),
-                    report: dark::importers::resolve_object_description(
-                        look.as_deref(),
-                        name.as_deref(),
-                        symbol.as_deref(),
-                        &descriptions,
-                    )
-                    .unwrap_or_else(|| "Research complete. No written report available.".into()),
+                    icon: hydrate_template_component::<PropObjIcon>(id, info)
+                        .map(|p| format!("{}.pcx", p.0)),
+                    description: text
+                        .as_deref()
+                        .map(|t| dark::importers::resolve_localized_property_string(t, &texts))
+                        .unwrap_or_else(|| "Research in progress.".into()),
+                    status: String::new(),
+                    fraction: 0.0,
+                    complete: false,
                 }
             });
-        }
-        self.describe(quests.research(), |name| {
-            crate::scripts::gui::chemical_display_name(world, name)
-        })
-    }
-
-    fn describe(&self, state: &ResearchState, chemical_name: impl Fn(&str) -> String) -> String {
-        let ids = state.project_template_ids();
-        if ids.is_empty() {
-            return "No research projects yet. Use a researchable item to begin a project. Opening this overview does not start research.".into();
-        }
-        let mut body = String::new();
-        for id in ids {
-            let Some(project) = self.0.get(&id) else {
-                continue;
-            };
-            let status = state.status(id, project.chemicals.as_ref());
-            body.push_str(&format!("{}\n", project.name));
-            if status.complete {
-                body.push_str(&format!("Complete\nReport: {}\n\n", project.report));
+            let status = quests.research().status(id, project.chemicals.as_ref());
+            project.complete = status.complete;
+            project.fraction = (status.authored_seconds / project.seconds).clamp(0.0, 1.0);
+            project.status = if let Some(chemical) = status.needed_chemical {
+                format!(
+                    "Research paused. Required chemical: {}.",
+                    crate::scripts::gui::chemical_display_name(world, &chemical)
+                )
+            } else if status.complete {
+                "Research complete. Select REPORTS to read the findings.".into()
+            } else if status.active {
+                project.description.clone()
             } else {
-                let fraction =
-                    (status.authored_seconds / project.seconds * 100.0).clamp(0.0, 100.0);
-                body.push_str(&format!(
-                    "{}: {fraction:.0} percent\n",
-                    if status.active { "Active" } else { "Suspended" }
+                "Research suspended. Use the specimen to resume.".into()
+            };
+            if !status.complete {
+                self.rows.push((
+                    Selection::Project(id),
+                    format!(
+                        "{}: {}",
+                        if status.active { "Active" } else { "Suspended" },
+                        "Unresearched Object"
+                    ),
                 ));
-                if let Some(chemical) = status.needed_chemical {
-                    body.push_str(&format!("Chemical needed: {}\n", chemical_name(&chemical)));
-                }
-                body.push('\n');
             }
         }
-        body
+        self.refresh_reports(quests.research(), &strings);
+        let (count, total) = match self.selected {
+            None => (9, self.rows.len()),
+            Some(Selection::Project(_)) => (7, self.lines().len()),
+            Some(Selection::Report(_)) => (PAGE_LINES, self.lines().len()),
+        };
+        self.page = self.page.min(total.saturating_sub(1) / count);
+    }
+
+    fn refresh_reports(
+        &mut self,
+        state: &crate::research::ResearchState,
+        strings: &HashMap<String, String>,
+    ) {
+        for index in 1..=32 {
+            if !state.has_report(1 << (index - 1)) {
+                continue;
+            }
+            let report = self.reports.entry(index).or_insert_with(|| {
+                let get = |prefix: &str| {
+                    strings
+                        .get(&format!("{prefix}{index}").to_ascii_lowercase())
+                        .cloned()
+                };
+                Report {
+                    header: get("ResRepName").unwrap_or_default(),
+                    name: get("ReportName").unwrap_or_else(|| "Research report".into()),
+                    text: get("ResRepText")
+                        .unwrap_or_else(|| "No written report available.".into()),
+                    portrait: get("ResRepPortrait").map(|n| format!("{n}.pcx")),
+                    icon: get("ResRepIcon").map(|n| format!("{n}.pcx")),
+                }
+            });
+            self.rows
+                .push((Selection::Report(index), report.name.clone()));
+        }
+    }
+
+    pub(super) fn select_project(&mut self, id: i32) {
+        self.selected = Some(Selection::Project(id));
+        self.page = 0;
+    }
+    fn lines(&self) -> Vec<String> {
+        let body = match self.selected {
+            Some(Selection::Project(id)) => self.projects.get(&id).map(|p| p.status.clone()),
+            Some(Selection::Report(id)) => self.reports.get(&id).map(|r| {
+                if r.header.is_empty() {
+                    r.text.clone()
+                } else {
+                    format!("{}\n\n{}", r.header, r.text)
+                }
+            }),
+            None => None,
+        }
+        .unwrap_or_default();
+        if let Some(font) = &self.font {
+            engine::wrap_text_to_width(&***font, &body, font.base_height(), 136.0)
+        } else {
+            wrap_text(&body, 27)
+        }
+    }
+    /// Close is returned to the owning utility state; all other actions only
+    /// navigate the journal and never start, consume or complete research.
+    pub(super) fn update(&mut self, point: Vector2<f32>, pressed: bool) -> bool {
+        if !pressed {
+            return false;
+        }
+        let elements = self.elements();
+        let label = elements
+            .iter()
+            .find(|e| {
+                e.kind == "button"
+                    && Rect::new(e.rect[0], e.rect[1], e.rect[2], e.rect[3]).contains(point)
+            })
+            .and_then(|e| e.label.as_deref());
+        match label {
+            Some("utility_close") => return true,
+            Some("research_back") => {
+                self.selected = None;
+                self.page = 0;
+            }
+            Some("utility_previous") => self.page = self.page.saturating_sub(1),
+            Some("utility_next") => self.page += 1,
+            Some(label) => {
+                if let Some(index) = label
+                    .strip_prefix("research_entry:")
+                    .and_then(|n| n.parse::<usize>().ok())
+                {
+                    if let Some((selection, _)) = self.rows.get(index) {
+                        self.selected = Some(*selection);
+                        self.page = 0;
+                    }
+                }
+            }
+            None => {}
+        }
+        false
+    }
+    pub(super) fn contains(&self, point: Vector2<f32>) -> bool {
+        PANEL.contains(point)
+    }
+
+    pub(super) fn elements(&self) -> Vec<DebugUiElement> {
+        let mut out = Vec::new();
+        let mut add = |kind: &str,
+                       rect: Rect,
+                       texture: Option<&str>,
+                       text: Option<&str>,
+                       label: Option<String>| {
+            let r = [PANEL.x + rect.x, PANEL.y + rect.y, rect.w, rect.h];
+            out.push(DebugUiElement {
+                kind: kind.into(),
+                texture: texture.map(str::to_owned),
+                text: text.map(str::to_owned),
+                label,
+                entity_id: None,
+                rect: r,
+                screen_rect: r,
+            });
+        };
+        let backdrop = match self.selected {
+            None => "iface/pda.pcx",
+            Some(Selection::Project(_)) => "iface/research.pcx",
+            Some(Selection::Report(_)) => "iface/resrep.pcx",
+        };
+        add(
+            "image",
+            Rect::new(0.0, 0.0, 188.0, 296.0),
+            Some(backdrop),
+            None,
+            None,
+        );
+        add(
+            "button",
+            Rect::new(163.0, 8.0, 20.0, 21.0),
+            Some("iface/closeoff.pcx"),
+            None,
+            Some("utility_close".into()),
+        );
+        if self.selected.is_none() {
+            add(
+                "text",
+                Rect::new(15.0, 12.0, 138.0, 15.0),
+                None,
+                Some("Research"),
+                Some("utility_text".into()),
+            );
+            if self.rows.is_empty() {
+                for (i, line) in wrap_text(
+                    "No research projects yet. Use a researchable item to begin.",
+                    27,
+                )
+                .iter()
+                .enumerate()
+                {
+                    add(
+                        "text",
+                        Rect::new(15.0, 38.0 + i as f32 * 12.0, 138.0, 12.0),
+                        None,
+                        Some(line),
+                        Some("utility_text".into()),
+                    );
+                }
+            }
+            for (i, (_, name)) in self.rows.iter().enumerate().skip(self.page * 9).take(9) {
+                add(
+                    "button",
+                    Rect::new(13.0, 34.0 + (i % 9) as f32 * 24.0, 139.0, 24.0),
+                    None,
+                    Some(name),
+                    Some(format!("research_entry:{i}")),
+                );
+                add(
+                    "text",
+                    Rect::new(22.0, 36.0 + (i % 9) as f32 * 24.0, 130.0, 24.0),
+                    None,
+                    Some(name),
+                    Some("utility_text".into()),
+                );
+            }
+        } else {
+            let (top, count) = if let Some(Selection::Project(id)) = self.selected {
+                if let Some(project) = self.projects.get(&id) {
+                    if let Some(icon) = &project.icon {
+                        add("object_icon", layout::SPECIMEN, Some(icon), None, None);
+                    }
+                    add(
+                        "text",
+                        layout::TITLE,
+                        None,
+                        Some(if project.complete {
+                            &project.name
+                        } else {
+                            "Unresearched Object"
+                        }),
+                        Some("utility_text".into()),
+                    );
+                    if project.fraction > 0.0 {
+                        add(
+                            "image",
+                            Rect {
+                                w: layout::PROGRESS.w * project.fraction,
+                                ..layout::PROGRESS
+                            },
+                            Some("iface/resprog.pcx"),
+                            None,
+                            None,
+                        );
+                    }
+                    add(
+                        "text",
+                        layout::PERCENT,
+                        None,
+                        Some(&format!("{:.1} %", project.fraction * 100.0)),
+                        Some("utility_text".into()),
+                    );
+                }
+                add(
+                    "button",
+                    layout::REPORTS,
+                    Some("iface/report0.pcx"),
+                    None,
+                    Some("research_back".into()),
+                );
+                (153.0, 7)
+            } else {
+                if let Some(Selection::Report(id)) = self.selected {
+                    if let Some(report) = self.reports.get(&id) {
+                        if let Some(portrait) = &report.portrait {
+                            add(
+                                "image",
+                                Rect::new(15.0, 13.0, 58.0, 84.0),
+                                Some(portrait),
+                                None,
+                                None,
+                            );
+                        }
+                        if let Some(icon) = &report.icon {
+                            add(
+                                "image",
+                                Rect::new(83.0, 13.0, 68.0, 84.0),
+                                Some(icon),
+                                None,
+                                None,
+                            );
+                        }
+                    }
+                }
+                add(
+                    "button",
+                    Rect::new(159.0, 252.0, 18.0, 34.0),
+                    Some("iface/return0.pcx"),
+                    None,
+                    Some("research_back".into()),
+                );
+                (105.0, PAGE_LINES)
+            };
+            for (i, line) in self
+                .lines()
+                .iter()
+                .skip(self.page * count)
+                .take(count)
+                .enumerate()
+            {
+                if !line.trim().is_empty() {
+                    add(
+                        "text",
+                        Rect::new(15.0, top + i as f32 * 12.0, 136.0, 12.0),
+                        None,
+                        Some(line),
+                        Some("utility_text".into()),
+                    );
+                }
+            }
+        }
+        let (count, total) = match self.selected {
+            None => (9, self.rows.len()),
+            Some(Selection::Project(_)) => (7, self.lines().len()),
+            _ => (PAGE_LINES, self.lines().len()),
+        };
+        if self.page > 0 {
+            add(
+                "button",
+                Rect::new(159.0, 174.0, 18.0, 26.0),
+                Some("iface/pgup0.pcx"),
+                None,
+                Some("utility_previous".into()),
+            );
+        }
+        if (self.page + 1) * count < total {
+            add(
+                "button",
+                Rect::new(159.0, 203.0, 18.0, 26.0),
+                Some("iface/pgdn0.pcx"),
+                None,
+                Some("utility_next".into()),
+            );
+        }
+        out
+    }
+    pub(super) fn draw(&self, canvas: &mut UiCanvas) {
+        for e in self.elements() {
+            let r = Rect::new(e.rect[0], e.rect[1], e.rect[2], e.rect[3]);
+            if let Some(texture) = e.texture {
+                if e.kind == "object_icon" {
+                    canvas.fitted_object_icon(r, &texture);
+                } else {
+                    canvas.image(r, &texture);
+                }
+            }
+            if let Some(text) = e.text.filter(|_| e.kind == "text") {
+                canvas.text_native_fit(r, &text, MFD_FONT, HAlign::Left, VAlign::Top);
+            }
+        }
     }
 }
 
@@ -102,23 +442,74 @@ impl ResearchCatalog {
 mod tests {
     use super::*;
     #[test]
-    fn completed_report_survives_without_a_live_item_and_reading_is_pure() {
-        let mut state = ResearchState::default();
-        state.begin(-42, 1, 1);
-        state.advance(-42, 10.0, 1, 1.0, 1.0, None, 1);
+    fn collected_reports_use_report_strings_without_a_live_specimen() {
+        let mut state = crate::research::ResearchState::default();
+        state.begin(-148, 1, 1);
+        state.advance(-148, 10.0, 1, 1.0, 1.0, None, 1 << 21);
         let before = serde_json::to_value(&state).unwrap();
-        let catalog = ResearchCatalog(HashMap::from([(
-            -42,
-            Project {
-                name: "Sample".into(),
-                seconds: 1.0,
-                chemicals: None,
-                report: "Findings preserved.".into(),
-            },
-        )]));
-        let body = catalog.describe(&state, str::to_owned);
-        assert!(body.contains("Complete"));
-        assert!(body.contains("Findings preserved."));
+        let strings = HashMap::from([
+            ("reportname22".into(), "Monkey Brain".into()),
+            (
+                "resreptext22".into(),
+                (0..48).map(|n| format!("Report line {n}\n")).collect(),
+            ),
+            ("resrepportrait22".into(), "mport".into()),
+            ("resrepicon22".into(), "resicon".into()),
+        ]);
+        let mut catalog = ResearchCatalog::default();
+        catalog.refresh_reports(&state, &strings);
+        assert_eq!(catalog.rows.len(), 1);
+        catalog.selected = Some(catalog.rows[0].0);
+        let elements = catalog.elements();
+        assert!(
+            elements
+                .iter()
+                .any(|e| e.texture.as_deref() == Some("iface/resrep.pcx"))
+        );
+        assert!(
+            elements
+                .iter()
+                .any(|e| e.texture.as_deref() == Some("mport.pcx"))
+        );
+        assert!(
+            elements
+                .iter()
+                .any(|e| e.texture.as_deref() == Some("resicon.pcx"))
+        );
+        let mut seen = Vec::new();
+        loop {
+            let elements = catalog.elements();
+            seen.extend(
+                elements
+                    .iter()
+                    .filter(|e| e.label.as_deref() == Some("utility_text"))
+                    .filter_map(|e| e.text.clone()),
+            );
+            let Some(next) = elements
+                .iter()
+                .find(|e| e.label.as_deref() == Some("utility_next"))
+            else {
+                break;
+            };
+            catalog.update(Vector2::new(next.rect[0] + 2.0, next.rect[1] + 2.0), true);
+        }
+        assert_eq!(seen.len(), 48);
+        assert_eq!(seen.last().unwrap(), "Report line 47");
         assert_eq!(serde_json::to_value(&state).unwrap(), before);
+    }
+    #[test]
+    fn every_research_control_and_text_stays_in_the_authored_panel() {
+        let mut catalog = ResearchCatalog::default();
+        catalog.rows = (0..24)
+            .map(|n| (Selection::Report(n), format!("Report {n}")))
+            .collect();
+        for page in 0..3 {
+            catalog.page = page;
+            for e in catalog.elements() {
+                assert!(e.rect[0] >= PANEL.x && e.rect[1] >= PANEL.y);
+                assert!(e.rect[0] + e.rect[2] <= PANEL.x + PANEL.w);
+                assert!(e.rect[1] + e.rect[3] <= PANEL.y + PANEL.h);
+            }
+        }
     }
 }

--- a/shock2vr/src/research.rs
+++ b/shock2vr/src/research.rs
@@ -110,6 +110,13 @@ pub enum AdvanceResearchResult {
 }
 
 impl ResearchState {
+    /// Stable identities of projects the player has begun, including finished
+    /// and suspended work whose original inventory instance no longer exists.
+    pub fn project_template_ids(&self) -> Vec<i32> {
+        let mut ids: Vec<_> = self.progress.keys().copied().collect();
+        ids.sort_by_key(|id| (Some(*id) != self.active_template_id, *id));
+        ids
+    }
     pub fn active_template_id(&self) -> Option<i32> {
         self.active_template_id
     }

--- a/shock2vr/src/scenes/debug_interactions.rs
+++ b/shock2vr/src/scenes/debug_interactions.rs
@@ -247,6 +247,36 @@ pub const INTERACTION_FIXTURES: &[InteractionFixture] = &[
         model: "gameboy",
     },
     InteractionFixture {
+        label: "Research: monkey brain",
+        template_id: -148,
+        model: "monbr",
+    },
+    InteractionFixture {
+        label: "Research: hybrid organ",
+        template_id: -1095,
+        model: "organ",
+    },
+    InteractionFixture {
+        label: "Research: Toxin-A",
+        template_id: -1341,
+        model: "filter",
+    },
+    InteractionFixture {
+        label: "Chemical: Antimony",
+        template_id: -145,
+        model: "Sb",
+    },
+    InteractionFixture {
+        label: "Chemical: Vanadium",
+        template_id: -139,
+        model: "V",
+    },
+    InteractionFixture {
+        label: "Chemical: Fermium",
+        template_id: -20,
+        model: "Fm",
+    },
+    InteractionFixture {
         label: "ICE-Pick hack tool",
         template_id: -73,
         model: "icepick",
@@ -404,6 +434,21 @@ impl DebugSceneHooks for InteractionHooks {
             asset_cache,
             audio_context,
         );
+        // Toxin-A requests Antimony twice. Provide both doses without
+        // requiring a scene reset (which also clears research progress).
+        let antimony: Vec<_> = core
+            .world
+            .borrow::<View<dark::properties::PropTemplateId>>()
+            .unwrap()
+            .iter()
+            .with_id()
+            .filter(|(_, template)| template.template_id == -145)
+            .map(|(entity, _)| entity)
+            .collect();
+        for entity in antimony {
+            core.world
+                .add_component(entity, dark::properties::PropStackCount(2));
+        }
         let buttons = {
             let templates = core
                 .world

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -312,6 +312,11 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
+    /// Read the collected research journal without requiring a live specimen.
+    OpenResearchReports,
+    /// Explicit research MFD suspend control.
+    SuspendResearch,
+
     /// Offer one carried chemical to the active research project. The handler
     /// consumes it only when it matches the currently authored gate.
     UseResearchChemical {

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -8,7 +8,7 @@ mod map;
 mod media;
 mod psi_powers;
 mod replicator;
-mod research;
+pub(crate) mod research;
 mod trainer;
 mod traits;
 mod weapon_settings;

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -2,8 +2,7 @@
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::{
-    PropBaseTechDesc, PropChemicalNeeded, PropObjLookString, PropResearchReport, PropResearchText,
-    PropResearchTime,
+    PropBaseTechDesc, PropChemicalNeeded, PropObjIcon, PropResearchText, PropResearchTime,
 };
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
@@ -22,7 +21,7 @@ const PANEL_H: f32 = 296.0;
 const TEXT_X: f32 = 15.0;
 const TEXT_TOP: f32 = 153.0;
 const TEXT_W: f32 = 138.0;
-const LINE_H: f32 = 11.0;
+const LINE_H: f32 = 12.0;
 // Seven lines stop above the authored report button at y=243. The adjacent
 // retail page gadgets expose the remainder instead of drawing underneath it.
 const PAGE_LINES: usize = 7;
@@ -31,17 +30,27 @@ const SCROLL_X: f32 = 159.0;
 const PGUP_Y: f32 = 174.0;
 const PGDN_Y: f32 = 203.0;
 
+/// Authored RESEARCH.PCX slots shared by the live item and journal views.
+pub(crate) mod layout {
+    use crate::ui::Rect;
+    pub const SPECIMEN: Rect = Rect::new(15.0, 14.0, 138.0, 109.0);
+    pub const TITLE: Rect = Rect::new(24.0, 133.0, 129.0, 12.0);
+    pub const PROGRESS: Rect = Rect::new(15.0, 267.0, 138.0, 17.0);
+    pub const PERCENT: Rect = Rect::new(50.0, 270.0, 100.0, 12.0);
+    pub const REPORTS: Rect = Rect::new(13.0, 243.0, 142.0, 22.0);
+}
+
 pub struct ResearchGui;
 
 #[derive(Clone, Debug, Default)]
 pub struct ResearchGuiState {
-    show_report: bool,
     scroll: usize,
 }
 
 #[derive(Clone)]
 pub enum ResearchGuiMsg {
     ToggleReport,
+    Suspend,
     PageUp,
     PageDown,
 }
@@ -89,33 +98,44 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
             .unwrap_or(1.0);
         let fraction = (status.authored_seconds / total).clamp(0.0, 1.0);
 
-        // The original overlays RESPROG on this slot; cropping is unavailable
-        // in the generic GUI primitive, so retain the authored bar art and add
-        // an exact numeric percentage for unambiguous progress feedback.
-        components.push(
-            gui::image("iface/resprog.pcx")
-                .with_position(vec2(15.0, 131.0))
-                .with_size(vec2(138.0 * fraction.max(0.01), 17.0)),
-        );
-        components.push(
-            gui::text(&format!("Research: {:.0}%", fraction * 100.0))
-                .with_position(vec2(18.0, 134.0))
-                .with_size(vec2(132.0, LINE_H)),
-        );
-
-        let report_mask = world
-            .borrow::<View<PropResearchReport>>()
-            .unwrap()
-            .get(entity_id)
-            .map(|report| report.0)
-            .unwrap_or(0);
-        if status.complete && report_mask != 0 {
+        if let Ok(icon) = world.borrow::<View<PropObjIcon>>().unwrap().get(entity_id) {
             components.push(
-                gui::button(ResearchGuiMsg::ToggleReport)
-                    .with_image("iface/report0.pcx")
-                    .with_label("Research report")
-                    .with_position(vec2(13.0, 243.0))
-                    .with_size(vec2(142.0, 22.0)),
+                gui::image(&format!("{}.pcx", icon.0))
+                    .with_object_icon()
+                    .with_rect(layout::SPECIMEN),
+            );
+        }
+        components.push(
+            gui::text(if status.complete {
+                "Research complete"
+            } else {
+                "Unresearched Object"
+            })
+            .with_rect(layout::TITLE),
+        );
+        // shkrsrch.cpp: progress well at (15,267), not the name at y=133.
+        // RESPROG is a solid fill, so sizing it preserves its authored pixels.
+        if fraction > 0.0 {
+            components.push(gui::image("iface/resprog.pcx").with_rect(crate::ui::Rect {
+                w: layout::PROGRESS.w * fraction,
+                ..layout::PROGRESS
+            }));
+        }
+        components
+            .push(gui::text(&format!("{:.1} %", fraction * 100.0)).with_rect(layout::PERCENT));
+        components.push(
+            gui::button(ResearchGuiMsg::ToggleReport)
+                .with_image("iface/report0.pcx")
+                .with_label("Research reports")
+                .with_rect(layout::REPORTS),
+        );
+        if status.active && !status.complete {
+            components.push(
+                gui::button(ResearchGuiMsg::Suspend)
+                    .with_image("iface/sus0.pcx")
+                    .with_label("Suspend research")
+                    .with_position(vec2(157.0, 152.0))
+                    .with_size(vec2(18.0, 134.0)),
             );
         }
 
@@ -128,22 +148,16 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
                 "Research paused. Required chemical: {}.",
                 chemical_display_name(world, chemical)
             )
-        } else if status.complete && state.show_report {
-            property_fallback(world, entity_id, true)
         } else if status.complete {
             "Research complete. The item is now ready for use. Select the report button to review your findings.".to_owned()
         } else if status.active {
-            property_fallback(world, entity_id, false)
+            property_fallback(world, entity_id)
         } else {
             "Research suspended. Double-click this item to resume.".to_owned()
         };
 
         let lines = wrap_text(&body, WRAP_CHARS);
-        let start = if status.complete && state.show_report {
-            state.scroll.min(lines.len())
-        } else {
-            0
-        };
+        let start = state.scroll.min(lines.len().saturating_sub(PAGE_LINES));
         for (index, line) in lines[start..].iter().take(PAGE_LINES).enumerate() {
             if !line.is_empty() {
                 components.push(
@@ -153,7 +167,7 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
                 );
             }
         }
-        if status.complete && state.show_report && lines.len() > PAGE_LINES {
+        if !status.active && lines.len() > PAGE_LINES {
             components.push(
                 gui::button(ResearchGuiMsg::PageUp)
                     .with_image("pgup0.pcx")
@@ -168,6 +182,11 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
                     .with_position(vec2(SCROLL_X, PGDN_Y))
                     .with_size(vec2(18.0, 26.0)),
             );
+        }
+        for component in &mut components {
+            if let GuiComponent::Text { font, .. } = component {
+                *font = crate::ui::MFD_FONT.into();
+            }
         }
         components
     }
@@ -186,26 +205,27 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
         state: &ResearchGuiState,
         msg: &ResearchGuiMsg,
     ) -> (ResearchGuiState, Effect) {
-        let next_state = match msg {
-            ResearchGuiMsg::ToggleReport => ResearchGuiState {
-                show_report: !state.show_report,
-                scroll: 0,
-            },
-            ResearchGuiMsg::PageUp => ResearchGuiState {
-                show_report: state.show_report,
-                scroll: state.scroll.saturating_sub(PAGE_LINES),
-            },
+        match msg {
+            ResearchGuiMsg::ToggleReport => (state.clone(), Effect::OpenResearchReports),
+            ResearchGuiMsg::Suspend => (ResearchGuiState::default(), Effect::SuspendResearch),
+            ResearchGuiMsg::PageUp => (
+                ResearchGuiState {
+                    scroll: state.scroll.saturating_sub(PAGE_LINES),
+                },
+                Effect::NoEffect,
+            ),
             ResearchGuiMsg::PageDown => {
-                let max_scroll = wrap_text(&property_fallback(world, entity_id, true), WRAP_CHARS)
+                let max_scroll = wrap_text(&property_fallback(world, entity_id), WRAP_CHARS)
                     .len()
                     .saturating_sub(PAGE_LINES);
-                ResearchGuiState {
-                    show_report: state.show_report,
-                    scroll: (state.scroll + PAGE_LINES).min(max_scroll),
-                }
+                (
+                    ResearchGuiState {
+                        scroll: (state.scroll + PAGE_LINES).min(max_scroll),
+                    },
+                    Effect::NoEffect,
+                )
             }
-        };
-        (next_state, Effect::NoEffect)
+        }
     }
 
     fn on_frob(&self, entity_id: EntityId, _world: &World) -> Effect {
@@ -214,28 +234,16 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
     }
 }
 
-fn property_fallback(world: &World, entity_id: EntityId, report: bool) -> String {
-    if report {
-        world
-            .borrow::<View<PropObjLookString>>()
-            .ok()
-            .and_then(|view| {
-                view.get(entity_id)
-                    .ok()
-                    .map(|text| localized_fallback(&text.0))
-            })
-            .unwrap_or_else(|| "Research report available.".to_owned())
-    } else {
-        world
-            .borrow::<View<PropResearchText>>()
-            .ok()
-            .and_then(|view| {
-                view.get(entity_id)
-                    .ok()
-                    .map(|text| localized_fallback(&text.0))
-            })
-            .unwrap_or_else(|| "Research in progress.".to_owned())
-    }
+fn property_fallback(world: &World, entity_id: EntityId) -> String {
+    world
+        .borrow::<View<PropResearchText>>()
+        .ok()
+        .and_then(|view| {
+            view.get(entity_id)
+                .ok()
+                .map(|text| localized_fallback(&text.0))
+        })
+        .unwrap_or_else(|| "Research in progress.".to_owned())
 }
 
 /// The English text out of an object string (`key: "text"`), for a data

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -248,7 +248,7 @@ pub(crate) fn localized_fallback(value: &str) -> String {
         .replace("\\n", "\n")
 }
 
-fn chemical_display_name(world: &World, sym_name: &str) -> String {
+pub(crate) fn chemical_display_name(world: &World, sym_name: &str) -> String {
     let key = sym_name.to_ascii_lowercase();
     world
         .borrow::<UniqueView<GlobalEntityMetadata>>()

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -67,13 +67,25 @@ pub use pointer_visual::{PointerVisuals, pointer_beams};
 /// font and is unaffected.
 pub const BUILTIN_FONT: &str = "@builtin";
 
+/// Retail MFDs use MAINAA with the cyan text palette (shkutils.cpp).
+pub const MFD_FONT: &str = "@shock-mfd";
+
 /// The font for a `UiElement::Text`, whichever kind it is.
 ///
 /// Both presentations and the layout pass go through here, so the two cannot
 /// disagree about which font measured the text and which font draws it.
-fn resolve_font(asset_cache: &mut AssetCache, font: &str) -> Rc<Box<dyn engine::Font>> {
+pub(crate) fn resolve_font(asset_cache: &mut AssetCache, font: &str) -> Rc<Box<dyn engine::Font>> {
     if font == BUILTIN_FONT {
         return engine::shared_builtin_font();
+    }
+    if font == MFD_FONT {
+        // Family mounts strip their prefix. The bare key resolves the canonical
+        // fonts family; "fonts/mainaa.fon" instead names iface's stripped copy.
+        return asset_cache.get_ext(
+            &dark::importers::TINTED_FONT_IMPORTER,
+            "mainaa.fon",
+            &[0, 255, 190],
+        );
     }
     asset_cache.get(&FONT_IMPORTER, font).clone()
 }

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -279,14 +279,22 @@ test(
     );
 
     const report = panel.active_panel!.elements.find(
-      (element) => element.label === "Research report",
+      (element) => element.label === "Research reports",
     );
     assert.ok(report, "completed research unlocks report #5");
     await clickUiElement(game, report);
     await game.step({ frames: 3 });
+    const reportEntry = (await game.ui.state()).strip?.elements.find(
+      element => element.label === "research_entry:0",
+    );
+    assert.ok(reportEntry, "completed Toxin-A appears in the research journal");
+    await clickUiElement(game, reportEntry);
     let reportPanel = await game.ui.state();
+    const reportTexts = (ui: UiState) => ui.strip?.elements
+      .filter(element => element.label === "utility_text")
+      .flatMap(element => element.text ? [element.text] : []) ?? [];
     assert.ok(
-      panelTexts(reportPanel).some((text) => text.includes("Summary:")),
+      reportTexts(reportPanel).some((text) => text.includes("Summary:")),
       "the report button reveals the authored analysis",
     );
 
@@ -294,11 +302,11 @@ test(
     // scroll gadget and prove the late recommendation is reachable rather
     // than silently truncated or drawn under the report button.
     for (let page = 0; page < 8; page += 1) {
-      if (panelTexts(reportPanel).some((text) => text.includes("Recommendation:"))) {
+      if (reportTexts(reportPanel).some((text) => text.includes("Recommendation:"))) {
         break;
       }
-      const nextPage = reportPanel.active_panel?.elements.find(
-        (element) => element.label === "Research report next page",
+      const nextPage = reportPanel.strip?.elements.find(
+        (element) => element.label === "utility_next",
       );
       assert.ok(nextPage, "a long research report should expose next-page navigation");
       await clickUiElement(game, nextPage);
@@ -306,8 +314,8 @@ test(
       reportPanel = await game.ui.state();
     }
     assert.ok(
-      panelTexts(reportPanel).some((text) => text.includes("Recommendation:")),
-      `late report recommendation should be reachable; got ${JSON.stringify(panelTexts(reportPanel))}`,
+      reportTexts(reportPanel).some((text) => text.includes("Recommendation:")),
+      `late report recommendation should be reachable; got ${JSON.stringify(reportTexts(reportPanel))}`,
     );
 
     // Both vials predated completion, so both must be normalized to researched

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { GameServer } from "../src/index.js";
 import type { UiElement } from "../src/types.js";
+import { clickUiElement, clickCanvasWithRay, canvasCenter, requirePanelPose } from "./helpers/ui.js";
 import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 
 for (const vr of [false, true]) {
@@ -28,22 +29,9 @@ for (const vr of [false, true]) {
       assert.ok(element, `${label} exists`);
       return element;
     };
-    // Reuse the common VR canvas aim; flat screen_rect follows the existing loot tests.
     const click = async (element: UiElement) => {
-      if (vr) {
-        const ui = await game.ui.state();
-        const [x,y,w,h] = element.rect;
-        await aimVrHandAtCanvas(game, ui.panel_pose!, [x+w/2,y+h/2], {hand:"right",squeeze:0});
-        await game.input.set("right_hand.trigger",1);
-      } else {
-        const [x,y,w,h] = element.screen_rect;
-        await game.input.set("pointer.position",[x+w/2,y+h/2]);
-        await game.step({frames:2});
-        await game.input.set("pointer.pressed",1);
-      }
-      await game.step({frames:2});
-      await game.input.set(vr ? "right_hand.trigger" : "pointer.pressed",0);
-      await game.step({frames:2});
+      if (vr) await clickCanvasWithRay(game, requirePanelPose(await game.ui.state()), canvasCenter(element));
+      else await clickUiElement(game, element);
     };
     const before = await game.player.inventory();
     const cursor = (await game.ui.state()).cursor;
@@ -122,3 +110,47 @@ test("VR inspection reserves an off-panel held hypo trigger through cancel until
   await game.step({frames:3});
   assert.equal((await game.info()).player.right_hand_entity_id,hypo.id,"releasing reserved trigger does not consume hypo");
 });
+
+
+for (const vr of [false,true]) {
+  test(`Research overview reads existing projects without starting research (${vr ? "VR" : "flat"})`, {
+    skip: process.env.SHOCK2_E2E !== "1", timeout:180_000,
+  }, async(t)=>{
+    await using game = await GameServer.launch({mission:"debug_interactions",debugFlags:vr?["--vr"]:[]});
+    t.after(async()=>{await writeFile(`/tmp/astra-mfd-research-${vr?"vr":"flat"}-runtime.log`,game.logs().join("\n"));});
+    await game.step({frames:30});
+    await game.player.setStats({skills:{research:6}});
+    const toxin=await game.player.spawnItem(-1341);
+    await game.input.trigger("ToggleUseMode");await game.step({frames:5});
+    const elements=async()=>(await game.ui.state()).strip!.elements;
+    const text=async()=>(await elements()).filter(e=>e.label === "utility_text").map(e=>e.text).join(" ");
+    const click=async(e:UiElement)=>{
+      if(vr) await clickCanvasWithRay(game,requirePanelPose(await game.ui.state()),canvasCenter(e));
+      else await clickUiElement(game,e);
+    };
+    const control=async(label:string)=>{const e=(await elements()).find(e=>e.label===label);assert.ok(e,label);return e;};
+    const capture=async(name:string)=>{
+      const output=process.env.ASTRA_RESEARCH_CAPTURE;if(!output)return;
+      await mkdir(output,{recursive:true});const path=`${output}/${vr?"vr":"flat"}-${name}`;
+      await game.screenshot(`${path}.png`,1600);await writeFile(`${path}.json`,JSON.stringify({ui:await game.ui.state(),inventory:await game.player.inventory(),info:await game.info()},null,2));
+    };
+    const inventory=await game.player.inventory();
+    await capture("idle");
+    await click(await control("research_overview"));
+    assert.match(await text(),/No research projects yet/);
+    await capture("empty");
+    await game.step({frames:75});
+    assert.match(await text(),/No research projects yet/,"overview must not start research on carried Toxin-A");
+    assert.deepEqual(await game.player.inventory(),inventory);
+    await click(await control("utility_close"));
+    const item=(await elements()).find(e=>e.entity_id===toxin.entity_id&&e.kind==="button");assert.ok(item);
+    await click(item);await click(item);await game.step({frames:75});
+    const active=(await game.ui.state()).active_panel;assert.ok(active,"real item use opens research MFD");
+    assert.ok(active.elements.some(e=>e.text?.includes("Antimony")),"real research reaches authored chemical gate");
+    await click(await control("research_overview"));
+    const gate=await text();assert.match(gate,/Active: 5 percent/);assert.match(gate,/Chemical needed/);assert.match(gate,/Antimony/);
+    await capture("chemical-gate");
+    await game.step({frames:60});assert.equal(await text(),gate,"read-only overview leaves chemically blocked progress unchanged");
+    assert.deepEqual(await game.player.inventory(),inventory,"overview never consumes research specimen");
+  });
+}

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -147,10 +147,48 @@ for (const vr of [false,true]) {
     await click(item);await click(item);await game.step({frames:75});
     const active=(await game.ui.state()).active_panel;assert.ok(active,"real item use opens research MFD");
     assert.ok(active.elements.some(e=>e.text?.includes("Antimony")),"real research reaches authored chemical gate");
-    await click(await control("research_overview"));
-    const gate=await text();assert.match(gate,/Active: 5 percent/);assert.match(gate,/Chemical needed/);assert.match(gate,/Antimony/);
+    const reports=active.elements.find(e=>e.label==="Research reports");assert.ok(reports);
+    // The flat case covers the actual Reports button; VR enters through RES.
+    // Legacy world-panel proxy targeting is not asserted by this scenario.
+    await click(vr ? await control("research_overview") : reports);
+    await capture("reports-button-result");
+    assert.ok((await elements()).some(e=>e.texture?.toLowerCase()==="iface/pda.pcx"));
+    await capture("journal-list");
+    await click(await control("research_entry:0"));
+    assert.ok((await elements()).some(e=>e.texture?.toLowerCase()==="iface/research.pcx"));
+    const gate=await text();assert.match(gate,/chemical/i);assert.match(gate,/Antimony/);assert.match(gate,/5\.0 %/,"authored progress retains its percent glyph");
     await capture("chemical-gate");
-    await game.step({frames:60});assert.equal(await text(),gate,"read-only overview leaves chemically blocked progress unchanged");
-    assert.deepEqual(await game.player.inventory(),inventory,"overview never consumes research specimen");
+    await game.step({frames:60});assert.equal(await text(),gate,"read-only journal leaves chemically blocked progress unchanged");
+    assert.deepEqual(await game.player.inventory(),inventory,"journal never consumes research specimen");
+    await click(await control("research_back"));
+    assert.ok((await elements()).some(e=>e.label==="research_entry:0"));
+    await click(await control("utility_close"));
+    // Real research progress, accelerated only through the supported skill debug setting.
+    const brain=await game.player.spawnItem(-148);
+    const brainButton=(await elements()).find(e=>e.entity_id===brain.entity_id&&e.kind==="button");assert.ok(brainButton);
+    await click(brainButton);await click(brainButton);await game.step({frames:1000});
+    assert.ok((await game.ui.state()).active_panel!.elements.some(e=>e.text?.includes("Fermium")),"Monkey Brain reaches its authored Fermium gate");
+    const fermium=await game.player.spawnItem(-20);
+    const chemical=(await elements()).find(e=>e.entity_id===fermium.entity_id&&e.kind==="button");assert.ok(chemical);
+    await click(chemical);await click(chemical);await game.step({frames:3600});
+    assert.ok(!(await game.player.inventory()).items.some(e=>e.entity_id===fermium.entity_id),"real research consumes required Fermium");
+    assert.ok((await game.ui.state()).active_panel!.elements.some(e=>e.text?.includes("Research complete")),"Monkey Brain research completes");
+    await click(await control("research_overview"));
+    await capture("completed-list");
+    const rows=(await elements()).filter(e=>e.label?.startsWith("research_entry:"));
+    assert.equal(rows.length,2,"suspended toxin and completed brain report");
+    const row=rows[1]!;
+    await click(row);
+    assert.ok((await elements()).some(e=>e.texture?.toLowerCase()==="iface/resrep.pcx"),"completed selection uses retail report artwork");
+    assert.ok((await elements()).filter(e=>/^(mport|resicon)\.pcx$/i.test(e.texture??"")).length>=2,"portrait and specimen icon");
+    const completedInventory=await game.player.inventory();
+    const first=await text();assert.doesNotMatch(first,/No written report/);assert.match(first,/25%/,"authored report bonus retains percent");assert.doesNotMatch(first,/\.\.\.|…/,"wrapped report must not discard text through ellipsis");
+    await capture("completed-report");
+    await click(await control("utility_next"));
+    assert.notEqual(await text(),first);await capture("completed-page-2");
+    await click(await control("utility_previous"));assert.equal(await text(),first);
+    assert.deepEqual(await game.player.inventory(),completedInventory,"reading report does not mutate inventory");
+    await click(await control("research_back"));
+    await capture("completed-list");
   });
 }


### PR DESCRIPTION
The cyber interface now has a research journal that stays useful after a specimen is gone. RES opens the retail PDA list; active projects use the RESEARCH layout, and collected reports use RESREP with their authored portrait, flask icon, header and full RESEARCH.STR text. Reading never starts research or consumes chemicals.

The live specimen panel now puts progress in its authored bottom well and exposes REPORTS and SUSPEND. `debug_interactions` adds Monkey Brain, Hybrid Organ, Toxin-A, Fermium, Vanadium and two Antimony doses for repeatable normal research interactions. Specimen previews currently use centered inventory art; rotating 3D previews remain a separate increment.

The 25th Anniversary asset mounts now include the canonical fonts family before the interface's stripped copies, restoring percent glyphs. Research uses cyan MAINAA, and report wrapping measures actual glyph advances so words are preserved across pages.

Validation: core/engine/font tests; real Monkey Brain + Fermium completion and read-only journal/paging checks in flat and VR; full Hydro research/chemical/save-load/ACR regression. Independent code, duplication and flat/VR image reviews completed. The VR journal entry is automated; the separate world-panel REPORTS shortcut was code-reviewed but its proxy-pointer harness remains unverified. Headset testing deferred.

![Retail research before and after](https://gist.githubusercontent.com/tommy-xr/fe577efe7e0b93e61a8c408b6cbd30af/raw/astra-research-retail-before-after.png)

![Flat and VR research journal and completed report](https://gist.githubusercontent.com/tommy-xr/fe577efe7e0b93e61a8c408b6cbd30af/raw/astra-research-retail.gif)

Real Toxin-A chemical gate and completed Monkey Brain report, using Fermium and accelerated Research skill 6. Loop shows discrete checkpoints. Canonical cyan font preserves percentages and full wrapped report text. Flat uses the actual Reports button; VR captures use RES. No headset validation.

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/fe577efe7e0b93e61a8c408b6cbd30af/raw/astra-research-retail-gallery.html)
