### PR TITLE
feat(vr): support the assault rifle with either hand

### DIFF
--- a/assets/vr-support-grips.json
+++ b/assets/vr-support-grips.json
@@ -144,5 +144,27 @@
     "grab_radius": 0.07,
     "release_distance": 0.12,
     "max_swing_degrees": 75.0
+  },
+  "ar15_h": {
+    "palm_anchor": [
+      -0.6,
+      -0.08,
+      0.0
+    ],
+    "rotation_degrees": [
+      0.0,
+      0.0,
+      90.0
+    ],
+    "curls": [
+      0.35,
+      0.45,
+      0.55,
+      0.6,
+      0.65
+    ],
+    "grab_radius": 0.07,
+    "release_distance": 0.12,
+    "max_swing_degrees": 75.0
   }
 }

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -716,3 +716,33 @@ Runtime checks also acquire support at the live moving socket, then release it
 mid-kick: the existing backward recoil curve continues within 0.005 world
 units of an uninterrupted shot. Every matrix shot recovers within 0.005 world
 units and 0.1 degrees of its starting pose, with unchanged head orientation.
+
+
+## AR support grip and complete handedness matrix
+
+The AR had a calibrated primary grip but no support profile or support
+eligibility. Add a fore-end support socket in the existing shared system;
+left/right reflection, squeeze ownership and two-anchor steering use the same
+path as the other supported weapons. Calibrate placement against the active
+25AE AR mesh and rendered gloves on both sides, rather than accepting a socket
+merely because the controller can latch to it.
+
+AR support scenarios run with physical-held guns enabled and verify acquisition,
+barrel direction, steering, primary-only firing, latch retention through recoil,
+release and recovery. Extend the Strength matrix to genuine AR support at
+Strength 1/3/6, alongside its existing one-handed cases.
+
+
+Measured AR peak backward travel in the physical-held runtime (Agility 1,
+Standard 6):
+
+| Strength | One hand | Two hands |
+| --- | ---: | ---: |
+| 1 | 0.198354 | 0.099178 |
+| 3 | 0.144634 | 0.082649 |
+| 6 | 0.105789 | 0.066114 |
+
+Both hands preserve the primary barrel direction when support attaches. The
+six-shot AR matrix verifies ammo use, fixed head pose, expected scaling and
+recovery after every shot. These are headless checks; headset fit and feel
+remain a device-validation task.

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 /// Authored support sockets and regions currently enabled in gameplay.
 /// Keep the Explorer eligibility notice and runtime policy together.
 pub fn supports_model(model: &str) -> bool {
-    matches!(model, "wrench_h" | "atek_h" | "sg_h" | "fsn_h" | "al_h")
+    matches!(
+        model,
+        "wrench_h" | "atek_h" | "ar15_h" | "sg_h" | "fsn_h" | "al_h"
+    )
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]

--- a/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
@@ -9,12 +9,12 @@ const vector = (v: ResolvedGrip["offset"]): Vec3 => [v.x,v.y,v.z];
 const quaternion = (q: ResolvedGrip["rotation"]): Quat => [...vector(q.v),q.s];
 const distance = (a: Vec3,b: Vec3) => Math.hypot(...sub(a,b));
 
