### PR TITLE
feat(vr): apply authored gun kick through physical recoil springs

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -235,6 +235,10 @@ pub struct PropExp(pub i32);
 #[derive(Debug, Component, Clone, Copy, Serialize, Deserialize)]
 pub struct PropWeaponType(pub i32);
 
+/// `P$ImplantDe`: original ImplantDesc enum; 6 is the aiming implant.
+#[derive(Debug, Component, Clone, Copy, Serialize, Deserialize)]
+pub struct PropImplantDesc(pub i32);
+
 /// The count of a stackable object (e.g. how many cyber modules an EXP-cookie
 /// pile is worth - the retail engine stores an EXP cookie's module value as its
 /// stack count, `P$StackCoun`). A 4-byte signed int.
@@ -1487,6 +1491,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$ExP",
             |reader, _len| read_i32(reader),
             PropExp,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ImplantDe",
+            |reader, _len| read_i32(reader),
+            PropImplantDesc,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/properties/prop_gun_kick.rs
+++ b/dark/src/properties/prop_gun_kick.rs
@@ -15,17 +15,14 @@ const SETTING_SIZE: u64 = 32;
 
 /// One fire setting's authored recoil.
 ///
-/// Six fields are 16-bit turns, decoded here to degrees; the rest are the raw
-/// authored scalars. The *magnitudes* are what the data verifies - whether a
-/// field is applied per shot or per second is not settled by the data, and the
-/// shotgun's 22.5 deg kick / the 65.9 deg jolt on template -26 are too large to
-/// be instantaneous angles, so the first consumer must decide that, not these
-/// names. Angles are read unsigned: no shipped record exceeds 12000 units
-/// (65.9 deg), so whether the top half of the range is meant as negative is
-/// untested.
+/// Six fields are 16-bit turns, decoded here to degrees; the rest are raw
+/// authored scalars. Dark's `ApplyKick` adds kick angles/displacement per shot,
+/// clamps pitch/back, and uses the return rates per second. `CalcKickAngle`
+/// applies Agility, Still Hand, aiming implant and direction/random flags.
+/// Player jolt is separate and must not be applied to the tracked VR head.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GunKickSetting {
-    /// Fraction of the kick applied before the shot leaves the barrel.
+    /// Historical pre-shot fraction; the original firing path ignores it.
     pub pre_kick_pct: f32,
     /// Pitch the shot adds to the gun, in degrees.
     pub kick_pitch_degrees: f32,
