### PR TITLE
feat(vr): play material impacts for physically held guns

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -617,3 +617,22 @@ headset feel and rotational clearance remain explicit validation boundaries.
 Validation: 1,634 gameplay tests, 172 Dark tests, warning-denied desktop/debug
 checks, and three SDK cases (left/right wall contact and firing, withdrawal,
 drop, and full-backpack release). [Before/after evidence](https://gist.github.com/tommy-xr/7e0d0b99cfebcb5cae09724ee16e5376).
+
+
+## Held-gun collision audio
+
+Adapt #1153 on the physical-held foundation. The same blocking sweep now emits
+one contact edge when an inert held gun reaches world geometry. Reuse the
+melee sound cooldown and approach-speed guard; resting and grazing contacts
+remain quiet. This adds no contact damage and leaves projectile filtering inert.
+
+Stock gun classes have no collision sound schemas. Prefer an authored gun
+schema when available; otherwise use the wrench's material-sensitive solid-metal
+impact query as an explicit VR augmentation. Preserve `NO_COLLISION_SOUND`.
+Validation asserts an actual resolved sample, silence at rest, and another
+sample after withdrawal and a second tap in the isolated weapon scene.
+
+Audio validation: 1,638 gameplay tests pass (2 diagnostic ignores), all 23
+missions load, and 27 SDK cases pass. Warning-denied desktop/debug checks pass.
+The near-boundary impact regression verifies that pre-stop speed keeps a fast
+tap audible even when the body can travel less than a millimetre.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -24,9 +24,10 @@ use dark::{
         FrobFlag, InternalPropOriginalModelName, Link, Links, PhysicsModelType, PoseType, PropAI,
         PropClassTag, PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo,
         PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropLimbModel,
-        PropModelName, PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
-        PropRenderType, PropScale, PropSymName, PropTemplateId, PropTranslatingDoor, PropTripFlags,
-        RenderType, StimPropagator, StimSourceOptions, TemplateLinks, WrappedEntityId,
+        PropModelName, PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType,
+        PropPlayerGun, PropPosition, PropRenderType, PropScale, PropSymName, PropTemplateId,
+        PropTranslatingDoor, PropTripFlags, RenderType, StimPropagator, StimSourceOptions,
+        TemplateLinks, WrappedEntityId,
     },
     ss2_entity_info,
 };
@@ -449,6 +450,20 @@ pub fn create_entity_core(
     let v_limb_model = world.borrow::<View<PropLimbModel>>().unwrap();
     if needs_internal_triggered_melee(v_limb_model.get(entity_id).is_ok()) {
         processed_scripts.push("internal_triggered_melee_weapon".to_owned());
+    }
+
+    // A gun held under `physical_held_items` is stopped by the level but takes
+    // part in no collision, so the only report that it touched anything is the
+    // block its drive's sweep found (see `scripts::impact_sound`). Give every
+    // gun the handler that turns that into a sound; it is inert whenever the
+    // gun is not being held that way, and unlike the melee script above it
+    // never deals damage - a gun is not a club.
+    let is_player_gun = {
+        let v_player_gun = world.borrow::<View<PropPlayerGun>>().unwrap();
+        v_player_gun.get(entity_id).is_ok()
+    };
+    if is_player_gun && v_limb_model.get(entity_id).is_err() {
+        processed_scripts.push("internal_held_item_impact_sound".to_owned());
     }
 
     // `MOVE` is an engine frob action, not an object script. Ordinary goodies

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9166,6 +9166,30 @@ impl MissionCore {
                         );
                     }
                 }
+                Effect::PlayEnvironmentalSoundWithFallback {
+                    query,
+                    fallback,
+                    position,
+                    audio_handle,
+                } => {
+                    if !play_environmental_sound(
+                        &global_context.gamesys,
+                        asset_cache,
+                        audio_context,
+                        query,
+                        audio_handle.clone(),
+                        position,
+                    ) {
+                        play_environmental_sound(
+                            &global_context.gamesys,
+                            asset_cache,
+                            audio_context,
+                            fallback,
+                            audio_handle,
+                            position,
+                        );
+                    }
+                }
                 Effect::PlayEnvironmentalSound {
                     query,
                     position,
@@ -9199,7 +9223,7 @@ impl MissionCore {
                                 env_sound_query,
                                 AudioHandle::new(),
                                 position,
-                            )
+                            );
                         }
 
                         // With the `ragdoll` experimental flag, replace the slain