-for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
+for (const [model, template] of [["atek_h",-17],["ar15_h",-18],["sg_h",-19]] as const) {
   for (const primary of ["left","right"] as const) {
     test(`${model} support (${primary}): steering, firing, scale, ownership and release`, {
       skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
     }, async () => {
-      await using game = await GameServer.launch({mission:"debug_weapons",debugFlags:["--vr"]});
+      await using game = await GameServer.launch({mission:"debug_weapons",debugFlags:model === "ar15_h" ? ["--vr","--experimental","physical_held_items"] : ["--vr"]});
       await game.step({frames:30});
       const weapon = await cycleToWeapon(game,e=>e.template_id === template);
       await aimVrHandAt(game,weapon.position,.2,1,0,{hand:primary});
@@ -27,6 +27,13 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       await game.step({frames:30});
       const grip = async (): Promise<HandGrip> => (await game.info()).player.hand_grips.find(g=>g.hand === primary)!;
       const before = await grip();
+      const initialBody = model === "ar15_h"
+        ? (await game.physics.bodies({entityId:weapon.id})).bodies[0] : null;
+      if (model === "ar15_h") {
+        assert.ok(initialBody,"AR support must retain the physical held body");
+        assert.deepEqual(initialBody.collision_groups,[],"held gun contacts stay inert");
+      }
+      if (initialBody) assert.equal(initialBody.body_type,"kinematic");
       assert.ok(before?.support && before.grip,`${model} publishes its authored support socket`);
       const socket = vector(before.support.controller_position);
       const place = async (worldPosition: Vec3) => {
@@ -39,6 +46,13 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       await game.input.set(`${other}_hand.squeeze`,1);
       await game.step({frames:15});
       assert.equal((await grip()).support!.attached,true);
+      if (initialBody) {
+        const body = (await game.physics.bodies({entityId:weapon.id})).bodies[0]!;
+        const forward = quatRotate(body.rotation,[-1,0,0]);
+        const original = quatRotate(initialBody.rotation,[-1,0,0]);
+        assert.ok(forward.reduce((sum,v,i)=>sum+v*original[i]!,0) > .99,
+          "support attachment preserves the primary barrel direction");
+      }
       await place(add(socket,[.07,0,0]));
       await game.step({frames:30});
       const steered = await grip();
@@ -64,16 +78,21 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       await game.step({frames:1});
       assert.equal(ammoOf(await game.entities.detail(weapon.id)),ammo-1,"primary trigger fires while supported");
       const fired = await grip();
+      assert.equal(fired.support!.attached,true,"support latch survives actual firing");
       assert.equal(fired.visual_trigger,1);
       assert.deepEqual(fired.finger_curls,fired.grip!.trigger_curls ?? fired.grip!.curls);
       await game.input.set(`${primary}_hand.trigger`,0);
+      if (model === "ar15_h") {
+        await game.step({frames:12});
+        assert.equal((await grip()).support!.attached,true,"support stays latched through physical recoil");
+      }
       await game.input.set(`${other}_hand.squeeze`,0);
       await game.step({frames:1});
       assert.equal((await grip()).support!.attached,false);
       assert.equal((await game.info()).player[owner],weapon.id);
       assert.equal((await game.info()).player[empty],null);
       await game.input.set(`${other}_hand.trigger`,0);
-      await game.step({frames:60});
+      await game.step({frames:model === "ar15_h" ? 180 : 60});
       assert.ok(distance(vector((await grip()).support!.model_position),vector(before.support.model_position)) < .001);
       await place(socket);
       await game.input.set(`${other}_hand.squeeze`,1);

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -16,7 +16,7 @@ for (const [name, template] of [
   ["AR", -18],
 ] as const) {
   test(
-    `${name} recoil decreases with Strength${name === "pistol" ? " and genuine support removes the extra spring" : ""}`,
+    `${name} recoil decreases with Strength and genuine support removes the extra spring`,
     { skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000 },
     async (context) => {
       await using game = await GameServer.launch({
@@ -48,7 +48,7 @@ for (const [name, template] of [
         const socket = player.hand_grips.find(
           (g) => g.hand === "right",
         )!.support;
-        assert.ok(socket, "the pistol must expose its authored support socket");
+        assert.ok(socket, `${name} must expose its authored support socket`);
         const inverse = quatConjugate(player.rotation);
         const p = socket.controller_position;
         const q = socket.controller_rotation;
@@ -83,7 +83,7 @@ for (const [name, template] of [
       }[] = [];
       for (const strength of [1, 3, 6]) {
         await game.player.setStats({ strength });
-        for (const supported of name === "pistol" ? [false, true] : [false]) {
+        for (const supported of [false, true]) {
           await support(supported);
           await game.step({ frames: 180 });
           const initial = await body();
@@ -131,7 +131,7 @@ for (const [name, template] of [
       const value = (s: number, supported: boolean) =>
         measurements.find((m) => m.strength === s && m.supported === supported)!
           .back;
-      const baseline = name === "pistol" ? value(1, true) : value(1, false) / 2;
+      const baseline = value(1, true);
       assert.ok(
         baseline > 0.03,
         "actual firing must produce measurable backward recoil",


### PR DESCRIPTION
The AR had a calibrated primary grip but could not acquire support, so it always received the one-handed recoil penalty. Add a fore-end socket to the existing shared support system and enable AR support for either primary hand.

The socket was fitted against the active 25AE mesh, then lowered after rendered checks showed the first candidate buried the palm. Both hands now sit beneath the fore-end; the primary barrel direction stays unchanged on attachment.

Validation: five support geometry tests and warning-denied runtime checks pass. Physical-enabled SDK scenarios cover both primary hands, steering, ownership, primary-only firing, latch retention through recoil, release and recovery. The complete AR Strength1/3/6 one/two-hand matrix verifies fixed head pose, scaling and recovery after each shot.

| Strength | AR one hand | AR two hands |
| --- | ---: | ---: |
| 1 | 0.198354 | 0.099178 |
| 3 | 0.144634 | 0.082649 |
| 6 | 0.105789 | 0.066114 |

Peak backward travel in world units; Agility1, Standard6. Headless validation establishes behavior and placement, not headset feel. Source/visual reviews found no remaining issue; duplication names/index/source checks found no actionable reuse (clone-tool report unavailable).

![Complete Strength and support recoil evaluation](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/recoil-curves.png)

Twelve actual-shot gun-pose traces: pistol and AR, Strength 1/3/6, one/two hands. Backward displacement validates scaling; angular samples are independently randomized.

![right primary support demonstration](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/right-comparison.gif)

![right primary before and after](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/right-comparison.png)

![left primary support demonstration](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/left-comparison.gif)

![left primary before and after](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/left-comparison.png)

[Raw CSV](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/recoil-curves.csv) · [Summary JSON](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/recoil-summary.json) · [Vector plot](https://gist.githubusercontent.com/tommy-xr/c2b07c24a32e6206326db38f2d1a5398/raw/62a799b0b5cdeb65120641a94efd8b27cec52ea3/recoil-curves.svg)