@@ -33,7 +30,7 @@ pub struct GunKickSetting {
     pub kick_pitch_max_degrees: f32,
     /// Heading the shot adds to the gun, in degrees.
     pub kick_heading_degrees: f32,
-    /// How fast the accumulated kick angles return to rest, in degrees.
+    /// How fast the accumulated kick angles return to rest, in degrees per second.
     pub kick_angular_return_rate_degrees: f32,
     /// Displacement the shot adds to the gun (negative drives it towards the
     /// player).

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -636,3 +636,34 @@ Audio validation: 1,638 gameplay tests pass (2 diagnostic ignores), all 23
 missions load, and 27 SDK cases pass. Warning-denied desktop/debug checks pass.
 The near-boundary impact regression verifies that pre-stop speed keeps a fast
 tap audible even when the body can travel less than a millimetre.
+
+
+## Authored VR spring recoil baseline
+
+Physical-held VR guns now apply one kick per successful shell, including each
+round in a burst. The current fire setting selects `GunKick`; original
+`CalcKickAngle` supplies direction flags, randomized angular magnitude, Agility,
+Still Hand, and the aiming-implant multiplier. Back displacement and pitch/back
+ceilings retain the authored values. Camera/body jolt is excluded from VR.
+
+The response is an intentional VR adaptation of Dark's instantaneous kick and
+linear return: use Citadel's mass 1, stiffness 40, damping 14 spring, integrated
+analytically. Normalize an isolated impulse's peak to the authored magnitude.
+Map authored return/limit onto the spring time scale, clamped to 0.25–4 so zero
+return settings still recover. Heading shares this angular spring time scale;
+Dark instead returns heading with `GunAnimParams.m_swingReturn`. This is VR
+response tuning, not exact return-motion parity. Apply the offset before the held-body
+translation sweep; rendered gun, gloves and muzzle follow the resulting body.
+The original source's disabled pre-shot fraction is not revived. The first
+projectile leaves the current muzzle; subsequent shots inherit accumulated kick.
+
+The `P$ImplantDe` property honors aiming type 6 only in equipped Contains slots
+1003/1004. The shipped gamesys has no type-6 implant, and the port does not yet
+provide equipment-slot UI; carrying an implant in an ordinary cell grants no
+bonus. Still Hand uses its shipped template -1107. Recoil spring state is
+transient: dropping/recreating a held body or loading starts it at rest.
+
+This baseline does not yet distinguish support or Strength. Those are the next
+VR augmentation. Flat firing and nonexperimental VR do not draw recoil RNG or
+receive impulses. Translation-only wall clearance remains the foundation's
+limit; Quest feel still needs device validation.

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -667,3 +667,8 @@ This baseline does not yet distinguish support or Strength. Those are the next
 VR augmentation. Flat firing and nonexperimental VR do not draw recoil RNG or
 receive impulses. Translation-only wall clearance remains the foundation's
 limit; Quest feel still needs device validation.
+
+Baseline validation: 1,644 gameplay tests (2 diagnostic ignores), 172 Dark tests,
+warning-denied runtime checks, and all 23 mission loads pass. Fixed-hand pistol
+and AR captures show kick and recovery with unchanged head pose;
+[before/after GIFs and stills](https://gist.github.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0).

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -52,6 +52,7 @@ mod util;
 mod virtual_hand;
 mod vr_config;
 mod weapon_muzzle;
+pub mod weapon_recoil;
 mod weapon_requirements;
 pub use hand_glove::{GloveRenderer, HandLight};
 /// Re-exported (the module itself stays private) so the `melee_grip` example

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9166,6 +9166,9 @@ impl MissionCore {
                         );
                     }
                 }
