### PR TITLE
feat(mfd): restore native navigation and ammo strips

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -35,13 +35,19 @@ Ordinary items use their object-name key in OBJLOOKS; an authored look-string
 override takes priority. Missing entries show an explicit fallback, never the
 short item name masquerading as a description.
 
-Utility buttons occupy a dedicated row below the reserved right MFD slot and
-above the ammo readout. Their drawing, input and debug rectangles are shared
-in canvas pixels; these are new layout rectangles, not guessed BIN indices.
+The vial, `?`, and MAP buttons use the native BIOFULL wells and IFBTN40,
+IFBTN30, and IFBTN50 artwork. Their drawing, input and debug rectangles share
+`shkiface.cpp`'s authored canvas coordinates. AMMOFULL stays visible on the
+right with empty hands; its weapon controls appear only with relevant content.
+Clicking either strip while carrying a cursor item preserves the item.
+
+The current ammo controls still target the hand-agnostic wielded weapon (right
+hand first in VR). Dual readouts and explicit per-weapon action routing are a
+separate increment; the restored frame does not resolve that ownership yet.
 
 ### Research overview
 
-RES opens the retail PDA-style research list in the left MFD. Active projects
+The vial opens the retail PDA-style research list in the left MFD. Active projects
 open the RESEARCH status layout; completed entries open RESREP with the
 portrait, flask icon and report text from RESEARCH.STR, not OBJLOOKS. Reports
 are selected from collected report bits and survive the original specimen.
@@ -59,7 +65,7 @@ a rotating 3D specimen is still a separate rendering increment.
 
 MAP toggles the existing automap in the cyber interface through `ToggleMap`.
 Both presentations use its mission map art, explored regions and player pip.
-The wide panel scales uniformly to clear the utility row/HUD and keep CLOSE
+The wide panel scales uniformly to clear the bottom HUD and keep CLOSE
 inside the canvas. VR's map is a synthetic cyber-panel host, never an extra
 world quad even with the legacy experimental GUI enabled. Opening MAP closes
 the utility reader; clicking it again or using the map's close button dismisses

--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -47,6 +47,14 @@ pub(crate) const PSI_TEXT: Rect = Rect::new(92.0, 40.0, TEXT_W, BAR_H);
 /// AMMOFULL 260).
 pub(crate) const BIO_ORIGIN: Vector2<f32> = vec2(2.0, 414.0);
 pub(crate) const AMMO_ORIGIN: Vector2<f32> = vec2(378.0, 414.0);
+pub(crate) const BIO_FULL_RECT: Rect =
+    Rect::new(BIO_ORIGIN.x, BIO_ORIGIN.y, BIO_FULL_SIZE.x, BIO_FULL_SIZE.y);
+pub(crate) const AMMO_FULL_RECT: Rect = Rect::new(
+    AMMO_ORIGIN.x,
+    AMMO_ORIGIN.y,
+    ammo_panel::PANEL_W,
+    ammo_panel::PANEL_H,
+);
 
 /// The system-menu affordance: the pause menu's only *discoverable* control in
 /// VR, since the Menu button's long press advertises nothing until it is held.
@@ -177,20 +185,10 @@ pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
         BIO_FULL_SIZE,
         &readouts.bio,
     );
-    // No weapon with a clip and no psi power wielded: the gauge is not drawn
-    // at all, exactly as in shooter mode.
-    if !readouts.ammo.is_empty() {
-        canvas.image(
-            Rect::new(
-                AMMO_ORIGIN.x,
-                AMMO_ORIGIN.y,
-                ammo_panel::PANEL_W,
-                ammo_panel::PANEL_H,
-            ),
-            "AMMOFULL.PCX",
-        );
-        ammo_panel::emit(canvas, AMMO_ORIGIN, &readouts.ammo);
-    }
+    // The expanded strip also houses MFD navigation: keep its frame visible
+    // with empty hands, while weapon controls remain conditional.
+    canvas.image(AMMO_FULL_RECT, "AMMOFULL.PCX");
+    ammo_panel::emit(canvas, AMMO_ORIGIN, &readouts.ammo);
     // Always: the way out of the game does not depend on what is wielded.
     let system = system_button();
     ammo_panel::draw_button(canvas, &system, system.rect);
