### PR TITLE
feat(mfd): expose automap in the shared cyber interface

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -55,6 +55,18 @@ explicitly from `fonts/` and tinted cyan; the alternate `iface/fonts` copy is
 not suitable. Specimens currently use their inventory artwork in the preview;
 a rotating 3D specimen is still a separate rendering increment.
 
+### Map control
+
+MAP toggles the existing automap in the cyber interface through `ToggleMap`.
+Both presentations use its mission map art, explored regions and player pip.
+The wide panel scales uniformly to clear the utility row/HUD and keep CLOSE
+inside the canvas. VR's map is a synthetic cyber-panel host, never an extra
+world quad even with the legacy experimental GUI enabled. Opening MAP closes
+the utility reader; clicking it again or using the map's close button dismisses
+the map. The VR shortcut only acts while the cyber interface is active.
+
+Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
+
 
 ### Mirrored arm layout prototype
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -86,6 +86,7 @@ const NAME_STRIP_FONT: &str = "mainfont.fon";
 /// click, acting on the still-contained item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlatUiDragAction {
+    ToggleMap,
     Throw(EntityId),
     Wield(EntityId),
     /// One of the AMMOFULL readout's controls was clicked (fire-mode setting,
@@ -913,7 +914,21 @@ impl FlatUiHost {
                     self.close();
                 }
                 self.hover_close = false;
-                return (Vec::new(), Vec::new());
+                if self.utilities.is_open()
+                    && self
+                        .panel_rect()
+                        .is_some_and(|rect| rect.x + rect.w > 450.0)
+                {
+                    // A wide map and the right utility reader share space.
+                    // Switching utilities must not leave an opaque map over it.
+                    self.close();
+                }
+                let actions = if self.utilities.take_map_request() {
+                    vec![FlatUiDragAction::ToggleMap]
+                } else {
+                    Vec::new()
+                };
+                return (Vec::new(), actions);
             }
         }
         if strip_rect.is_some_and(|r| hand_readout_rects(r).iter().any(|r| r.contains(canvas_pos)))