+                Effect::KickHeldGun { entity_id, impulse } => {
+                    self.physics.kick_held_gun(entity_id, impulse);
+                }
                 Effect::PlayEnvironmentalSoundWithFallback {
                     query,
                     fallback,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2744,6 +2744,7 @@ pub struct PlayerHandle {
 /// authoritative rendered/contact body.
 #[derive(Clone, Copy)]
 struct HeldItemDrive {
+    recoil: crate::weapon_recoil::RecoilState,
     target: RigidBodyHandle,
     /// The weapon's own entity, so a swept blow can be reported without
     /// digging it back out of the body's user data every frame.
@@ -3265,6 +3266,7 @@ impl PhysicsWorld {
             self.held_item_drives.insert(
                 handle,
                 HeldItemDrive {
+                    recoil: crate::weapon_recoil::RecoilState::default(),
                     target,
                     weapon_entity: EntityId::from_inner(
                         self.rigid_body_set
@@ -3298,6 +3300,20 @@ impl PhysicsWorld {
         self.entity_id_to_body
             .get(&entity_id)
             .is_some_and(|handle| self.held_item_drives.contains_key(handle))
+    }
+
+    pub fn kick_held_gun(
+        &mut self,
+        entity: EntityId,
+        impulse: crate::weapon_recoil::RecoilImpulse,
+    ) {
+        if !self.is_held_inert(entity) {
+            return;
+        }
+        let handle = self.entity_id_to_body[&entity];
+        if let Some(drive) = self.held_item_drives.get_mut(&handle) {
+            drive.recoil.kick(impulse);
+        }
     }
 
     /// A held gun uses empty groups so its sweep is its only collision source.
@@ -4636,13 +4652,18 @@ impl PhysicsWorld {
             // `set_next_kinematic_position`, which Rapier only commits during
             // the step. Reading the committed pose would aim at where the hand
             // was last frame, a permanent one-frame lag no gain removes.
-            let Some(desired) = self
+            let Some(mut desired) = self
                 .rigid_body_set
                 .get(target)
                 .map(|body| *body.next_position())
             else {
                 continue;
             };
+            if let Some(drive) = self.held_item_drives.get_mut(&weapon) {
+                let (offset, rotation) = drive.recoil.step(self.integration_parameters.dt);
+                desired.translation.vector += desired.rotation * vec_to_nvec(offset);
+                desired.rotation *= quat_to_nquat(rotation);
+            }
             let Some(body) = self.rigid_body_set.get(weapon) else {
                 continue;
             };

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -721,6 +721,10 @@ pub enum Effect {
         concept: String,
         tags: Vec<(String, String)>,
     },
+    KickHeldGun {
+        entity_id: EntityId,
+        impulse: crate::weapon_recoil::RecoilImpulse,
+    },
     PlayEnvironmentalSound {
         audio_handle: AudioHandle,
         query: EnvSoundQuery,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -639,6 +639,11 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
             });
         }
     }
+    if is_gunshot {
+        if let Some(impulse) = crate::weapon_recoil::shot_impulse(world, entity_id) {
+            effects.push(Effect::KickHeldGun { entity_id, impulse });
+        }
+    }
     ShotOutcome::Fired(Effect::Multiple(effects))
 }
 

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -1,0 +1,369 @@
+//! Authored gun kick with a VR spring response. Camera jolt is deliberately
+//! excluded: the tracked head is never moved. Citadel's mass=1, stiffness=40,
+//! damping=14 response is integrated analytically, without frame-rate drift.
+use cgmath::{InnerSpace, Vector3, vec3};
+use dark::properties::{
+    GunKickSetting, Link, Links, PropGunKick, PropGunState, PropImplantDesc, PropPlayerGun,
+};
+use rand::Rng;
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+#[derive(Clone, Copy, Debug)]
+pub struct RecoilImpulse {
+    pub pitch: f32,
+    pub heading: f32,
+    pub back: f32,
+    pub pitch_limit: f32,
+    pub back_limit: f32,
+    pub angular_rate: f32,
+    pub back_rate: f32,
+    pub forward: Vector3<f32>,
+}
+
+/// Original CalcKickAngle: Agility, Still Hand, then the aiming implant.
+fn kick_angle<R: Rng + ?Sized>(
+    degrees: f32,
+    flags: u32,
+    agility: i32,
+    still_hand: bool,
+    aiming: bool,
+    rng: &mut R,
+) -> f32 {
+    if still_hand {
+        return 0.0;
+    }
+    let mut turns = (degrees * 65536.0 / 360.0) as u16;
+    turns = (turns as f32 * (6 - agility.clamp(1, 6)) as f32 / 5.0) as u16;
+    if aiming {
+        turns = (turns as f32 * 0.8) as u16;
+    }
+    let direction = match flags & 3 {
+        1 => 1.0,
+        2 => -1.0,
+        3 => {
+            if rng.gen_bool(0.5) {
+                1.0
+            } else {
+                -1.0
+            }
+        }
+        _ => return 0.0,
+    };
+    turns as f32 * (360.0 / 65536.0) * direction * rng.gen_range(0.5..=1.0)
+}
+
+fn aiming_implant(world: &World) -> bool {
+    let Ok(player) = world.borrow::<UniqueView<crate::mission::PlayerInfo>>() else {
+        return false;
+    };
+    let Ok((links, implants)) = world.borrow::<(View<Links>, View<PropImplantDesc>)>() else {
+        return false;
+    };
+    // Dark GetEquip: PDOLLBASE 1000 + Special/Special2 (3/4). Merely
+    // carrying an implant in a backpack cell does not activate it.
+    [player.entity_id, player.inventory_entity_id]
+        .into_iter()
+        .any(|owner| {
+            links.get(owner).is_ok_and(|links| {
+                links.to_links.iter().any(|link| {
+                    matches!(link.link, Link::Contains(1003 | 1004))
+                        && link
+                            .to_entity_id
+                            .is_some_and(|id| implants.get(id.0).is_ok_and(|p| p.0 == 6))
+                })
+            })
+        })
+}
+
+/// Called only after the shared firing gate succeeds, once per shell (not pellet).
+pub fn shot_impulse(world: &World, gun: EntityId) -> Option<RecoilImpulse> {
+    // Keep the flat/nonphysical firing path free of recoil RNG draws.
+    crate::mission::mission_core::held_item_collision_group(world, gun)?;
+    let (kicks, states, guns) = world
+        .borrow::<(View<PropGunKick>, View<PropGunState>, View<PropPlayerGun>)>()
+        .ok()?;
+    let setting = states.get(gun).map(|s| s.setting).unwrap_or(0);
+    let kick = kicks.get(gun).ok()?.setting(setting);
+    let flags = guns.get(gun).ok()?.flags;
+    let agility = world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|q| q.player_stats().agility)
+        .unwrap_or(1);
+    // Shipped Still Hand template, verified against gamesys (power id 2).
+    let still_hand = world
+        .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+        .is_ok_and(|powers| powers.is_active(-1107));
+    let mut rng = rand::thread_rng();
+    Some(authored_impulse(
+        kick,
+        flags,
+        agility,
+        still_hand,
+        aiming_implant(world),
+        crate::weapon_muzzle::resolve(world, gun).axis,
+        &mut rng,
+    ))
+}
+
+fn authored_impulse<R: Rng + ?Sized>(
+    kick: &GunKickSetting,
+    flags: u32,
+    agility: i32,
+    still_hand: bool,
+    aiming: bool,
+    forward: Vector3<f32>,
+    rng: &mut R,
+) -> RecoilImpulse {
+    RecoilImpulse {
+        pitch: kick_angle(
+            kick.kick_pitch_degrees,
+            flags,
+            agility,
+            still_hand,
+            aiming,
+            rng,
+        ),
+        heading: kick_angle(
+            kick.kick_heading_degrees,
+            flags >> 2,
+            agility,
+            still_hand,
+            aiming,
+            rng,
+        ),
+        back: kick.kick_back / dark::SCALE_FACTOR,
+        pitch_limit: kick.kick_pitch_max_degrees.abs(),
+        back_limit: kick.kick_back_max.abs() / dark::SCALE_FACTOR,
+        angular_rate: recovery_rate(
+            kick.kick_angular_return_rate_degrees,
+            kick.kick_pitch_max_degrees,
+        ),
+        back_rate: recovery_rate(kick.kick_back_return_rate, kick.kick_back_max),
+        forward,
+    }
+}
+
+// The original uses linear return. VR maps its return/limit ratio onto the
+// spring's time scale, bounded so even authored zero-return settings recover.
+fn recovery_rate(return_rate: f32, limit: f32) -> f32 {
+    if !return_rate.is_finite() || !limit.is_finite() || limit.abs() < 1e-6 {
+        return 1.0;
+    }
+    (return_rate.abs() / limit.abs()).clamp(0.25, 4.0)
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Spring {
+    position: f32,
+    velocity: f32,
+}
+
+impl Spring {
+    fn kick(&mut self, amount: f32, rate: f32) {
+        // Normalize the isolated spring peak to the authored kick magnitude.
+        // Unit impulse response is (exp(-4t)-exp(-10t))/6.
+        let peak_time = (2.5_f32).ln() / 6.0;
+        let peak = ((-4.0 * peak_time).exp() - (-10.0 * peak_time).exp()) / 6.0;
+        self.velocity += amount * rate / peak;
+    }
+    fn step(&mut self, dt: f32, rate: f32, limit: f32) {
+        if dt <= 0.0 || !dt.is_finite() {
+            return;
+        }
+        let a = (self.velocity + 10.0 * rate * self.position) / (6.0 * rate);
+        let b = self.position - a;
+        let slow = a * (-4.0 * rate * dt).exp();
+        let fast = b * (-10.0 * rate * dt).exp();
+        self.position = slow + fast;
+        self.velocity = -4.0 * rate * slow - 10.0 * rate * fast;
+        if self.position.abs() > limit {
+            self.position = self.position.clamp(-limit, limit);
+            self.velocity = 0.0;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RecoilState {
+    pitch: Spring,
+    heading: Spring,
+    back: Spring,
+    impulse: Option<RecoilImpulse>,
+}
+impl RecoilState {
+    pub fn kick(&mut self, impulse: RecoilImpulse) {
+        // Malformed authored data must not introduce NaNs into a rigid body.
+        if ![
+            impulse.pitch,
+            impulse.heading,
+            impulse.back,
+            impulse.pitch_limit,
+            impulse.back_limit,
+            impulse.angular_rate,
+            impulse.back_rate,
+            impulse.forward.x,
+            impulse.forward.y,
+            impulse.forward.z,
+        ]
+        .into_iter()
+        .all(f32::is_finite)
+            || impulse.angular_rate <= 0.0
+            || impulse.back_rate <= 0.0
+            || impulse.pitch_limit < 0.0
+            || impulse.back_limit < 0.0
+            || Vector3::unit_y().cross(impulse.forward).magnitude2() < 1e-8
+        {
+            return;
+        }
+        self.pitch.kick(impulse.pitch, impulse.angular_rate);
+        self.heading.kick(impulse.heading, impulse.angular_rate);
+        self.back.kick(impulse.back, impulse.back_rate);
+        self.impulse = Some(impulse);
+    }
+    /// Translation and local rotation axes/angles, in the held model's frame.
+    pub fn step(&mut self, dt: f32) -> (Vector3<f32>, cgmath::Quaternion<f32>) {
+        use cgmath::{Deg, Quaternion, Rotation3};
+        let Some(i) = self.impulse else {
+            return (vec3(0.0, 0.0, 0.0), Quaternion::new(1.0, 0.0, 0.0, 0.0));
+        };
+        self.pitch.step(dt, i.angular_rate, i.pitch_limit);
+        self.heading.step(dt, i.angular_rate, f32::MAX);
+        self.back.step(dt, i.back_rate, i.back_limit);
+        let forward = i.forward.normalize();
+        let right = Vector3::unit_y().cross(forward).normalize();
+        (
+            forward * self.back.position,
+            Quaternion::from_axis_angle(Vector3::unit_y(), Deg(self.heading.position))
+                * Quaternion::from_axis_angle(right, Deg(-self.pitch.position)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{SeedableRng, rngs::StdRng};
+    #[test]
+    fn recoil_raises_and_backs_away_along_each_model_barrel() {
+        use cgmath::Rotation;
+        for forward in [-Vector3::unit_x(), Vector3::unit_x(), -Vector3::unit_z()] {
+            let mut state = RecoilState::default();
+            state.kick(RecoilImpulse {
+                pitch: 7.0,
+                heading: 0.0,
+                back: -0.1,
+                pitch_limit: 10.0,
+                back_limit: 0.2,
+                angular_rate: 1.0,
+                back_rate: 1.0,
+                forward,
+            });
+            let (offset, rotation) = state.step(0.15);
+            assert!(offset.dot(forward) < -0.09);
+            assert!(rotation.rotate_vector(forward).y > 0.1);
+            let (offset, rotation) = state.step(5.0);
+            assert!(offset.magnitude() < 1e-6);
+            assert!((rotation.rotate_vector(forward) - forward).magnitude() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn invalid_impulse_cannot_poison_physics_pose() {
+        let mut state = RecoilState::default();
+        state.kick(RecoilImpulse {
+            pitch: f32::NAN,
+            heading: 0.0,
+            back: -0.1,
+            pitch_limit: 10.0,
+            back_limit: 0.2,
+            angular_rate: 1.0,
+            back_rate: 1.0,
+            forward: Vector3::unit_y(),
+        });
+        assert!(state.impulse.is_none());
+        assert_eq!(state.step(0.1).0, vec3(0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn aiming_implant_requires_an_equipped_special_slot() {
+        use crate::mission::PlayerInfo;
+        use dark::properties::{ToLink, WrappedEntityId};
+        let mut world = World::new();
+        let implant = world.add_entity(PropImplantDesc(6));
+        let owner = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: owner,
+            inventory_entity_id: owner,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+        });
+        for (slot, expected) in [(0, false), (1002, false), (1003, true), (1004, true)] {
+            world.add_component(
+                owner,
+                Links {
+                    to_links: vec![ToLink {
+                        to_template_id: 0,
+                        to_entity_id: Some(WrappedEntityId(implant)),
+                        link: Link::Contains(slot),
+                    }],
+                },
+            );
+            assert_eq!(aiming_implant(&world), expected);
+        }
+        world.add_component(implant, PropImplantDesc(5));
+        assert!(!aiming_implant(&world));
+    }
+
+    #[test]
+    fn original_angular_modifiers_and_direction_flags() {
+        for (agility, still, aiming, max) in [
+            (1, false, false, 10.0),
+            (3, false, false, 6.0),
+            (1, false, true, 8.0),
+            (6, false, false, 0.0),
+            (1, true, false, 0.0),
+        ] {
+            let mut rng = StdRng::seed_from_u64(9);
+            for _ in 0..50 {
+                let angle = kick_angle(10.0, 1, agility, still, aiming, &mut rng);
+                assert!(angle >= max * 0.5 - 0.02 && angle <= max + 0.02);
+                assert!(kick_angle(10.0, 2, agility, still, aiming, &mut rng) <= 0.0);
+                assert_eq!(kick_angle(10.0, 0, agility, still, aiming, &mut rng), 0.0);
+            }
+        }
+    }
+    #[test]
+    fn spring_has_authored_peak_and_independent_timestep() {
+        let mut a = Spring::default();
+        a.kick(7.0, 1.0);
+        let mut b = a;
+        let mut peak = 0.0_f32;
+        for _ in 0..120 {
+            a.step(1.0 / 120.0, 1.0, 100.0);
+            peak = peak.max(a.position);
+        }
+        for _ in 0..60 {
+            b.step(1.0 / 60.0, 1.0, 100.0);
+        }
+        assert!((peak - 7.0).abs() < 0.02);
+        assert!((a.position - b.position).abs() < 1e-4);
+        assert!((a.velocity - b.velocity).abs() < 1e-4);
+        a.step(10.0, 1.0, 100.0);
+        assert!(a.position.abs() < 1e-10);
+    }
+    #[test]
+    fn repeated_impulses_respect_authored_ceiling_and_paused_time() {
+        let mut s = Spring::default();
+        for _ in 0..200 {
+            s.kick(10.0, 1.0);
+            s.step(1.0 / 60.0, 1.0, 12.0);
+            assert!(s.position <= 12.0);
+        }
+        let before = s;
+        s.step(0.0, 1.0, 12.0);
+        assert_eq!(before.position, s.position);
+        assert_eq!(before.velocity, s.velocity);
+    }
+}

--- a/tools/shock2-sdk/test/vr-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-recoil.e2e.test.ts
@@ -1,8 +1,24 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { GameServer } from "../src/index.js";
-import { aimVrHandAt } from "./helpers/vr-hand.js";
+import {
+  aimVrHandAt,
+  quatConjugate,
+  quatMultiply,
+  quatNormalize,
+  type Quat,
+} from "./helpers/vr-hand.js";
 import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+function rotationDifferenceDegrees(a: Quat, b: Quat): number {
+  const relative = quatNormalize(quatMultiply(quatConjugate(a), b));
+  return (
+    (2 *
+      Math.atan2(Math.hypot(...relative.slice(0, 3)), Math.abs(relative[3])) *
+      180) /
+    Math.PI
+  );
+}
 
 for (const [name, template, hand] of [
   ["pistol", -17, "right"],
@@ -14,7 +30,7 @@ for (const [name, template, hand] of [
       skip: process.env.SHOCK2_E2E !== "1",
       timeout: 180_000,
     },
-    async () => {
+    async (context) => {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
         debugFlags: ["--vr", "--experimental", "physical_held_items"],
@@ -65,26 +81,50 @@ for (const [name, template, hand] of [
       await game.input.set(`${hand}_hand.trigger`, 1);
       await game.step({ frames: 1 });
       await game.input.set(`${hand}_hand.trigger`, 0);
+      let peakAngle = rotationDifferenceDegrees(
+        initial.rotation,
+        (await body()).rotation,
+      );
       await game.step({ frames: 1 });
+      peakAngle = Math.max(
+        peakAngle,
+        rotationDifferenceDegrees(initial.rotation, (await body()).rotation),
+      );
       const firedAmmo = ammoOf(await game.entities.detail(gun.id));
       assert.ok(firedAmmo < initialAmmo);
       await game.input.set(`${hand}_hand.trigger`, 1);
       await game.step({ frames: 1 });
       await game.input.set(`${hand}_hand.trigger`, 0);
+      peakAngle = Math.max(
+        peakAngle,
+        rotationDifferenceDegrees(initial.rotation, (await body()).rotation),
+      );
       assert.equal(
         ammoOf(await game.entities.detail(gun.id)),
         firedAmmo,
         "cooldown refuses a second immediate shot",
       );
-      await game.step({ frames: 12 });
+      for (let frame = 0; frame < 12; frame++) {
+        await game.step({ frames: 1 });
+        peakAngle = Math.max(
+          peakAngle,
+          rotationDifferenceDegrees(initial.rotation, (await body()).rotation),
+        );
+      }
       const kicked = await body();
       assert.ok(
         kicked.position[0] > initial.position[0] + 0.005,
         "gun kicks backward from the barrel direction",
       );
       assert.ok(
-        Math.abs(kicked.rotation[2]) > 0.005,
-        "Agility 1 leaves authored angular recoil",
+        peakAngle > 1,
+        `Agility 1 leaves authored angular recoil; measured peak ${peakAngle} degrees`,
+      );
+      // AR's minimum randomized pitch is 1.626 degrees. Its fast return can
+      // already fall below 0.573 degrees (quaternion Z=.005) at 15 frames;
+      // inspect the early peak instead of treating that valid recovery as no kick.
+      context.diagnostic(
+        `peak=${peakAngle.toFixed(4)}deg, late=${rotationDifferenceDegrees(initial.rotation, kicked.rotation).toFixed(4)}deg, oldLateZ=${Math.abs(kicked.rotation[2]).toFixed(6)}`,
       );
       assert.deepEqual(
         (await game.info()).player.camera_rotation,
@@ -99,7 +139,7 @@ for (const [name, template, hand] of [
         ) < 0.005,
       );
       assert.ok(
-        Math.abs(settled.rotation[2]) < 0.001,
+        rotationDifferenceDegrees(initial.rotation, settled.rotation) < 0.1,
         "spring returns to the unchanged controller pose",
       );
     },

--- a/tools/shock2-sdk/test/vr-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-recoil.e2e.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+for (const [name, template, hand] of [
+  ["pistol", -17, "right"],
+  ["assault rifle", -18, "left"],
+] as const) {
+  test(
+    `VR ${name} recoils after a successful shot and returns to its fixed hand`,
+    {
+      skip: process.env.SHOCK2_E2E !== "1",
+      timeout: 180_000,
+    },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        debugFlags: ["--vr", "--experimental", "physical_held_items"],
+      });
+      await game.step({ frames: 10 });
+      const gun = await cycleToWeapon(game, (e) => e.template_id === template, {
+        settleFrames: 90,
+      });
+      await aimVrHandAt(game, gun.position!, 0.45, 1, 0, { hand });
+      await game.step({ frames: 8 });
+      const info = await game.info();
+      assert.equal(
+        hand === "right"
+          ? info.player.right_hand_entity_id
+          : info.player.wielded_entity_id,
+        gun.id,
+      );
+      await game.input.set("head.rotation", [0, 0, 0, 1]);
+      await game.input.set(`${hand}_hand.position`, [0, 1, 0]);
+      await game.input.set(`${hand}_hand.rotation`, [
+        0,
+        Math.SQRT1_2,
+        0,
+        Math.SQRT1_2,
+      ]);
+      await game.step({ frames: 90 });
+      const body = async () =>
+        (await game.physics.bodies({ entityId: gun.id })).bodies[0]!;
+      const initial = await body();
+      const initialHead = (await game.info()).player.camera_rotation;
+      const initialAmmo = ammoOf(await game.entities.detail(gun.id));
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      await game.step({ frames: 12 });
+      assert.equal(
+        ammoOf(await game.entities.detail(gun.id)),
+        initialAmmo,
+        "insufficient skill refuses the shot",
+      );
+      const refused = await body();
+      assert.deepEqual(
+        refused.rotation,
+        initial.rotation,
+        "refused shots do not kick the gun",
+      );
+      await game.player.setStats({ skills: { standard_weapons: 6 } });
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      await game.step({ frames: 1 });
+      const firedAmmo = ammoOf(await game.entities.detail(gun.id));
+      assert.ok(firedAmmo < initialAmmo);
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      assert.equal(
+        ammoOf(await game.entities.detail(gun.id)),
+        firedAmmo,
+        "cooldown refuses a second immediate shot",
+      );
+      await game.step({ frames: 12 });
+      const kicked = await body();
+      assert.ok(
+        kicked.position[0] > initial.position[0] + 0.005,
+        "gun kicks backward from the barrel direction",
+      );
+      assert.ok(
+        Math.abs(kicked.rotation[2]) > 0.005,
+        "Agility 1 leaves authored angular recoil",
+      );
+      assert.deepEqual(
+        (await game.info()).player.camera_rotation,
+        initialHead,
+        "gun recoil does not jolt the head",
+      );
+      await game.step({ frames: 300 });
+      const settled = await body();
+      assert.ok(
+        Math.hypot(
+          ...settled.position.map((v, i) => v - initial.position[i]!),
+        ) < 0.005,
+      );
+      assert.ok(
+        Math.abs(settled.rotation[2]) < 0.001,
+        "spring returns to the unchanged controller pose",
+      );
+    },
+  );
+}
+
+test(
+  "flat weapon firing does not create a held recoil body or move the camera",
+  { skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--experimental", "physical_held_items"],
+    });
+    await game.step({ frames: 10 });
+    await game.player.setStats({ skills: { standard_weapons: 6 } });
+    await game.player.spawnItem("Pistol");
+    await game.input.trigger("EquipPistol");
+    await game.step({ frames: 5 });
+    const initial = (await game.info()).player;
+    assert.ok(initial.wielded_entity_id);
+    const ammo = ammoOf(await game.entities.detail(initial.wielded_entity_id));
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 15 });
+    assert.ok(
+      ammoOf(await game.entities.detail(initial.wielded_entity_id)) < ammo,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: initial.wielded_entity_id }))
+        .bodies.length,
+      0,
+    );
+    assert.deepEqual(
+      (await game.info()).player.camera_rotation,
+      initial.camera_rotation,
+    );
+  },
+);


### PR DESCRIPTION
Physical-held VR guns previously stayed rigid when fired. Successful shots now kick the collision-constrained gun and recover through springs; the rendered gun, gripping glove and muzzle follow that pose. The tracked head stays fixed.

Uses each fire setting’s authored pitch/heading/back kick and ceilings, including the original Agility, Still Hand and aiming-implant angular modifiers. Citadel’s spring response replaces Dark’s instantaneous kick/linear return as a documented VR adaptation. This layer establishes the baseline; Strength and the extra one-handed penalty follow separately.

Validation: 1,644 gameplay tests (2 diagnostic ignores), 172 Dark tests, warning-denied gameplay/desktop/debug checks. All 23 mission-load checks pass. SDK verifies pistol/right and AR/left actual shots, refused shots, cooldown, recovery, unchanged head, and flat behavior. Independent code, duplication and visual reviews found no blocking issue.

Requires VR and `--experimental physical_held_items`. Translation-only wall clearance remains inherited. Recoil state resets when a held body is recreated or loaded. Quest comfort is pending device validation.

![Pistol recoil before/after](https://gist.githubusercontent.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0/raw/pistol-comparison.gif)
![Pistol recoil still](https://gist.githubusercontent.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0/raw/pistol-comparison.png)
![AR recoil before/after](https://gist.githubusercontent.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0/raw/ar-comparison.gif)
![AR recoil still](https://gist.githubusercontent.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0/raw/ar-comparison.png)

Fixed tracked hand/head; Agility 1, Standard 6. Captured random samples peak at 4.42° (pistol) and 2.70° (AR), both at rest by the final 3.5-second sample. These are headless runtime captures, not headset footage.
