### PR TITLE
feat(vr): scale recoil with strength and supporting hand

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -672,3 +672,47 @@ Baseline validation: 1,644 gameplay tests (2 diagnostic ignores), 172 Dark tests
 warning-denied runtime checks, and all 23 mission loads pass. Fixed-hand pistol
 and AR captures show kick and recovery with unchanged head pose;
 [before/after GIFs and stills](https://gist.github.com/tommy-xr/d5bfc0ed59cbabb6906079601764b3a0).
+
+
+## Strength and one-handed recoil control
+
+Strength is a VR augmentation, applied after the original Agility/Still Hand/
+aiming-implant angular modifiers. At Strength `S` (clamped 1–6), scale each new
+baseline impulse by `1 / (1 + 0.1 * (S - 1))`. If the gun has no active latched
+support grip, add a separate spring impulse of
+`1 / (1 + 0.3 * (S - 1))` times its unscaled authored kick. At Strength 1,
+two hands use the full authored baseline and one hand adds an equal penalty.
+At Strength 6, the baseline is about 67% and the extra penalty is 40%.
+These are initial tuning values, not values taken from Dark Engine.
+
+Both pitch/heading and backward kick scale. Spring recovery rates and authored
+caps do not change with Strength or support, so an existing offset is never
+rescaled or reset. Both springs continue settling every physics step. A support
+preview or fading released glove is not an active support grip; only a latched,
+active attachment removes the penalty from future shots. Strength does not
+change the accuracy cone or the tracked head pose.
+
+
+Initial fixed-hand measurements (Agility 1, Standard 6; peak backward gun
+travel in world units):
+
+| Strength | Pistol, one hand | Pistol, two hands | AR, one hand |
+| --- | ---: | ---: | ---: |
+| 1 | 0.279430 | 0.139714 | 0.198354 |
+| 3 | 0.203750 | 0.116430 | 0.144634 |
+| 6 | 0.149030 | 0.093144 | 0.105789 |
+
+The deterministic backward kick follows the expected scaling within 0.003
+world units. Angular kick retains its authored randomness, so separate shots
+are not matched angular samples. AR two-hand measurements require the next
+support-socket increment; attachment success and glove placement must both
+be validated before calling that comparison two-handed.
+
+[Measured gun-pose curves and comparison media](https://gist.github.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b)
+include the raw CSV and summary JSON. These measure the physical gun pose that
+drives the muzzle; they do not independently sample the muzzle endpoint.
+
+Runtime checks also acquire support at the live moving socket, then release it
+mid-kick: the existing backward recoil curve continues within 0.005 world
+units of an uninterrupted shot. Every matrix shot recovers within 0.005 world
+units and 0.1 degrees of its starting pose, with unchanged head orientation.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -111,6 +111,11 @@ pub trait PlayerInteraction {
     /// wielded weapon as the "left".
     fn held_entities(&self) -> (Option<EntityId>, Option<EntityId>);
 
+    /// A latched support grip, rather than proximity or the visual blend-out.
+    fn is_supported(&self, _entity: EntityId) -> bool {
+        false
+    }
+
     /// Entities under the reticle/hands, for the hover-highlight overlay.
     fn highlighted_entities(&self) -> Vec<EntityId>;
 
@@ -1164,6 +1169,12 @@ impl PlayerInteraction for VrInteraction {
         left_msgs
     }
 
+    fn is_supported(&self, entity: EntityId) -> bool {
+        self.support
+            .as_ref()
+            .is_some_and(|s| s.active && s.entity == entity)
+    }
+
     fn held_entities(&self) -> (Option<EntityId>, Option<EntityId>) {
         (
             self.left_hand.get_held_entity(),
@@ -1707,6 +1718,7 @@ mod tests {
         ctx.step_dt = 0.0;
         interaction.update_support(&ctx);
         assert!(interaction.support.as_ref().unwrap().active);
+        assert!(interaction.is_supported(entity));
         // Supporting hand input is swallowed even on render-only frames.
         let effects = interaction.update(&ctx);
         assert!(
@@ -1759,28 +1771,35 @@ mod tests {
         input.left_hand.squeeze_value = 1.0;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(interaction.support.as_ref().unwrap().active);
+        assert!(interaction.is_supported(entity));
         input.left_hand.position.y = 2.0;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(!interaction.support.as_ref().unwrap().active);
+        assert!(!interaction.is_supported(entity));
         input.left_hand.position.y = 1.2;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(!interaction.support.as_ref().unwrap().active);
+        assert!(!interaction.is_supported(entity));
         input.left_hand.squeeze_value = 0.0;
         interaction.update_support(&context(&world, &physics, &input));
         input.left_hand.squeeze_value = 1.0;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(interaction.support.as_ref().unwrap().active);
+        assert!(interaction.is_supported(entity));
         input.left_hand.rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
         interaction.update_support(&context(&world, &physics, &input));
         assert!(!interaction.support.as_ref().unwrap().active);
+        assert!(!interaction.is_supported(entity));
         input.left_hand.rotation = identity();
         interaction.update_support(&context(&world, &physics, &input));
         assert!(!interaction.support.as_ref().unwrap().active);
+        assert!(!interaction.is_supported(entity));
         input.left_hand.squeeze_value = 0.0;
         interaction.update_support(&context(&world, &physics, &input));
         input.left_hand.squeeze_value = 1.0;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(interaction.support.as_ref().unwrap().active);
+        assert!(interaction.is_supported(entity));
         // A broad region chooses a fresh nearest point only on a new squeeze.
         interaction.support = None;
         interaction
@@ -1811,6 +1830,7 @@ mod tests {
         input.left_hand.position.y = 1.28;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(interaction.support.as_ref().unwrap().active);
+        assert!(interaction.is_supported(entity));
         assert_eq!(interaction.support.as_ref().unwrap().anchor, locked);
         input.left_hand.squeeze_value = 0.0;
         interaction.update_support(&context(&world, &physics, &input));
@@ -1822,6 +1842,7 @@ mod tests {
         ctx.support_enabled = false;
         interaction.update_support(&ctx);
         assert!(!interaction.support.as_ref().unwrap().active);
+        assert!(!interaction.is_supported(entity));
         let other_item = grabbable(&mut world);
         interaction.grab(&world, other_item, Handedness::Left);
         interaction.apply_support(&world, &mut Vec::new());

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9167,7 +9167,17 @@ impl MissionCore {
                     }
                 }
                 Effect::KickHeldGun { entity_id, impulse } => {
-                    self.physics.kick_held_gun(entity_id, impulse);
+                    let strength = self
+                        .world
+                        .borrow::<UniqueView<QuestInfo>>()
+                        .map(|q| q.player_stats().strength)
+                        .unwrap_or(1);
+                    self.physics.kick_held_gun(
+                        entity_id,
+                        impulse,
+                        strength,
+                        self.interaction.is_supported(entity_id),
+                    );
                 }
                 Effect::PlayEnvironmentalSoundWithFallback {
                     query,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2745,6 +2745,7 @@ pub struct PlayerHandle {
 #[derive(Clone, Copy)]
 struct HeldItemDrive {
     recoil: crate::weapon_recoil::RecoilState,
+    one_hand_recoil: crate::weapon_recoil::RecoilState,
     target: RigidBodyHandle,
     /// The weapon's own entity, so a swept blow can be reported without
     /// digging it back out of the body's user data every frame.
@@ -3267,6 +3268,7 @@ impl PhysicsWorld {
                 handle,
                 HeldItemDrive {
                     recoil: crate::weapon_recoil::RecoilState::default(),
+                    one_hand_recoil: crate::weapon_recoil::RecoilState::default(),
                     target,
                     weapon_entity: EntityId::from_inner(
                         self.rigid_body_set
@@ -3306,13 +3308,19 @@ impl PhysicsWorld {
         &mut self,
         entity: EntityId,
         impulse: crate::weapon_recoil::RecoilImpulse,
+        strength: i32,
+        supported: bool,
     ) {
         if !self.is_held_inert(entity) {
             return;
         }
         let handle = self.entity_id_to_body[&entity];
         if let Some(drive) = self.held_item_drives.get_mut(&handle) {
-            drive.recoil.kick(impulse);
+            let (baseline, extra) = crate::weapon_recoil::vr_impulses(impulse, strength, supported);
+            drive.recoil.kick(baseline);
+            if let Some(extra) = extra {
+                drive.one_hand_recoil.kick(extra);
+            }
         }
     }
 
@@ -4661,8 +4669,10 @@ impl PhysicsWorld {
             };
             if let Some(drive) = self.held_item_drives.get_mut(&weapon) {
                 let (offset, rotation) = drive.recoil.step(self.integration_parameters.dt);
-                desired.translation.vector += desired.rotation * vec_to_nvec(offset);
-                desired.rotation *= quat_to_nquat(rotation);
+                let (extra_offset, extra_rotation) =
+                    drive.one_hand_recoil.step(self.integration_parameters.dt);
+                desired.translation.vector += desired.rotation * vec_to_nvec(offset + extra_offset);
+                desired.rotation *= quat_to_nquat(rotation * extra_rotation);
             }
             let Some(body) = self.rigid_body_set.get(weapon) else {
                 continue;

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -20,6 +20,27 @@ pub struct RecoilImpulse {
     pub forward: Vector3<f32>,
 }
 
+/// Intentional VR control tuning, separate from Dark's Agility modifier.
+/// Caps and spring rates remain authored: changing Strength/support affects
+/// future impulses, never the pose or recovery of an already moving spring.
+pub fn vr_impulses(
+    impulse: RecoilImpulse,
+    strength: i32,
+    supported: bool,
+) -> (RecoilImpulse, Option<RecoilImpulse>) {
+    let above_minimum = (strength.clamp(1, 6) - 1) as f32;
+    let scaled = |scale| RecoilImpulse {
+        pitch: impulse.pitch * scale,
+        heading: impulse.heading * scale,
+        back: impulse.back * scale,
+        ..impulse
+    };
+    (
+        scaled(1.0 / (1.0 + 0.1 * above_minimum)),
+        (!supported).then(|| scaled(1.0 / (1.0 + 0.3 * above_minimum))),
+    )
+}
+
 /// Original CalcKickAngle: Agility, Still Hand, then the aiming implant.
 fn kick_angle<R: Rng + ?Sized>(
     degrees: f32,
@@ -243,6 +264,71 @@ impl RecoilState {
 mod tests {
     use super::*;
     use rand::{SeedableRng, rngs::StdRng};
+    #[test]
+    fn strength_reduces_both_new_impulses_without_changing_recovery_or_caps() {
+        let authored = RecoilImpulse {
+            pitch: 7.0,
+            heading: 1.0,
+            back: -0.1,
+            pitch_limit: 10.0,
+            back_limit: 0.2,
+            angular_rate: 1.0,
+            back_rate: 2.0,
+            forward: -Vector3::unit_x(),
+        };
+        let mut previous = (f32::MAX, f32::MAX);
+        for strength in [1, 3, 6] {
+            let (base, extra) = vr_impulses(authored, strength, false);
+            let extra = extra.unwrap();
+            assert!(base.pitch < previous.0 && extra.pitch < previous.1);
+            previous = (base.pitch, extra.pitch);
+            assert_eq!(base.pitch_limit, authored.pitch_limit);
+            assert_eq!(extra.back_limit, authored.back_limit);
+            assert_eq!(base.angular_rate, authored.angular_rate);
+            assert_eq!(extra.back_rate, authored.back_rate);
+            let (supported, penalty) = vr_impulses(authored, strength, true);
+            assert!(penalty.is_none());
+            assert_eq!(supported.pitch, base.pitch);
+            assert_eq!(supported.back, base.back);
+        }
+        assert_eq!(vr_impulses(authored, 1, true).0.pitch, authored.pitch);
+        assert_eq!(vr_impulses(authored, -2, true).0.pitch, authored.pitch);
+        assert_eq!(
+            vr_impulses(authored, 99, true).0.pitch,
+            vr_impulses(authored, 6, true).0.pitch
+        );
+    }
+
+    #[test]
+    fn acquiring_support_preserves_the_previous_one_hand_kick() {
+        let authored = RecoilImpulse {
+            pitch: 4.0,
+            heading: 0.0,
+            back: -0.1,
+            pitch_limit: 10.0,
+            back_limit: 0.2,
+            angular_rate: 1.0,
+            back_rate: 1.0,
+            forward: -Vector3::unit_x(),
+        };
+        let mut penalty = RecoilState::default();
+        penalty.kick(vr_impulses(authored, 1, false).1.unwrap());
+        penalty.step(0.1);
+        let mut uninterrupted = penalty;
+        // A supported follow-up shot has no new penalty; the old spring remains.
+        if let Some(extra) = vr_impulses(authored, 6, true).1 {
+            penalty.kick(extra);
+        }
+        assert_eq!(penalty.step(0.1), uninterrupted.step(0.1));
+        assert!(penalty.pitch.position > 0.0);
+        // Losing support adds velocity, without resetting accumulated displacement.
+        let before = penalty.step(0.0);
+        penalty.kick(vr_impulses(authored, 6, false).1.unwrap());
+        assert_eq!(penalty.step(0.0), before);
+        penalty.step(5.0);
+        assert!(penalty.pitch.position.abs() < 1e-6);
+    }
+
     #[test]
     fn recoil_raises_and_backs_away_along_each_model_barrel() {
         use cgmath::Rotation;

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import {
+  aimVrHandAt,
+  quatConjugate,
+  quatMultiply,
+  quatRotate,
+  sub,
+  type Quat,
+} from "./helpers/vr-hand.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+for (const [name, template] of [
+  ["pistol", -17],
+  ["AR", -18],
+] as const) {
+  test(
+    `${name} recoil decreases with Strength${name === "pistol" ? " and genuine support removes the extra spring" : ""}`,
+    { skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000 },
+    async (context) => {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        debugFlags: ["--vr", "--experimental", "physical_held_items"],
+      });
+      await game.step({ frames: 10 });
+      await game.player.setStats({ skills: { standard_weapons: 6 } });
+      const gun = await cycleToWeapon(game, (e) => e.template_id === template, {
+        settleFrames: 90,
+      });
+      await aimVrHandAt(game, gun.position!, 0.45, 1);
+      await game.step({ frames: 8 });
+      assert.equal((await game.info()).player.right_hand_entity_id, gun.id);
+      await game.input.set("head.rotation", [0, 0, 0, 1]);
+      await game.input.set("right_hand.position", [0, 1, 0]);
+      await game.input.set("right_hand.rotation", [
+        0,
+        Math.SQRT1_2,
+        0,
+        Math.SQRT1_2,
+      ]);
+      await game.step({ frames: 180 });
+      const head = (await game.info()).player.camera_rotation;
+      const body = async () =>
+        (await game.physics.bodies({ entityId: gun.id })).bodies[0]!;
+      const placeSupportHandAtCurrentSocket = async () => {
+        const player = (await game.info()).player;
+        const socket = player.hand_grips.find(
+          (g) => g.hand === "right",
+        )!.support;
+        assert.ok(socket, "the pistol must expose its authored support socket");
+        const inverse = quatConjugate(player.rotation);
+        const p = socket.controller_position;
+        const q = socket.controller_rotation;
+        await game.input.set(
+          "left_hand.position",
+          quatRotate(inverse, sub([p.x, p.y, p.z], player.position)),
+        );
+        await game.input.set(
+          "left_hand.rotation",
+          quatMultiply(inverse, [q.v.x, q.v.y, q.v.z, q.s] as Quat),
+        );
+      };
+      const support = async (attached: boolean) => {
+        await game.input.set("left_hand.squeeze", 0);
+        await game.step({ frames: 2 });
+        if (attached) {
+          await placeSupportHandAtCurrentSocket();
+          await game.input.set("left_hand.squeeze", 1);
+        }
+        await game.step({ frames: 15 });
+        assert.equal(
+          (await game.info()).player.hand_grips.find((g) => g.hand === "right")!
+            .support?.attached ?? false,
+          attached,
+        );
+      };
+      const measurements: {
+        strength: number;
+        supported: boolean;
+        back: number;
+        curve: number[];
+      }[] = [];
+      for (const strength of [1, 3, 6]) {
+        await game.player.setStats({ strength });
+        for (const supported of name === "pistol" ? [false, true] : [false]) {
+          await support(supported);
+          await game.step({ frames: 180 });
+          const initial = await body();
+          const ammo = ammoOf(await game.entities.detail(gun.id));
+          await game.input.set("right_hand.trigger", 1);
+          let peakBack = 0;
+          const curve: number[] = [];
+          for (let frame = 0; frame < 20; frame++) {
+            await game.step({ frames: 1 });
+            if (frame === 0) await game.input.set("right_hand.trigger", 0);
+            const back = (await body()).position[0] - initial.position[0];
+            curve.push(back);
+            peakBack = Math.max(peakBack, back);
+          }
+          assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+          assert.deepEqual((await game.info()).player.camera_rotation, head);
+          measurements.push({ strength, supported, back: peakBack, curve });
+          await game.step({ frames: 180 });
+          const settled = await body();
+          assert.ok(
+            Math.hypot(...sub(settled.position, initial.position)) < 0.005,
+            "both recoil springs must return to this shot's resting position",
+          );
+          const relative = quatMultiply(
+            quatConjugate(initial.rotation),
+            settled.rotation,
+          );
+          const angle =
+            (2 *
+              Math.atan2(
+                Math.hypot(...relative.slice(0, 3)),
+                Math.abs(relative[3]),
+              ) *
+              180) /
+            Math.PI;
+          assert.ok(
+            angle < 0.1,
+            `both recoil springs must restore this shot's resting rotation; ${angle} degrees remain`,
+          );
+        }
+      }
+      context.diagnostic(
+        JSON.stringify(measurements.map(({ curve, ...result }) => result)),
+      );
+      const value = (s: number, supported: boolean) =>
+        measurements.find((m) => m.strength === s && m.supported === supported)!
+          .back;
+      const baseline = name === "pistol" ? value(1, true) : value(1, false) / 2;
+      assert.ok(
+        baseline > 0.03,
+        "actual firing must produce measurable backward recoil",
+      );
+      for (const m of measurements) {
+        const n = m.strength - 1;
+        const expected =
+          baseline *
+          (1 / (1 + 0.1 * n) + (m.supported ? 0 : 1 / (1 + 0.3 * n)));
+        assert.ok(
+          Math.abs(m.back - expected) < 0.003,
+          `${JSON.stringify(m)} expected ${expected}`,
+        );
+      }
+      if (name === "pistol") {
+        await support(false);
+        await game.step({ frames: 180 });
+        await placeSupportHandAtCurrentSocket();
+        const initial = await body();
+        const reference = measurements.find(
+          (m) => m.strength === 6 && !m.supported,
+        )!.curve;
+        await game.input.set("right_hand.trigger", 1);
+        for (let frame = 0; frame < 20; frame++) {
+          if (frame === 2) {
+            // Acquire the moving socket, not its pre-shot position: backward
+            // recoil can already exceed the authored 7 cm grab radius.
+            await placeSupportHandAtCurrentSocket();
+            await game.input.set("left_hand.squeeze", 1);
+          }
+          if (frame === 5) await game.input.set("left_hand.squeeze", 0);
+          await game.step({ frames: 1 });
+          if (frame === 0) await game.input.set("right_hand.trigger", 0);
+          if (frame === 3 || frame === 6) {
+            assert.equal(
+              (await game.info()).player.hand_grips.find(
+                (g) => g.hand === "right",
+              )!.support!.attached,
+              frame === 3,
+            );
+          }
+          const back = (await body()).position[0] - initial.position[0];
+          assert.ok(
+            Math.abs(back - reference[frame]!) < 0.005,
+            `support transition must preserve the existing recoil: frame ${frame}, back ${back}, uninterrupted ${reference[frame]}`,
+          );
+        }
+        assert.deepEqual((await game.info()).player.camera_rotation, head);
+      }
+    },
+  );
+}


### PR DESCRIPTION
A supported gun uses the authored recoil baseline; firing one-handed adds a separate spring penalty. Strength reduces both new impulses, with a steeper reduction for the one-handed penalty. Attaching or releasing support preserves recoil already in motion.

This is an intentional VR augmentation after the original Agility/Still Hand/aiming-implant modifiers. At Strength 1 the supported baseline is unchanged; at Strength 6 it is about 67%, with a 40% additional one-handed impulse. Caps and recovery rates remain fixed. The head and accuracy cone are unchanged.

Validation: 1,646 gameplay tests (2 diagnostic ignores), warning-denied gameplay/desktop/debug checks, independent source and duplication reviews. Fixed-hand runtime measurements at Strength 1/3/6 match expected backward-kick ratios for pistol one/two hands and AR one hand. Tests also verify recovery after every shot and preserve the existing recoil curve while acquiring and releasing support mid-kick. The AR support socket follows in its own layer.

| Strength | Pistol one hand | Pistol two hands | AR one hand |
| --- | ---: | ---: | ---: |
| 1 | 0.279430 | 0.139714 | 0.198354 |
| 3 | 0.203750 | 0.116430 | 0.144634 |
| 6 | 0.149030 | 0.093144 | 0.105789 |

Values are peak backward displacement in world units. Angular kick remains randomized, so separate captures are not matched angular samples. Headless captures establish behavior and scaling; Quest feel remains pending device validation.

![Strength 1, one-handed recoil](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/pistol-s1-one-comparison.gif)
![Strength 1, one-handed still](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/pistol-s1-one-comparison.png)
![Strength 6, supported recoil](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/pistol-s6-two-comparison.gif)
![Strength 6, supported still](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/pistol-s6-two-comparison.png)
![Measured recoil curves](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/recoil-curves.png)

[All four before/after comparisons](https://gist.github.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b) · [CSV measurements](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/recoil-curves.csv) · [Summary JSON](https://gist.githubusercontent.com/tommy-xr/253123eebb4d23982df1c6fddcb7cf2b/raw/recoil-summary.json)