@@ -12937,7 +12961,7 @@ fn play_environmental_sound(
     query: dark::EnvSoundQuery,
     audio_handle: AudioHandle,
     position: Vector3<f32>,
-) {
+) -> bool {
     if let Some(resolved) = gamesys.get_random_environmental_sound(&query) {
         let audio_clip = asset_cache.get(&AUDIO_IMPORTER, &format!("{}.wav", resolved.sample_name));
 
@@ -12966,6 +12990,9 @@ fn play_environmental_sound(
                 source_entity: None,
             },
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2923,7 +2923,7 @@ pub struct PhysicsWorld {
     /// Blows reported by the held-melee sweep: a swing stopped by a limb is a
     /// hit on that limb, and the stop is what prevents the narrow phase from
     /// ever seeing it.
-    pending_melee_sweep_events: Vec<CollisionEvent>,
+    pending_held_sweep_events: Vec<CollisionEvent>,
 
     // Entities already reported by report_nonfinite_rigid_body_state, so a
     // body fed bad state every frame (e.g. NaN animation joints driving a
@@ -3298,6 +3298,22 @@ impl PhysicsWorld {
         self.entity_id_to_body
             .get(&entity_id)
             .is_some_and(|handle| self.held_item_drives.contains_key(handle))
+    }
+
+    /// A held gun uses empty groups so its sweep is its only collision source.
+    pub fn is_held_inert(&self, entity_id: EntityId) -> bool {
+        if !self.is_held_item(entity_id) {
+            return false;
+        }
+        let body = &self.rigid_body_set[self.entity_id_to_body[&entity_id]];
+        !body.colliders().is_empty()
+            && body.colliders().iter().all(|handle| {
+                let collider = &self.collider_set[*handle];
+                collider.collision_groups().memberships.is_empty()
+                    && collider.collision_groups().filter.is_empty()
+                    && collider.solver_groups().memberships.is_empty()
+                    && collider.solver_groups().filter.is_empty()
+            })
     }
 
     /// Replace a held melee body's inherited loose-pickup box with the local
@@ -4694,13 +4710,19 @@ impl PhysicsWorld {
                 // drive's - it carries whatever error the weapon had accrued
                 // behind the hand - which is why the script path reads the
                 // hand target instead of a body that has been obstructed.
-                let speed = relative_swing_speed(
-                    nvec_to_cgmath(heading * travel),
-                    self.player_velocity,
-                    Vector3::new(0.0, 0.0, 0.0),
-                    Some(stop.normal),
-                );
-                self.pending_melee_sweep_events
+                let speed = if self.is_held_inert(weapon_entity) {
+                    // Gun audio measures arrival before the sweep truncates
+                    // motion, including locomotion into the surface.
+                    nvec_to_cgmath(heading * travel).dot(stop.normal).max(0.0)
+                } else {
+                    relative_swing_speed(
+                        nvec_to_cgmath(heading * travel),
+                        self.player_velocity,
+                        Vector3::new(0.0, 0.0, 0.0),
+                        Some(stop.normal),
+                    )
+                };
+                self.pending_held_sweep_events
                     .push(CollisionEvent::CollisionStarted {
                         entity1_id: weapon_entity,
                         entity2_id: stop.limb,
@@ -4729,6 +4751,8 @@ impl PhysicsWorld {
         let Some(body) = self.rigid_body_set.get(weapon) else {
             return (1.0, None);
         };
+        let inert = EntityId::from_inner(body.user_data as u64)
+            .is_some_and(|entity| self.is_held_inert(entity));
         let filter = QueryFilter::new()
             .groups(InteractionGroups::new(
                 // The weapon carries its melee membership here, not just
@@ -4803,9 +4827,10 @@ impl PhysicsWorld {
                     .collider_set
                     .get(hit_collider)
                     .filter(|collider| {
-                        collider.collision_groups().memberships.bits()
-                            & InternalCollisionGroups::HITBOX.bits
-                            != 0
+                        inert
+                            || collider.collision_groups().memberships.bits()
+                                & InternalCollisionGroups::HITBOX.bits
+                                != 0
                     })
                     .and_then(|collider| EntityId::from_inner(collider.user_data as u64))
                     .map(|limb| SweepStop {
@@ -5115,7 +5140,7 @@ impl PhysicsWorld {
 
             player_sensor_intersections: HashSet::new(),
             pending_player_sensor_events: Vec::new(),
-            pending_melee_sweep_events: Vec::new(),
+            pending_held_sweep_events: Vec::new(),
 
             reported_nonfinite_entities: HashSet::new(),
 
@@ -6299,7 +6324,7 @@ impl PhysicsWorld {
         // `player_sensor_intersections` at the hop's final occupancy, so the
         // diff below sees no change for anything they already reported.
         let mut collision_events = std::mem::take(&mut self.pending_player_sensor_events);
-        collision_events.append(&mut std::mem::take(&mut self.pending_melee_sweep_events));
+        collision_events.append(&mut std::mem::take(&mut self.pending_held_sweep_events));
         let current_sensor_intersections = profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
             // Only consider sensor colliders for player/sensor intersections.
             let sensor_filter = QueryFilter::new().predicate(&is_sensor_collider);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -726,6 +726,13 @@ pub enum Effect {
         query: EnvSoundQuery,
         position: Vector3<f32>,
     },
+    /// Try the authored schema first, using a fallback only when none resolves.
+    PlayEnvironmentalSoundWithFallback {
+        audio_handle: AudioHandle,
+        query: EnvSoundQuery,
+        fallback: EnvSoundQuery,
+        position: Vector3<f32>,
+    },
     PositionInventory {
         position: Vector3<f32>,
         rotation: Quaternion<f32>,

--- a/shock2vr/src/scripts/impact_sound.rs
+++ b/shock2vr/src/scripts/impact_sound.rs
@@ -1,0 +1,410 @@
+//! Impact sounds for things the player holds, and the rate limiting they share.
+//!
+//! Two different held items arrive here by two different routes:
+//!
+//! - a **melee weapon** is held with a live collision group, so Rapier's narrow
+//!   phase reports its touch as an ordinary contact ([`super::melee_weapon`]);
+//! - a **gun** under `physical_held_items` is held *inert* - no memberships and
+//!   no filter, so the projectile ray cannot hit the barrel it starts inside
+//!   and nothing spawned at the muzzle can be shoved by it - and therefore
+//!   generates no contact at all. What stops it at a wall is the drive's shape
+//!   cast, and that cast's blocking hit is reported as the collision instead
+//!   (see `PhysicsWorld::held_item_sweep_fraction`).
+//!
+//! Once the event exists the two are the same problem, so the guard below is
+//! shared rather than reimplemented: a contact is audible only if the item was
+//! closing on what it hit, and that partner then stays quiet for a moment.
+
+use std::collections::HashMap;
+
+use cgmath::{EuclideanSpace, InnerSpace, vec3};
+use dark::properties::{CollisionType, PropCollisionType};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::{physics::PhysicsWorld, util::get_position_from_transform};
+
+use super::{Effect, MessagePayload, Script, script_util::play_impact_sound};
+
+/// How long one contact partner stays silent after an item thuds against it.
+/// Rapier reports a fresh contact edge every time the solver separates and
+/// re-touches, so a weapon chattering against a wall would otherwise
+/// machine-gun impact sounds. Shorter than the melee free-swing damage
+/// cooldown on purpose: two deliberate taps in quick succession should both be
+/// audible even though only the first one is billed.
+///
+/// Note the key is an *entity*, and a mission's entire static geometry is one
+/// collider owning one entity - so this is one thud per 0.15 s for the whole
+/// level, plus one per prop. That is the right granularity for an impact
+/// sound, and deliberately coarser than "per surface" would be.
+pub const IMPACT_SOUND_COOLDOWN_SECONDS: f32 = 0.15;
+
+/// Approach speed below which a contact makes no sound at all, in world units
+/// per second. Only something that arrived *at* the surface clangs: an item
+/// resting against one, or dragged along one, is silent.
+///
+/// Measured in `debug_melee` (see its module docs): a held weapon at rest
+/// reads ~0.005 and a brisk controller sweep peaks at ~1.6. This sits well
+/// clear of rest while staying far below the free-swing *damage* threshold
+/// (0.5 in that scene), so a light tap that does no damage still clinks.
+const IMPACT_SOUND_MIN_SPEED: f32 = 0.1;
+
+/// Per-partner rate limiting for a held item's impact sounds.
+#[derive(Default)]
+pub struct ImpactSoundGuard {
+    /// Remaining seconds before this item may thud against the same contact
+    /// partner again. Deliberately independent of any damage cooldown: a wall
+    /// makes a noise whether or not the contact is billable.
+    cooldowns: HashMap<EntityId, f32>,
+}
+
+impl ImpactSoundGuard {
+    /// Expire the per-partner cooldowns.
+    pub fn tick(&mut self, elapsed: f32) {
+        self.cooldowns.retain(|_, remaining| {
+            *remaining -= elapsed;
+            *remaining > 0.0
+        });
+    }
+
+    /// Whether this contact should be heard, arming the partner's cooldown
+    /// when it should.
+    ///
+    /// The speed is taken *along the contact normal*, not as a raw magnitude.
+    /// A held item carries the player's whole locomotion velocity, so a wrench
+    /// brushing a corridor wall while walking reads fast by magnitude while
+    /// barely closing on the wall at all - and would otherwise clang every
+    /// 0.15 s for the length of the corridor. `abs` because the normal's
+    /// orientation depends on which collider was listed first.
+    ///
+    /// Melee retains its body-velocity sound rule. An inert gun instead uses
+    /// the sweep's pre-stop approach speed: a fast hand arriving within a
+    /// millimetre of the wall must still clang even though its final travel
+    /// (and therefore its kinematic velocity) was tiny.
+    pub fn should_play(
+        &mut self,
+        entity_id: EntityId,
+        with: EntityId,
+        physics: &PhysicsWorld,
+        contact: Option<crate::physics::CollisionContact>,
+    ) -> bool {
+        if self.cooldowns.contains_key(&with) {
+            return false;
+        }
+        let velocity = physics
+            .get_velocity(entity_id)
+            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
+        let speed = if physics.is_held_inert(entity_id) {
+            contact.and_then(|c| c.closing_speed).unwrap_or(0.0)
+        } else {
+            match contact {
+                Some(contact) => velocity.dot(contact.normal).abs(),
+                None => velocity.magnitude(),
+            }
+        };
+        if speed < IMPACT_SOUND_MIN_SPEED {
+            return false;
+        }
+        self.arm(with);
+        true
+    }
+
+    /// Silence this partner for the cooldown without asking whether the sound
+    /// should play - for a caller that decided to play it on other grounds.
+    pub fn arm(&mut self, with: EntityId) {
+        self.cooldowns.insert(with, IMPACT_SOUND_COOLDOWN_SECONDS);
+    }
+}
+
+/// Impact sound for a contact: the item's collision schema (its class tag +
+/// the hit material - wrench on metal clangs, on a creature thuds), unless its
+/// collision type opts out. Needs no damage value: unmaterialed surfaces
+/// (world geometry, a bench) fall back to the default material tag.
+pub fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
+    let no_sound = world
+        .borrow::<View<PropCollisionType>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
+        .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
+    if no_sound {
+        return Effect::NoEffect;
+    }
+    let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+    play_impact_sound(world, entity_id, with, position.to_vec())
+}
+
+/// The audible half of a physically-held item that is *not* a melee weapon -
+/// today, a gun under `physical_held_items`.
+///
+/// It deliberately does nothing else. A gun is not a club: the contact carries
+/// no damage, opens no attack window, and the item is inert to the solver, so
+/// the only thing a block against the level should produce is the noise of it.
+///
+/// The guard on `is_held_inert` is what keeps that promise narrow. The only
+/// contacts an inert held item can receive are the blocks its own sweep found,
+/// so this script is silent for the same gun lying on the floor, thrown, or
+/// wielded flat - none of which is what the sweep is about, and all of which
+/// would otherwise be a behavior change nobody asked for.
+pub struct HeldItemImpactSound {
+    guard: ImpactSoundGuard,
+}
+
+impl HeldItemImpactSound {
+    pub fn new() -> Self {
+        Self {
+            guard: ImpactSoundGuard::default(),
+        }
+    }
+}
+
+impl Script for HeldItemImpactSound {
+    fn update(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        time: &crate::time::Time,
+    ) -> Effect {
+        self.guard.tick(time.elapsed.as_secs_f32());
+        Effect::NoEffect
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let MessagePayload::Collided { with, contact } = msg else {
+            return Effect::NoEffect;
+        };
+        if !physics.is_held_inert(entity_id) {
+            return Effect::NoEffect;
+        }
+        if !self.guard.should_play(entity_id, *with, physics, *contact) {
+            return Effect::NoEffect;
+        }
+        match impact_sound_effect(entity_id, *with, world) {
+            Effect::PlayEnvironmentalSound {
+                audio_handle,
+                query,
+                position,
+            } => {
+                // Retail never physically bumped guns into walls. Prefer an
+                // authored gun schema; otherwise reuse the wrench's material-
+                // sensitive solid-metal impact as an explicit VR augmentation.
+                let material = super::script_util::get_impact_material(world, *with);
+                Effect::PlayEnvironmentalSoundWithFallback {
+                    audio_handle,
+                    query,
+                    position,
+                    fallback: dark::EnvSoundQuery::from_tag_values(vec![
+                        ("event", "collision"),
+                        ("weapontype", "wrench"),
+                        ("material", &material),
+                    ]),
+                }
+            }
+            effect => effect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::Quaternion;
+    use dark::properties::PropClassTag;
+    use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape, Vector};
+    use shipyard::World;
+
+    use crate::physics::{
+        CollisionEvent, CollisionGroup, DynamicPhysicsOptions, PhysicsShape, PhysicsWorld,
+    };
+
+    use super::*;
+
+    /// Run the real drive: a gun held inert at x=-1, a fixed wall at x=0, and
+    /// the hand asking for x=+1. Returns the physics world plus the `Collided`
+    /// payloads the mission loop would dispatch to the gun - so the script is
+    /// tested against the events the game actually produces, not a hand-built
+    /// contact.
+    fn gun_pushed_into_a_wall(gun: EntityId, start_x: f32) -> (PhysicsWorld, Vec<MessagePayload>) {
+        let mut physics = PhysicsWorld::new();
+        let floor = physics.create_static_body(
+            Isometry::translation(0.0, -1.0, 0.0),
+            EntityId::from_inner(1000),
+        );
+        physics.attach_collider(
+            floor,
+            SharedShape::cuboid(100.0, 1.0, 100.0),
+            1.0,
+            CollisionGroup::entity(),
+        );
+        let mut player = physics.create_player(
+            vec3(1000.0, 1000.0, 1000.0),
+            EntityId::from_inner(1001).unwrap(),
+        );
+        physics.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(0.05, 1.0, 1.0)
+                .translation(Vector::new(0.0, 1.0, 0.0))
+                .build(),
+        );
+
+        physics.add_dynamic(
+            gun,
+            vec3(start_x, 1.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.4, 0.4, 0.4)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        physics.set_held_item_physical(gun, CollisionGroup::held_inert());
+        physics.set_position_rotation2(
+            gun,
+            vec3(start_x, 1.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        physics.set_position_rotation2(
+            gun,
+            vec3(1.0, 1.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        );
+
+        // Stops on the frame that produced the block, so the physics world
+        // handed back is in the state the mission loop would dispatch against:
+        // a held item's velocity is the distance it actually moved that step,
+        // and it is 0 again a frame later.
+        let mut messages = Vec::new();
+        for frame in 0.. {
+            assert!(frame < 120, "the drive never reported blocking on the wall");
+            let (_, events) = physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+            for event in events {
+                // The same translation `mission_core` performs: whichever side
+                // the gun is, it hears about the other, with the normal
+                // oriented toward it.
+                if let CollisionEvent::CollisionStarted {
+                    entity1_id,
+                    entity2_id,
+                    contact,
+                } = event
+                {
+                    if entity2_id == gun {
+                        messages.push(MessagePayload::Collided {
+                            with: entity1_id,
+                            contact: contact.map(|contact| crate::physics::CollisionContact {
+                                point: contact.point,
+                                normal: -contact.normal,
+                                closing_speed: contact.closing_speed,
+                            }),
+                        });
+                    } else if entity1_id == gun {
+                        messages.push(MessagePayload::Collided {
+                            with: entity2_id,
+                            contact,
+                        });
+                    }
+                }
+            }
+            if !messages.is_empty() {
+                break;
+            }
+        }
+        (physics, messages)
+    }
+
+    /// A world holding one gun that resolves an impact sound: the schema
+    /// lookup is keyed on the item's class tag.
+    fn world_with_audible_gun() -> (World, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity(PropClassTag::from_string("WeaponType Pistol"));
+        (world, gun)
+    }
+
+    fn sound_count(effect: &Effect) -> usize {
+        match effect {
+            Effect::PlayEnvironmentalSoundWithFallback { .. } => 1,
+            Effect::Multiple(effects) => effects.iter().map(sound_count).sum(),
+            _ => 0,
+        }
+    }
+
+    /// The report: a gun pushed into a bulkhead stopped dead and in silence,
+    /// because an inert held item generates no contact for anything to hear.
+    #[test]
+    fn a_held_gun_blocked_by_the_level_makes_one_impact_sound() {
+        let (world, gun) = world_with_audible_gun();
+        let (physics, messages) = gun_pushed_into_a_wall(gun, -1.0);
+        let mut script = HeldItemImpactSound::new();
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "the drive should report the block exactly once: {messages:?}"
+        );
+        let effect = script.handle_message(gun, &world, &physics, &messages[0]);
+        assert_eq!(sound_count(&effect), 1, "got {effect:?}");
+    }
+
+    #[test]
+    fn a_fast_approach_with_tiny_remaining_clearance_is_audible() {
+        let (world, gun) = world_with_audible_gun();
+        let (physics, messages) = gun_pushed_into_a_wall(gun, -0.2601);
+        assert!(physics.get_velocity(gun).unwrap().magnitude() < IMPACT_SOUND_MIN_SPEED);
+        let mut script = HeldItemImpactSound::new();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            sound_count(&script.handle_message(gun, &world, &physics, &messages[0])),
+            1
+        );
+    }
+
+    /// ...and it does not machine-gun. The block itself is edge-triggered, but
+    /// a gun chattering against a surface would still re-report; the same
+    /// partner stays quiet until the cooldown expires.
+    #[test]
+    fn a_repeat_block_within_the_cooldown_is_silent() {
+        let (world, gun) = world_with_audible_gun();
+        let (physics, messages) = gun_pushed_into_a_wall(gun, -1.0);
+        let mut script = HeldItemImpactSound::new();
+
+        let first = script.handle_message(gun, &world, &physics, &messages[0]);
+        assert_eq!(sound_count(&first), 1, "got {first:?}");
+        for _ in 0..5 {
+            let repeat = script.handle_message(gun, &world, &physics, &messages[0]);
+            assert_eq!(sound_count(&repeat), 0, "got {repeat:?}");
+        }
+
+        script.update(
+            gun,
+            &world,
+            &physics,
+            &crate::time::Time {
+                elapsed: std::time::Duration::from_millis(200),
+                total: std::time::Duration::from_millis(200),
+            },
+        );
+        let later = script.handle_message(gun, &world, &physics, &messages[0]);
+        assert_eq!(sound_count(&later), 1, "got {later:?}");
+    }
+
+    /// The script's whole remit is the swept, inert, held state. The same gun
+    /// lying on the floor collides for ordinary physical reasons, and turning
+    /// those into noise is a different feature nobody asked for.
+    #[test]
+    fn a_gun_that_is_not_held_inert_stays_silent() {
+        let (world, gun) = world_with_audible_gun();
+        let (mut physics, messages) = gun_pushed_into_a_wall(gun, -1.0);
+        physics.set_collision_group(gun, CollisionGroup::entity());
+        physics.set_held_item_physical(gun, CollisionGroup::entity());
+        let mut script = HeldItemImpactSound::new();
+
+        assert!(matches!(
+            script.handle_message(gun, &world, &physics, &messages[0]),
+            Effect::NoEffect
+        ));
+    }
+}

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -1,19 +1,18 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, InnerSpace, Vector3, vec3};
-use dark::properties::{CollisionType, PropCollisionType};
+use cgmath::{Vector3, vec3};
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     PresentationMode,
     mission::{GlobalPresentationMode, stim_response::contact_stim_damage},
     physics::PhysicsWorld,
-    util::get_position_from_transform,
 };
 
 use super::{
     Effect, Message, MessagePayload, Script,
-    script_util::{entity_class_template_id, play_impact_sound},
+    impact_sound::{ImpactSoundGuard, impact_sound_effect},
+    script_util::entity_class_template_id,
 };
 
 /// Contact damage for the player's authored melee weapons (`PropLimbModel`).
@@ -40,14 +39,14 @@ pub struct HeldMeleeWeapon {
     /// Remaining seconds before this weapon may thud against the same contact
     /// partner again. Independent of the damage cooldowns above: a wall makes
     /// a noise whether or not the contact is billable.
-    sound_cooldowns: HashMap<EntityId, f32>,
+    sound_guard: ImpactSoundGuard,
 }
 
 impl HeldMeleeWeapon {
     pub fn new() -> Self {
         Self {
             free_swing_cooldowns: HashMap::new(),
-            sound_cooldowns: HashMap::new(),
+            sound_guard: ImpactSoundGuard::default(),
         }
     }
 }
@@ -57,29 +56,6 @@ impl HeldMeleeWeapon {
 /// this a swing bills once per contact frame; long enough to cost one hit per
 /// swing, short enough not to eat a genuine second swing.
 const FREE_SWING_COOLDOWN_SECONDS: f32 = 0.4;
-
-/// How long one contact partner stays silent after this weapon thuds against
-/// it. Rapier reports a fresh contact edge every time the solver separates and
-/// re-touches, so a weapon chattering against a wall would otherwise
-/// machine-gun impact sounds. Shorter than [`FREE_SWING_COOLDOWN_SECONDS`] on
-/// purpose: two deliberate taps in quick succession should both be audible
-/// even though only the first one is billed.
-///
-/// Note the key is an *entity*, and a mission's entire static geometry is one
-/// collider owning one entity - so this is one thud per 0.15 s for the whole
-/// level, plus one per prop. That is the right granularity for an impact
-/// sound, and deliberately coarser than "per surface" would be.
-const IMPACT_SOUND_COOLDOWN_SECONDS: f32 = 0.15;
-
-/// Approach speed below which a contact makes no sound at all, in world units
-/// per second. Only something that arrived *at* the surface clangs: a weapon
-/// resting against one, or dragged along one, is silent.
-///
-/// Measured in `debug_melee` (see its module docs): a held weapon at rest
-/// reads ~0.005 and a brisk controller sweep peaks at ~1.6. This sits well
-/// clear of rest while staying far below the free-swing *damage* threshold
-/// (`MELEE_FREE_SWING_SPEED`), so a light tap that does no damage still clinks.
-const IMPACT_SOUND_MIN_SPEED: f32 = 0.1;
 
 /// The swing/graze gate: minimum closing speed for a contact to damage.
 fn free_swing_speed_threshold() -> f32 {
@@ -96,12 +72,11 @@ impl Script for HeldMeleeWeapon {
         time: &crate::time::Time,
     ) -> Effect {
         let elapsed = time.elapsed.as_secs_f32();
-        for cooldowns in [&mut self.free_swing_cooldowns, &mut self.sound_cooldowns] {
-            cooldowns.retain(|_, remaining| {
-                *remaining -= elapsed;
-                *remaining > 0.0
-            });
-        }
+        self.free_swing_cooldowns.retain(|_, remaining| {
+            *remaining -= elapsed;
+            *remaining > 0.0
+        });
+        self.sound_guard.tick(elapsed);
         Effect::NoEffect
     }
 
@@ -177,7 +152,9 @@ impl Script for HeldMeleeWeapon {
                 // A blow that lands is always audible, as it always was. The
                 // operator is a bitwise `|`, not `||`, so the guard still runs
                 // (and arms the cooldown) even when damage forces the sound.
-                if self.may_play_impact_sound(entity_id, owner, physics, *contact)
+                if self
+                    .sound_guard
+                    .should_play(entity_id, owner, physics, *contact)
                     | damage.is_some()
                 {
                     let sound = impact_sound_effect(entity_id, owner, world);
@@ -230,56 +207,6 @@ impl HeldMeleeWeapon {
         }
         self.free_swing_cooldowns
             .insert(with, FREE_SWING_COOLDOWN_SECONDS);
-        true
-    }
-
-    /// Whether this contact should be heard. Contacts repeat while a weapon
-    /// rests on or scrapes along a surface, and the damage path's own dedupe
-    /// does not cover the (much more common) contacts that deal no damage - so
-    /// the sound carries its own guard: the weapon must have been closing on
-    /// what it hit, and that partner then stays quiet for a moment.
-    ///
-    /// The speed is taken *along the contact normal*, not as a raw magnitude.
-    /// A held weapon carries the player's whole locomotion velocity, so a
-    /// wrench brushing a corridor wall while walking reads fast by magnitude
-    /// while barely closing on the wall at all - and would otherwise clang
-    /// every 0.15 s for the length of the corridor. `abs` because the normal's
-    /// orientation depends on which collider Rapier listed first.
-    ///
-    /// The damage rule above projects the same way but measures a different
-    /// quantity - it also divides out the victim's motion and the player's own
-    /// locomotion, and reads the hand rather than the weapon body. The two
-    /// stay separate because they answer different questions at different
-    /// thresholds: audible is a much lower bar than damaging, a contact too
-    /// gentle to bill should still clink, and a wrench carried head-on into a
-    /// bulkhead should clang even though walking is not a swing.
-    /// Whether this contact thuds. Same speed question as [`Self::may_damage`],
-    /// a lower bar - and the same reason for reading the sweep's own
-    /// measurement: a swing stopped on a limb has no live velocity left to
-    /// read, so without it exactly the blows that now land are the ones that
-    /// would fall silent.
-    fn may_play_impact_sound(
-        &mut self,
-        entity_id: EntityId,
-        with: EntityId,
-        physics: &PhysicsWorld,
-        contact: Option<crate::physics::CollisionContact>,
-    ) -> bool {
-        if self.sound_cooldowns.contains_key(&with) {
-            return false;
-        }
-        let velocity = physics
-            .get_velocity(entity_id)
-            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
-        let speed = match contact {
-            Some(contact) => velocity.dot(contact.normal).abs(),
-            None => velocity.magnitude(),
-        };
-        if speed < IMPACT_SOUND_MIN_SPEED {
-            return false;
-        }
-        self.sound_cooldowns
-            .insert(with, IMPACT_SOUND_COOLDOWN_SECONDS);
         true
     }
 }
@@ -399,25 +326,9 @@ fn contact_damage_effect(
     }
 }
 
-/// Impact sound for a contact: the weapon's collision schema (weapontype class
-/// tag + hit material - wrench on metal clangs, on a creature thuds), unless
-/// its collision type opts out. Needs no damage value: unmaterialed surfaces
-/// (world geometry, a bench) fall back to the default material tag.
-fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
-    let no_sound = world
-        .borrow::<View<PropCollisionType>>()
-        .ok()
-        .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
-        .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
-    if no_sound {
-        return Effect::NoEffect;
-    }
-    let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
-    play_impact_sound(world, entity_id, with, position.to_vec())
-}
-
 #[cfg(test)]
 mod tests {
+    use dark::properties::{CollisionType, PropCollisionType};
     use std::collections::HashMap;
 
     use dark::properties::{

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -32,6 +32,7 @@ mod frob_qb;
 pub mod gui;
 pub mod healing_item;
 mod homing;
+mod impact_sound;
 mod internal_collision_type;
 mod internal_explosion;
 pub mod internal_fast_projectile;
@@ -166,6 +167,7 @@ use self::{
     energy_weapon::EnergyWeapon,
     exp_cookie::ExpCookie,
     frob_qb::FrobQB,
+    impact_sound::HeldItemImpactSound,
     internal_collision_type::InternalCollisionType,
     internal_explosion::InternalExplosion,
     internal_keycard_script::KeyCardScript,
@@ -975,6 +977,12 @@ impl ScriptWorld {
                 Box::new(HeldMeleeWeapon::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
             ])),
+            // Attached by entity_creator to every PropPlayerGun. Under
+            // `physical_held_items` a wielded gun is held as an inert body
+            // stopped by a shape cast, and this turns that block into the
+            // noise of a gun meeting a bulkhead - the one thing a gun's
+            // collision should produce. Inert in every other state.
+            "internal_held_item_impact_sound" => Box::new(HeldItemImpactSound::new()),
             "pistolmodify" => Box::new(NoopScript::new()),
 
             // TODO: Necessary

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -1150,7 +1150,7 @@ pub const DEFAULT_IMPACT_MATERIAL: &str = "metal";
 /// "Material FleshTarget", authored via archetypes such as `MatFlesh`),
 /// falling back to the default for world hits / untagged entities. Hitbox
 /// proxies resolve to their parent creature.
-fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
+pub(super) fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
     let victim = resolve_proxy_entity(world, hit_entity_id);
     world
         .borrow::<View<PropMaterial>>()

--- a/tools/shock2-sdk/test/held-gun-impact-sound.e2e.test.ts
+++ b/tools/shock2-sdk/test/held-gun-impact-sound.e2e.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { collisionSoundsSince, tagValue } from "./helpers/audio.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// A gun held under `--experimental physical_held_items` is stopped by the level
+// but takes part in no collision at all (`CollisionGroup::held_inert`), so the
+// narrow phase has nothing to say about it: pushing it into a bulkhead was
+// completely silent, where a wrench thuds. The block the held-item sweep finds
+// is now reported as a collision instead, and this is the production wiring for
+// that - a real mission, the real VR grab, the real drive.
+//
+// Stock guns have no collision schema. The authored gun query is preferred;
+// the material-sensitive wrench impact supplies the VR fallback.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const PISTOL = -17;
+
+// Push the held weapon down through the floor line, advancing the tracked hand
+// one simulation frame at a time like a real controller sample. The target ends
+// well below the floor: the gun's collider is small and sits near the grip, so
+// a hand stopping at ankle height never brings it into contact with anything.
+async function pushThroughTheFloor(
+  game: GameServer,
+  frames = 90,
+): Promise<void> {
+  const start: Vec3 = [0.0, 1.5, 0.6];
+  const end: Vec3 = [0.0, -2.2, 0.6];
+  for (let frame = 1; frame <= frames; frame += 1) {
+    const t = frame / frames;
+    const hand: Vec3 = [start[0], start[1] + (end[1] - start[1]) * t, start[2]];
+    await game.input.set("right_hand.position", hand);
+    await game.step({ frames: 1 });
+  }
+}
+
+test(
+  "a physically-held gun reports the level block that stops it, exactly once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr", "--experimental", "physical_held_items"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    // In VR `wield` is a no-op, so DebugCycleWeapon drops the roster's first
+    // weapon - the Pistol - in front of the player as a world pickup.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    const pistol = (await game.entities.list()).entities.find(
+      (e) => e.template_id === PISTOL,
+    );
+    assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
+
+    await aimVrHandAt(game, pistol.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol.id,
+      "the VR right hand must hold the pistol",
+    );
+
+    // The flag's own precondition: held, and in no collision group at all.
+    // Without this the rest of the test would be about nothing.
+    const held = (await game.physics.bodies({ entityId: pistol.id })).bodies[0];
+    assert.ok(held, "the held gun must have a body under physical_held_items");
+    assert.deepEqual(held.collision_groups, [], "the held gun must be inert");
+
+    // Push it down through the floor. The trigger stays UP - a gun meeting a
+    // bulkhead is not an attack.
+    await game.input.set("right_hand.position", [0.0, 1.5, 0.6]);
+    await game.step({ frames: 20 });
+    const beforePush = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await pushThroughTheFloor(game);
+
+    const blockedY = (await game.physics.bodies({ entityId: pistol.id }))
+      .bodies[0]?.position[1];
+    assert.ok(blockedY !== undefined, "the held gun kept its body");
+    const handY = (await game.info()).player.position[1] - 2.2;
+    assert.ok(
+      blockedY > handY + 0.5,
+      `the level should have held the gun back: gun y=${blockedY}, hand y=${handY}`,
+    );
+
+    const impacts = () =>
+      game.audio
+        .recent()
+        .then((recent) =>
+          collisionSoundsSince(recent.sounds, beforePush).filter(
+            (sound) => tagValue(sound, "weapontype") === "wrench",
+          ),
+        );
+    assert.equal(
+      (await impacts()).length,
+      1,
+      "one resolved metal-weapon impact must play",
+    );
+    await game.step({ frames: 120 });
+    assert.equal(
+      (await impacts()).length,
+      1,
+      "resting contact must remain silent",
+    );
+    await game.input.set("right_hand.position", [0.0, 1.5, 0.6]);
+    await game.step({ frames: 60 });
+    await pushThroughTheFloor(game);
+    assert.equal(
+      (await impacts()).length,
+      2,
+      "a second deliberate tap must play again",
+    );
+  },
+);


### PR DESCRIPTION
A physically held VR gun now makes an impact sound when its blocking sweep reaches level geometry. It stays quiet while resting, and sounds again after withdrawal and another tap. Guns remain inert to projectiles and do no contact damage.

Adapts #1153 to the current sweep/contact system and shares the existing melee sound guard. Stock gun classes have no collision schemas, so an authored gun schema takes precedence, with the wrench’s material-sensitive metal impact as an explicit VR fallback. `NO_COLLISION_SOUND` is respected. Near-wall impacts use pre-stop approach speed, including locomotion, so collision truncation cannot silence a fast tap.

Validation:
- Full gameplay suite: 1,638 passed, 2 diagnostic tests ignored.
- Nine focused impact-sound tests, including tiny remaining clearance and existing melee behavior.
- SDK verifies an actual resolved impact sample, silence at rest, and a second tap.
- All 23 missions load; left/right physical-gun, blocked firing, drop and full-backpack regression tests pass (27 SDK cases total).
- Warning-denied gameplay/desktop/debug checks passed.
- Independent agent and Codex CLI review; addressed pre-stop speed finding. All four duplication strategies completed without actionable duplication.

This layer changes audio and contact reporting; visual wall blocking is demonstrated in parent #1472. Headless tests verify sound resolution and timing, not headset loudness or feel. Requires `--experimental physical_held_items` in VR.