@@ -1465,6 +1480,18 @@ impl Default for FlatUiHost {
 /// The active panel's rect on the canvas: panel-local pixels anchored at the
 /// original left-MFD slot.
 fn panel_canvas_rect(panel_size_px: Vector2<f32>) -> Rect {
+    if panel_size_px.x > 614.0 {
+        // Wide maps clear the utility row/HUD and leave room for CLOSE.
+        let scale = (614.0 / panel_size_px.x)
+            .min(248.0 / panel_size_px.y)
+            .min(1.0);
+        return Rect::new(
+            LEFT_MFD_ANCHOR.x,
+            LEFT_MFD_ANCHOR.y,
+            panel_size_px.x * scale,
+            panel_size_px.y * scale,
+        );
+    }
     Rect::new(
         LEFT_MFD_ANCHOR.x,
         LEFT_MFD_ANCHOR.y,
@@ -2478,6 +2505,42 @@ mod tests {
             None,
             "the decorative arm is not another backpack cell"
         );
+    }
+
+    #[test]
+    fn wide_map_clears_utility_row_and_keeps_close_inside_canvas() {
+        let map = panel_canvas_rect(vec2(636.0, 296.0));
+        let close = close_button_canvas_rect(map);
+        assert!(map.y + map.h <= 372.001);
+        assert!(close.x + close.w <= CANVAS_SIZE.x);
+        assert!((map.w / map.h - 636.0 / 296.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn replicator_with_hack_sidecar_keeps_native_size() {
+        let rect = panel_canvas_rect(vec2(261.0, 296.0));
+        assert_eq!((rect.w, rect.h), (261.0, 296.0));
+    }
+
+    #[test]
+    fn opening_research_closes_a_wide_map_panel() {
+        let (world, mut host, item, _) = drag_world();
+        host.open_unbound(item);
+        host.panel_size_px = Some(vec2(636.0, 296.0));
+        assert!(press_edge(&mut host, &world, (506.0, 395.0)).is_empty());
+        assert!(host.utilities.is_open());
+        assert!(host.panel_size_px.is_none());
+    }
+
+    #[test]
+    fn map_button_emits_only_map_toggle_and_keeps_cursor_item() {
+        let (world, mut host, item, _) = drag_world();
+        host.cursor_item = Some(make_cursor_item(&world, item));
+        assert_eq!(
+            press_edge(&mut host, &world, (544.0, 395.0)),
+            vec![FlatUiDragAction::ToggleMap]
+        );
+        assert_eq!(host.held_entity(), Some(item));
     }
 
     #[test]

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -17,6 +17,7 @@ const PAGE_LINES: usize = 16;
 enum Control {
     Inspect,
     Research,
+    Map,
     Close,
     Previous,
     Next,
@@ -26,6 +27,7 @@ enum Control {
 pub(crate) struct MfdUtilities {
     inspecting: bool,
     research: bool,
+    map_requested: bool,
     research_catalog: super::research_overview::ResearchCatalog,
     selected: Option<EntityId>,
     title: String,
@@ -44,6 +46,12 @@ impl MfdUtilities {
             self.research_catalog.select_project(id);
         }
     }
+    pub(crate) fn is_open(&self) -> bool {
+        self.inspecting || self.selected.is_some() || self.research
+    }
+    pub(crate) fn take_map_request(&mut self) -> bool {
+        std::mem::take(&mut self.map_requested)
+    }
     pub(crate) fn is_inspecting(&self) -> bool {
         self.inspecting
     }
@@ -56,6 +64,7 @@ impl MfdUtilities {
             Rect::new(488.0, 382.0, 36.0, 26.0),
             "RES",
         ));
+        controls.push((Control::Map, Rect::new(526.0, 382.0, 36.0, 26.0), "MAP"));
         if self.inspecting || self.selected.is_some() {
             controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
             if self.page > 0 {
@@ -96,6 +105,10 @@ impl MfdUtilities {
                     Control::Research => {
                         *self = Self::default();
                         self.research = true;
+                    }
+                    Control::Map => {
+                        *self = Self::default();
+                        self.map_requested = true;
                     }
                     Control::Close => *self = Self::default(),
                     Control::Previous => self.page = self.page.saturating_sub(1),
@@ -206,6 +219,7 @@ impl MfdUtilities {
                     match control {
                         Control::Inspect => "inspect",
                         Control::Research => "research_overview",
+                        Control::Map => "map",
                         Control::Close => "utility_close",
                         Control::Previous => "utility_previous",
                         Control::Next => "utility_next",

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2523,16 +2523,10 @@ impl MissionCore {
         );
         world.add_component(inventory, PlayerInventoryEntity {});
 
-        // The synthetic automap panel entity (projects/flat-ui-panels.md §5):
-        // carries `MapGui` (script `internal_map`) plus the level's page data.
-        // No world object opens the map - `Effect::ToggleMap` binds it to the
-        // flat host as an unbound (sticky) panel. Never serialized: rebuilt
-        // here on every load. Flat-only: in VR the panel cannot be opened
-        // (ToggleMap is flat-gated), and under `--experimental gui` its
-        // per-frame SetUI would otherwise materialize an undismissable world
-        // quad at the origin.
+        // Synthetic automap host for the shared flat/VR cyber canvas.
+        // Rebuilt on load and excluded from legacy free-floating GUI emission.
         world.add_unique(PlayerMapLocation::default());
-        if game_options.presentation_mode == crate::PresentationMode::Flat {
+        {
             let level_stem = mission.split('.').next().unwrap_or(&mission).to_uppercase();
             let (revealed_rects, explored_rects) =
                 dark::map::MapChunkData::load_from_mission(asset_cache, &level_stem)
@@ -6173,6 +6167,7 @@ impl MissionCore {
     ) -> Vec<Effect> {
         use crate::mission::flat_ui_host::FlatUiDragAction;
         match action {
+            FlatUiDragAction::ToggleMap => vec![Effect::ToggleMap],
             FlatUiDragAction::Throw(entity_id) => {
                 self.throw_entity_into_world(entity_id);
                 Vec::new()
@@ -7673,9 +7668,10 @@ impl MissionCore {
                 }
 
                 Effect::ToggleMap => {
-                    // Flat-presentation only, like OpenPanel: the automap is a
-                    // flat MFD; VR panels are world quads (out of scope here).
-                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                    // VR uses this host while the cyber interface is active.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat
+                        || self.use_mode
+                    {
                         if let Ok(map) = self.world.borrow::<UniqueView<MapPanelEntity>>() {
                             let entity = map.0;
                             drop(map);
@@ -7683,6 +7679,7 @@ impl MissionCore {
                                 self.flat_ui.close();
                             } else {
                                 // Unbound: no world object -> no walk-away close.
+                                self.flat_ui.utilities = Default::default();
                                 self.flat_ui.open_unbound(entity);
                             }
                         }
@@ -8398,9 +8395,14 @@ impl MissionCore {
                     // behavior.
                     self.flat_ui
                         .on_set_ui(&self.world, parent_entity, world_size, &components);
-                    let update_world_panel = game_options.experimental_features.contains("gui")
-                        || (game_options.presentation_mode == crate::PresentationMode::Vr
-                            && self.gui.active_panel() == Some(parent_entity));
+                    let is_map = self
+                        .world
+                        .borrow::<UniqueView<MapPanelEntity>>()
+                        .is_ok_and(|map| map.0 == parent_entity);
+                    let update_world_panel = !is_map
+                        && (game_options.experimental_features.contains("gui")
+                            || (game_options.presentation_mode == crate::PresentationMode::Vr
+                                && self.gui.active_panel() == Some(parent_entity)));
                     if update_world_panel {
                         // `internal_inventory` is a 15-column strip: keep its
                         // shared canvas/layout identical, but map that resolved

--- a/tools/shock2-sdk/test/map.e2e.test.ts
+++ b/tools/shock2-sdk/test/map.e2e.test.ts
@@ -29,7 +29,10 @@ test(
       atStart.length >= 1,
       `spawning inside a mapped room should reveal its location (got ${atStart})`,
     );
-    assert.ok(!(await game.ui.state()).active_panel, "no panel before ToggleMap");
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "no panel before ToggleMap",
+    );
 
     // --- ToggleMap opens the wide map panel ---
     await game.input.trigger("ToggleMap");
@@ -37,16 +40,19 @@ test(
     const opened = await game.ui.state();
     assert.ok(opened.active_panel, "ToggleMap should open the map panel");
     const textures = () =>
-      opened.active_panel!.elements
-        .filter((e) => e.kind === "image")
+      opened
+        .active_panel!.elements.filter((e) => e.kind === "image")
         .map((e) => (e.texture ?? "").toLowerCase());
     const backdrop = opened.active_panel.elements.find(
       (e) => (e.texture ?? "").toLowerCase() === "mapback.pcx",
     );
     assert.ok(backdrop, `panel should draw MAPBACK (got ${textures()})`);
-    // The wide panel: 636x296 anchored at the left-MFD slot, filling the
-    // canvas width (the original's {2,2}-{638,302} both-slot rect).
-    assert.deepEqual(backdrop.rect, [2, 124, 636, 296]);
+    // The wide panel preserves its aspect ratio above the utility row
+    // (the original's {2,2}-{638,302} both-slot rect).
+    const mapScale = backdrop.rect[2] / 636;
+    assert.deepEqual(backdrop.rect.slice(0, 2), [2, 124]);
+    assert.ok(Math.abs(backdrop.rect[3] - 248) < 0.01);
+    assert.ok(Math.abs(backdrop.rect[3] / 296 - mapScale) < 0.001);
     assert.ok(
       textures().some((t) => t.endsWith("page001.pcx")),
       "panel should draw the level's PAGE001 art",
@@ -60,12 +66,14 @@ test(
 
     // --- Player marker present, and it tracks movement ---
     const marker = () =>
-      game.ui.state().then(
-        (s) =>
-          s.active_panel?.elements.find(
-            (e) => (e.texture ?? "").toLowerCase() === "plrpip.pcx",
-          ) ?? null,
-      );
+      game.ui
+        .state()
+        .then(
+          (s) =>
+            s.active_panel?.elements.find(
+              (e) => (e.texture ?? "").toLowerCase() === "plrpip.pcx",
+            ) ?? null,
+        );
     const markerBefore = await marker();
     assert.ok(markerBefore, "panel should draw the player marker (plrpip)");
 
@@ -75,7 +83,10 @@ test(
     await game.step({ frames: 90 });
     await game.input.set("right_hand.thumbstick", [0.0, 0.0]);
     const markerAfter = await marker();
-    assert.ok(markerAfter, "map panel must survive walking (no distance close)");
+    assert.ok(
+      markerAfter,
+      "map panel must survive walking (no distance close)",
+    );
     const moved = Math.hypot(
       markerAfter.rect[0] - markerBefore.rect[0],
       markerAfter.rect[1] - markerBefore.rect[1],
@@ -100,8 +111,8 @@ test(
     const bx = 536 - sx * 32.874435;
     const sy = (10 - 239) / (44.685417 - -40.31117);
     const by = 239 - sy * -40.31117;
-    const expectX = 2 + 10 + (sx * pos.z + bx) - 8; // canvas = anchor + page offset + page px - half marker
-    const expectY = 124 + 8 + (sy * pos.x + by) - 8;
+    const expectX = 2 + (10 + (sx * pos.z + bx) - 8) * mapScale; // canvas = anchor + page offset + page px - half marker
+    const expectY = 124 + (8 + (sy * pos.x + by) - 8) * mapScale;
     assert.ok(
       Math.abs(markerAfter.rect[0] - expectX) < 4 &&
         Math.abs(markerAfter.rect[1] - expectY) < 4,
@@ -157,14 +168,17 @@ test(
       (e) => (e.texture ?? "").toLowerCase() === "plrpip.pcx",
     );
     assert.ok(insetPip, "pip should be drawn on the lower level");
-    const pipCenter = [insetPip.rect[0] + 8, insetPip.rect[1] + 8];
+    const pipCenter = [
+      insetPip.rect[0] + insetPip.rect[2] / 2,
+      insetPip.rect[1] + insetPip.rect[3] / 2,
+    ];
     // Canvas bounds of inset rect 2: anchor (2, 124) + page offset (10, 8) +
     // rect LTRB (25, 100, 144, 169).
     assert.ok(
-      pipCenter[0] >= 2 + 10 + 25 &&
-        pipCenter[0] <= 2 + 10 + 144 &&
-        pipCenter[1] >= 124 + 8 + 100 &&
-        pipCenter[1] <= 124 + 8 + 169,
+      pipCenter[0] >= 2 + (10 + 25) * mapScale &&
+        pipCenter[0] <= 2 + (10 + 144) * mapScale &&
+        pipCenter[1] >= 124 + (8 + 100) * mapScale &&
+        pipCenter[1] <= 124 + (8 + 169) * mapScale,
       `pip should land inside the lower-level inset box (center [${pipCenter}])`,
     );
     // And the bright decal follows the player to the inset location.

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -192,3 +192,40 @@ for (const vr of [false,true]) {
     await capture("completed-list");
   });
 }
+
+for (const vr of [false,true]) {
+  test(`MAP utility opens the real mission automap and preserves inventory (${vr ? "VR" : "flat"})`, {
+    skip: process.env.SHOCK2_E2E !== "1", timeout:180_000,
+  }, async()=>{
+    await using game=await GameServer.launch({mission:"medsci1.mis",debugFlags:vr?["--vr"]:[]});
+    await game.step({frames:30});
+    await game.player.spawnItem(-52);
+    await game.input.trigger("ToggleUseMode");await game.step({frames:5});
+    const inventory=await game.player.inventory();
+    const click=async(e:UiElement)=>{
+      if(vr)await clickCanvasWithRay(game,requirePanelPose(await game.ui.state()),canvasCenter(e));
+      else await clickUiElement(game,e);
+    };
+    const mapControl=async()=>{const e=(await game.ui.state()).strip!.elements.find(e=>e.label==="map");assert.ok(e);return e;};
+    const capture=async(name:string)=>{
+      const out=process.env.ASTRA_MAP_CAPTURE;if(!out)return;await mkdir(out,{recursive:true});
+      const path=`${out}/${vr?"vr":"flat"}-${name}`;await game.screenshot(path+".png",1600);
+      await writeFile(path+".json",JSON.stringify({ui:await game.ui.state(),info:await game.info(),inventory:await game.player.inventory()},null,2));
+    };
+    await capture("idle");
+    await click(await mapControl());
+    const panel=(await game.ui.state()).active_panel;assert.ok(panel);
+    for(const texture of ["mapback.pcx","page001.pcx","plrpip.pcx"]){assert.ok(panel.elements.some(e=>e.texture?.toLowerCase().endsWith(texture)),texture);}
+    assert.ok(panel.elements.some(e=>/p001r\d{3}\.pcx$/i.test(e.texture??"")),"current explored room decal");
+    for(const e of panel.elements){const [x,y,w,h]=e.rect;assert.ok(x>=0&&x+w<=640.01&&y>=0&&y+h<=480.01,`${e.label??e.texture} remains in canvas`);}
+    await capture("open");
+    await click(await mapControl());
+    assert.equal((await game.ui.state()).active_panel,null,"MAP toggles closed");
+    await capture("closed");
+    await click(await mapControl());
+    const close=(await game.ui.state()).active_panel!.elements.find(e=>e.label==="close");assert.ok(close,"map has close control");
+    await click(close);
+    assert.equal((await game.ui.state()).active_panel,null,"map close control works");
+    assert.deepEqual(await game.player.inventory(),inventory);
+  });
+}


### PR DESCRIPTION
MAP now opens the existing mission automap from the shared cyber interface in flat and VR. The authored map scales uniformly to keep its close button inside the canvas and its lower edge clear of the utility row.

Validation: 56 host tests; full MedSci automap exploration/marker/save-load regression; MAP open/toggle/close and unchanged-inventory checks in flat and VR. Independent code/visual and duplication reviews completed; shortcut utility-state and replicator sizing findings corrected. Headset validation deferred.

![MAP utility in flat and VR](https://gist.githubusercontent.com/tommy-xr/735b847c5dffa939d29b7daf044ce7b2/raw/astra-mfd-map.png)

![Open and close the mission map](https://gist.githubusercontent.com/tommy-xr/735b847c5dffa939d29b7daf044ce7b2/raw/astra-mfd-map.gif)

Real MedSci 1 map opened with MAP in the cyber interface. Both presentations verify authored page/current-room artwork, player marker, canvas bounds, toggle/close behavior and unchanged inventory. Loop shows discrete checkpoints; no headset validation.

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/735b847c5dffa939d29b7daf044ce7b2/raw/astra-mfd-map-gallery.html).