@@ -206,7 +204,7 @@ pub(crate) fn buttons(readouts: &UseModeReadouts) -> Vec<ReadoutButtonSpec> {
     // Drawn unconditionally above, so it is clickable unconditionally.
     let system = system_button();
     if readouts.ammo.is_empty() {
-        // The gauge is not drawn, so nothing on it is clickable.
+        // The empty frame has no weapon controls.
         return vec![system];
     }
     ammo_panel::buttons(&readouts.ammo)
@@ -243,10 +241,10 @@ mod tests {
 
     #[test]
     fn the_bio_monitor_is_always_drawn() {
-        // Backdrop + 2 bars + 2 numbers, with no weapon wielded.
+        // Both backdrops + 2 bars + 2 numbers, with no weapon wielded.
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
         emit_use_mode(&mut canvas, &readouts(None, false));
-        assert_eq!(canvas.element_count(), 5 + SYSTEM_ELEMENTS);
+        assert_eq!(canvas.element_count(), 6 + SYSTEM_ELEMENTS);
     }
 
     #[test]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -949,7 +949,11 @@ impl FlatUiHost {
             .into_iter()
             .find(|spec| spec.rect.contains(canvas_pos))
             .map(|spec| spec.button);
-        let over_ammo = readout_hit.is_some();
+        let over_readout = readout_hit.is_some()
+            || (self.readouts.is_some()
+                && [readouts::BIO_FULL_RECT, readouts::AMMO_FULL_RECT]
+                    .iter()
+                    .any(|rect| rect.contains(canvas_pos)));
 
         // --- Cursor-is-the-item drag: while an item rides the cursor, LMB
         // places/swaps/throws it and never routes to a GuiScript (protecting
@@ -1002,11 +1006,10 @@ impl FlatUiHost {
                 }
                 return (Vec::new(), Vec::new());
             }
-            if over_panel || over_ammo || pointer.bare_view == BareViewPress::Ignore {
-                // Escape hatch: a click on an open MFD or an AMMOFULL readout
-                // control keeps the held item (a visible button must not throw
-                // the item you're carrying) - and so does empty panel space in
-                // VR, where there is no 3D view behind the canvas to throw at.
+            if over_panel || over_readout || pointer.bare_view == BareViewPress::Ignore {
+                // A click on an open MFD or either bottom strip keeps the held
+                // item, including empty chrome between buttons. So does empty
+                // panel space in VR, which has no 3D view behind it to throw at.
                 return (Vec::new(), Vec::new());
             }
             // Bare 3D view: throw the held item along the view ray.
@@ -1016,9 +1019,9 @@ impl FlatUiHost {
         }
 
         // --- AMMOFULL readout controls (use mode): a click acts on the
-        // wielded weapon. Checked with an empty cursor only (mid-drag, a
-        // bottom-right click is a throw), before strip/panel routing since the
-        // controls are disjoint from both. ---
+        // wielded weapon. Checked with an empty cursor only (mid-drag,
+        // readout clicks preserve the carried item), before strip/panel routing
+        // since the controls are disjoint from both. ---
         if pressed_edge {
             if let Some(button) = readout_hit {
                 return (Vec::new(), vec![FlatUiDragAction::Readout(button)]);
@@ -2527,7 +2530,7 @@ mod tests {
         let (world, mut host, item, _) = drag_world();
         host.open_unbound(item);
         host.panel_size_px = Some(vec2(636.0, 296.0));
-        assert!(press_edge(&mut host, &world, (506.0, 395.0)).is_empty());
+        assert!(press_edge(&mut host, &world, (133.0, 451.0)).is_empty());
         assert!(host.utilities.is_open());
         assert!(host.panel_size_px.is_none());
     }
@@ -2537,7 +2540,7 @@ mod tests {
         let (world, mut host, item, _) = drag_world();
         host.cursor_item = Some(make_cursor_item(&world, item));
         assert_eq!(
-            press_edge(&mut host, &world, (544.0, 395.0)),
+            press_edge(&mut host, &world, (166.0, 460.0)),
             vec![FlatUiDragAction::ToggleMap]
         );
         assert_eq!(host.held_entity(), Some(item));
@@ -2546,7 +2549,7 @@ mod tests {
     #[test]
     fn inspect_click_does_not_lift_wield_or_frob_an_inventory_item() {
         let (world, mut host, item, _) = drag_world();
-        assert!(press_edge(&mut host, &world, (468.0, 395.0)).is_empty());
+        assert!(press_edge(&mut host, &world, (166.0, 440.0)).is_empty());
         assert!(host.utilities.is_inspecting());
         let point = host
             .strip_debug_elements(&world)
@@ -3009,6 +3012,25 @@ mod tests {
         let actions = press_edge(&mut host, &world, (570.0, 449.0)); // click the ammo button
         assert!(actions.is_empty(), "the click neither throws nor cycles");
         assert!(host.cursor_debug().is_some(), "the held item is protected");
+    }
+
+    #[test]
+    fn empty_bottom_strips_preserve_a_carried_item() {
+        let (world, mut host, wrench, _) = drag_world();
+        host.set_readouts(Some(UseModeReadouts {
+            bio: Default::default(),
+            ammo: Default::default(),
+        }));
+        press_edge(&mut host, &world, (23.5, 34.0));
+        for point in [(400.0, 460.0), (600.0, 460.0), (240.0, 460.0)] {
+            assert!(press_edge(&mut host, &world, point).is_empty());
+            assert_eq!(host.held_entity(), Some(wrench));
+        }
+        // Only the visible chrome is protected; the world still accepts drops.
+        assert_eq!(
+            press_edge(&mut host, &world, (300.0, 300.0)),
+            vec![FlatUiDragAction::Throw(wrench)]
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -55,16 +55,18 @@ impl MfdUtilities {
     pub(crate) fn is_inspecting(&self) -> bool {
         self.inspecting
     }
-    fn controls(&self) -> Vec<(Control, Rect, &'static str)> {
-        // Dedicated utility row below the reserved right MFD slot, clear of
-        // the bottom ammo readout. New utilities fill the row incrementally.
-        let mut controls = vec![(Control::Inspect, Rect::new(450.0, 382.0, 36.0, 26.0), "?")];
-        controls.push((
-            Control::Research,
-            Rect::new(488.0, 382.0, 36.0, 26.0),
-            "RES",
-        ));
-        controls.push((Control::Map, Rect::new(526.0, 382.0, 36.0, 26.0), "MAP"));
+    fn controls(&self) -> Vec<(Control, Rect, &'static str, &'static str)> {
+        // Retail shkiface.cpp iface_rects[3..6], on BIOFULL at (2, 414).
+        // Keep art, hit testing, and debug discovery on these same canvas rects.
+        let mut controls = vec![
+            (Control::Inspect, Rect::new(150.0, 431.0, 32.0, 18.0), "?"),
+            (
+                Control::Research,
+                Rect::new(117.0, 431.0, 32.0, 40.0),
+                "RES",
+            ),
+            (Control::Map, Rect::new(150.0, 451.0, 32.0, 18.0), "MAP"),
+        ];
         if self.inspecting || self.selected.is_some() {
             controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
             if self.page > 0 {
@@ -75,6 +77,19 @@ impl MfdUtilities {
             }
         }
         controls
+            .into_iter()
+            .map(|(control, rect, label)| {
+                let texture = match control {
+                    Control::Inspect if self.inspecting => "iface/ifbtn31.pcx",
+                    Control::Inspect => "iface/ifbtn30.pcx",
+                    Control::Research if self.research => "iface/ifbtn41.pcx",
+                    Control::Research => "iface/ifbtn40.pcx",
+                    Control::Map => "iface/ifbtn50.pcx",
+                    _ => "IFBTN00.PCX",
+                };
+                (control, rect, label, texture)
+            })
+            .collect()
     }
 
     /// Returns whether this pointer belongs to utilities. Inspect mode owns
@@ -85,10 +100,10 @@ impl MfdUtilities {
         pressed: bool,
         candidate: Option<EntityId>,
     ) -> bool {
-        if let Some((control, _, _)) = self
+        if let Some((control, _, _, _)) = self
             .controls()
             .into_iter()
-            .find(|(_, rect, _)| rect.contains(point))
+            .find(|(_, rect, _, _)| rect.contains(point))
         {
             if pressed {
                 match control {
@@ -193,9 +208,12 @@ impl MfdUtilities {
                 canvas.text_native_fit(rect, line, FONT, HAlign::Left, VAlign::Middle);
             }
         }
-        for (_, rect, label) in self.controls() {
-            canvas.image(rect, "IFBTN00.PCX");
-            canvas.text_native_fit(rect, label, FONT, HAlign::Center, VAlign::Middle);
+        for (control, rect, label, texture) in self.controls() {
+            canvas.image(rect, texture);
+            // Native navigation art contains its own glyphs (including the vial).
+            if matches!(control, Control::Close | Control::Previous | Control::Next) {
+                canvas.text_native_fit(rect, label, FONT, HAlign::Center, VAlign::Middle);
+            }
         }
     }
 
@@ -211,25 +229,27 @@ impl MfdUtilities {
     pub(crate) fn debug_elements(&self) -> Vec<crate::game_scene::DebugUiElement> {
         self.controls()
             .into_iter()
-            .map(|(control, r, label)| crate::game_scene::DebugUiElement {
-                kind: "button".into(),
-                texture: Some("IFBTN00.PCX".into()),
-                text: Some(label.into()),
-                label: Some(
-                    match control {
-                        Control::Inspect => "inspect",
-                        Control::Research => "research_overview",
-                        Control::Map => "map",
-                        Control::Close => "utility_close",
-                        Control::Previous => "utility_previous",
-                        Control::Next => "utility_next",
-                    }
-                    .into(),
-                ),
-                entity_id: None,
-                rect: [r.x, r.y, r.w, r.h],
-                screen_rect: [r.x, r.y, r.w, r.h],
-            })
+            .map(
+                |(control, r, label, texture)| crate::game_scene::DebugUiElement {
+                    kind: "button".into(),
+                    texture: Some(texture.into()),
+                    text: Some(label.into()),
+                    label: Some(
+                        match control {
+                            Control::Inspect => "inspect",
+                            Control::Research => "research_overview",
+                            Control::Map => "map",
+                            Control::Close => "utility_close",
+                            Control::Previous => "utility_previous",
+                            Control::Next => "utility_next",
+                        }
+                        .into(),
+                    ),
+                    entity_id: None,
+                    rect: [r.x, r.y, r.w, r.h],
+                    screen_rect: [r.x, r.y, r.w, r.h],
+                },
+            )
             .chain(if self.research {
                 self.research_catalog.elements()
             } else {
@@ -293,7 +313,7 @@ mod tests {
     #[test]
     fn pages_cover_every_line_and_clamp_when_content_shrinks() {
         let mut ui = MfdUtilities::default();
-        ui.update(vec2(468.0, 395.0), true, None);
+        ui.update(vec2(166.0, 440.0), true, None);
         ui.set_content(
             "Long description".into(),
             (0..40).map(|i| format!("Line {i}\n")).collect(),
@@ -302,10 +322,10 @@ mod tests {
         let mut seen = Vec::new();
         loop {
             seen.extend(ui.visible_lines().map(|(_, line)| line.clone()));
-            let Some((_, rect, _)) = ui
+            let Some((_, rect, _, _)) = ui
                 .controls()
                 .into_iter()
-                .find(|(control, _, _)| *control == Control::Next)
+                .find(|(control, _, _, _)| *control == Control::Next)
             else {
                 break;
             };
@@ -325,7 +345,7 @@ mod tests {
             "hypo: \"Restores health.\"".into(),
         ));
         let mut ui = MfdUtilities::default();
-        assert!(ui.update(vec2(468.0, 395.0), true, None));
+        assert!(ui.update(vec2(166.0, 440.0), true, None));
         assert!(ui.inspecting);
         assert!(ui.update(vec2(10.0, 40.0), false, Some(hypo)));
         assert_eq!(ui.selected, None);

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -212,6 +212,12 @@ for (const vr of [false,true]) {
       const path=`${out}/${vr?"vr":"flat"}-${name}`;await game.screenshot(path+".png",1600);
       await writeFile(path+".json",JSON.stringify({ui:await game.ui.state(),info:await game.info(),inventory:await game.player.inventory()},null,2));
     };
+    const idleUi=await game.ui.state();
+    assert.ok(idleUi.readout_elements.some(e=>e.texture?.toUpperCase()==="AMMOFULL.PCX"),"empty-handed use mode retains expanded ammo frame");
+    for (const [label,texture] of [["inspect","iface/ifbtn30.pcx"],["research_overview","iface/ifbtn40.pcx"],["map","iface/ifbtn50.pcx"]]) {
+      const button=idleUi.strip!.elements.find(e=>e.label===label);assert.ok(button,label);
+      assert.equal(button.texture?.toLowerCase(),texture,"native navigation artwork");
+    }
     await capture("idle");
     await click(await mapControl());
     const panel=(await game.ui.state()).active_panel;assert.ok(panel);
@@ -227,5 +233,14 @@ for (const vr of [false,true]) {
     await click(close);
     assert.equal((await game.ui.state()).active_panel,null,"map close control works");
     assert.deepEqual(await game.player.inventory(),inventory);
+    const item=(await game.ui.state()).strip!.elements.find(e=>e.kind==="button"&&e.entity_id===inventory.items[0]!.entity_id);assert.ok(item);
+    await click(item);
+    const carried=(await game.ui.state()).cursor;assert.ok(carried,"inventory click carries the hypo on the UI cursor");
+    const emptyFrame=(await game.ui.state()).readout_elements.find(e=>e.texture?.toUpperCase()==="AMMOFULL.PCX");assert.ok(emptyFrame);
+    await click(emptyFrame);
+    assert.deepEqual((await game.ui.state()).cursor,carried,"blank ammo strip chrome must not throw the cursor item");
+    await click(item);
+    assert.equal((await game.ui.state()).cursor,null);
+    assert.deepEqual(await game.player.inventory(),inventory,"returning cursor item preserves inventory");
   });
 }


### PR DESCRIPTION
The cyber interface left its native navigation wells empty and hid the right ammo frame whenever no weapon was equipped. Restore the vial, `?`, and MAP buttons using the original IFBTN assets and `shkiface.cpp` coordinates; keep AMMOFULL visible with empty hands. Research, inspection, and map actions continue through their existing shared flat/VR input paths.

Clicking empty bottom-strip chrome while carrying an inventory item now preserves the item instead of throwing it. Weapon controls still appear only when relevant. Dual-weapon readouts and per-weapon control routing remain a separate increment; the existing right-hand-first selection is unchanged.

Validation: 69 focused Rust UI tests pass, including carried-item protection and bare-world dropping. All seven SDK utility scenarios pass; both flat/VR map scenarios were repeated after the cursor protection fix and verify the carried item survives clicking empty ammo-strip chrome. Independent code and flat/VR visual reviews pass. Headset validation remains deferred.

![Native MFD strips before and after](https://gist.githubusercontent.com/tommy-xr/059db1a951eaed9472ee94127677acb5/raw/astra-native-strips-before-after.png)

![Native controls in flat and VR](https://gist.githubusercontent.com/tommy-xr/059db1a951eaed9472ee94127677acb5/raw/astra-native-strips.gif)

Matched parent/current medsci1 captures show the retail vial, ?, and MAP controls plus the empty-handed AMMOFULL frame. The loop includes separate debug-scene action checkpoints; existing pistol counters remain intact. Both presentations passed inspect/research/map and blank-frame cursor-retention checks. No headset validation.

![Armed strip retains pistol counters](https://gist.githubusercontent.com/tommy-xr/059db1a951eaed9472ee94127677acb5/raw/astra-native-strips-armed.png)

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/059db1a951eaed9472ee94127677acb5/raw/astra-native-strips-gallery.html)
