### PR TITLE
feat(mfd): add log shortcut and resource balances

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -41,6 +41,14 @@ IFBTN30, and IFBTN50 artwork. Their drawing, input and debug rectangles share
 right with empty hands; its weapon controls appear only with relevant content.
 Clicking either strip while carrying a cursor item preserves the item.
 
+BIOFULL's two resource wells show nanites (`nan_ic`) and cyber modules
+(`upgrade`) with live balances. The nanite total is the same one used by
+purchases, including legacy carried stacks. The first AMMOFULL well holds the
+log disc button: it opens the existing latest-unread collected-log reader,
+falling back to the latest readable log. Pressing it again closes just that
+reader and leaves the cyber interface open. With no collected logs it shows
+an empty native PDA panel. This is a shortcut, not yet a full PDA log browser.
+
 The current ammo controls still target the hand-agnostic wielded weapon (right
 hand first in VR). Dual readouts and explicit per-weapon action routing are a
 separate increment; the restored frame does not resolve that ownership yet.

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -132,6 +132,7 @@ pub enum ReadoutButton {
     /// is a control on that canvas, so it travels with the rest through the
     /// one list the host draws and hit-tests.
     SystemMenu,
+    Logs,
 }
 
 impl ReadoutButton {
@@ -147,6 +148,7 @@ impl ReadoutButton {
             ReadoutButton::PsiPowerNext => "psi_power_next",
             ReadoutButton::PsiSelect => "psi_select",
             ReadoutButton::SystemMenu => "system_menu",
+            ReadoutButton::Logs => "logs",
         }
     }
 }

--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -15,7 +15,7 @@
 //! exactly as [`super::ammo_panel`]'s are for the ammo panel.
 
 use cgmath::{Vector2, vec2};
-use shipyard::World;
+use shipyard::{UniqueView, World};
 
 use super::ammo_panel::{self, AmmoReadout, ReadoutButton, ReadoutButtonSpec};
 use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
@@ -55,6 +55,8 @@ pub(crate) const AMMO_FULL_RECT: Rect = Rect::new(
     ammo_panel::PANEL_W,
     ammo_panel::PANEL_H,
 );
+
+const LOG_BUTTON: Rect = Rect::new(383.0, 432.0, 38.0, 36.0);
 
 /// The system-menu affordance: the pause menu's only *discoverable* control in
 /// VR, since the Menu button's long press advertises nothing until it is held.
@@ -161,6 +163,8 @@ pub(crate) fn build_watch_canvas(readout: &BioReadout) -> UiCanvas {
 pub(crate) struct UseModeReadouts {
     pub bio: BioReadout,
     pub ammo: AmmoReadout,
+    /// Spendable nanites and cyber modules, in the order of the native wells.
+    pub resources: [i32; 2],
 }
 
 impl UseModeReadouts {
@@ -171,6 +175,13 @@ impl UseModeReadouts {
         Self {
             bio: BioReadout::from_world(world),
             ammo: AmmoReadout::from_world(world, true),
+            resources: [
+                crate::scripts::script_util::player_nanite_total(world),
+                world
+                    .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                    .map(|quests| quests.player_stats().cyber_modules)
+                    .unwrap_or(0),
+            ],
         }
     }
 }
@@ -192,6 +203,20 @@ pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
     // Always: the way out of the game does not depend on what is wielded.
     let system = system_button();
     ammo_panel::draw_button(canvas, &system, system.rect);
+    // shkiface.cpp button 0 and shkinv.cpp fake equipment icon wells.
+    canvas.image(LOG_BUTTON, "iface/ifbtn00.pcx");
+    canvas.fitted_object_icon(Rect::new(385.0, 434.0, 34.0, 32.0), "disc.pcx");
+    for (index, texture) in ["nan_ic.pcx", "upgrade.pcx"].into_iter().enumerate() {
+        let rect = Rect::new(185.0 + index as f32 * 39.0, 435.0, 32.0, 32.0);
+        canvas.fitted_object_icon(rect, texture);
+        canvas.text_native_fit(
+            Rect::new(rect.x, 434.0, 36.0, 12.0),
+            &readouts.resources[index].to_string(),
+            crate::ui::MFD_FONT,
+            HAlign::Left,
+            VAlign::Top,
+        );
+    }
 }
 
 /// The readout's clickable controls on the 640x480 canvas.
@@ -203,17 +228,19 @@ pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
 pub(crate) fn buttons(readouts: &UseModeReadouts) -> Vec<ReadoutButtonSpec> {
     // Drawn unconditionally above, so it is clickable unconditionally.
     let system = system_button();
-    if readouts.ammo.is_empty() {
-        // The empty frame has no weapon controls.
-        return vec![system];
-    }
+    let logs = ReadoutButtonSpec {
+        button: ReadoutButton::Logs,
+        rect: LOG_BUTTON,
+        texture: Some("iface/ifbtn00.pcx"),
+        text: None,
+    };
     ammo_panel::buttons(&readouts.ammo)
         .into_iter()
         .map(|spec| ReadoutButtonSpec {
             rect: ammo_panel::at(AMMO_ORIGIN, spec.rect),
             ..spec
         })
-        .chain([system])
+        .chain([system, logs])
         .collect()
 }
 
@@ -223,6 +250,7 @@ mod tests {
 
     fn readouts(ammo: Option<i32>, cycle: bool) -> UseModeReadouts {
         UseModeReadouts {
+            resources: [0; 2],
             bio: BioReadout {
                 health_fraction: 1.0,
                 psi_fraction: 0.75,
@@ -244,7 +272,7 @@ mod tests {
         // Both backdrops + 2 bars + 2 numbers, with no weapon wielded.
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
         emit_use_mode(&mut canvas, &readouts(None, false));
-        assert_eq!(canvas.element_count(), 6 + SYSTEM_ELEMENTS);
+        assert_eq!(canvas.element_count(), 12 + SYSTEM_ELEMENTS);
     }
 
     #[test]
@@ -252,7 +280,7 @@ mod tests {
         // ...plus the AMMOFULL backdrop + the round count.
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
         emit_use_mode(&mut canvas, &readouts(Some(12), false));
-        assert_eq!(canvas.element_count(), 7 + SYSTEM_ELEMENTS);
+        assert_eq!(canvas.element_count(), 13 + SYSTEM_ELEMENTS);
     }
 
     /// The interface's way to the pause menu is on the canvas whatever is
@@ -380,7 +408,9 @@ mod tests {
         let gauge = |r| {
             buttons(&r)
                 .into_iter()
-                .filter(|spec| spec.button != ReadoutButton::SystemMenu)
+                .filter(|spec| {
+                    !matches!(spec.button, ReadoutButton::SystemMenu | ReadoutButton::Logs)
+                })
                 .count()
         };
         assert_eq!(gauge(readouts(None, true)), 0);

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -642,7 +642,7 @@ impl FlatUiHost {
     /// Bind the MFD to `entity` (the original's `gOverlayObj`). Opening a
     /// second panel replaces the first - one panel per (left) slot.
     pub fn open(&mut self, entity: EntityId) {
-        if self.utilities.is_research() {
+        if self.utilities.has_left_panel() {
             self.utilities = Default::default();
         }
         if self.active_panel != Some(entity) {
@@ -910,7 +910,7 @@ impl FlatUiHost {
                 .utilities
                 .update(canvas_pos, pressed_edge || grab_edge, candidate)
             {
-                if self.utilities.is_research() {
+                if self.utilities.has_left_panel() {
                     self.close();
                 }
                 self.hover_close = false;
@@ -2943,6 +2943,7 @@ mod tests {
     /// ((496,429) and (564,429)).
     fn readout_fixture() -> UseModeReadouts {
         UseModeReadouts {
+            resources: [0; 2],
             bio: Default::default(),
             ammo: crate::hud::ammo_panel::AmmoReadout {
                 ammo: Some(12),
@@ -2978,7 +2979,7 @@ mod tests {
                 .iter()
                 .map(|e| e.label.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            vec!["gun_setting", "cycle_ammo", "system_menu"]
+            vec!["gun_setting", "cycle_ammo", "system_menu", "logs"]
         );
         assert_eq!(elements[0].text.as_deref(), Some("NORM"));
         assert!(elements.iter().all(|e| e.kind == "button"));
@@ -3018,6 +3019,7 @@ mod tests {
     fn empty_bottom_strips_preserve_a_carried_item() {
         let (world, mut host, wrench, _) = drag_world();
         host.set_readouts(Some(UseModeReadouts {
+            resources: [0; 2],
             bio: Default::default(),
             ammo: Default::default(),
         }));

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -27,6 +27,7 @@ enum Control {
 pub(crate) struct MfdUtilities {
     inspecting: bool,
     research: bool,
+    empty_logs: bool,
     map_requested: bool,
     research_catalog: super::research_overview::ResearchCatalog,
     selected: Option<EntityId>,
@@ -36,8 +37,16 @@ pub(crate) struct MfdUtilities {
 }
 
 impl MfdUtilities {
-    pub(crate) fn is_research(&self) -> bool {
-        self.research
+    pub(crate) fn has_left_panel(&self) -> bool {
+        self.research || self.empty_logs
+    }
+    pub(crate) fn show_empty_logs(&mut self) {
+        *self = Self::default();
+        self.empty_logs = true;
+        self.set_content("LOGS".into(), "No collected logs.".into());
+    }
+    pub(crate) fn is_empty_logs(&self) -> bool {
+        self.empty_logs
     }
     pub(crate) fn open_research(&mut self, template: Option<i32>) {
         *self = Self::default();
@@ -47,7 +56,7 @@ impl MfdUtilities {
         }
     }
     pub(crate) fn is_open(&self) -> bool {
-        self.inspecting || self.selected.is_some() || self.research
+        self.inspecting || self.selected.is_some() || self.research || self.empty_logs
     }
     pub(crate) fn take_map_request(&mut self) -> bool {
         std::mem::take(&mut self.map_requested)
@@ -67,6 +76,9 @@ impl MfdUtilities {
             ),
             (Control::Map, Rect::new(150.0, 451.0, 32.0, 18.0), "MAP"),
         ];
+        if self.empty_logs {
+            controls.push((Control::Close, Rect::new(165.0, 132.0, 20.0, 21.0), ""));
+        }
         if self.inspecting || self.selected.is_some() {
             controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
             if self.page > 0 {
@@ -85,6 +97,7 @@ impl MfdUtilities {
                     Control::Research if self.research => "iface/ifbtn41.pcx",
                     Control::Research => "iface/ifbtn40.pcx",
                     Control::Map => "iface/ifbtn50.pcx",
+                    Control::Close if self.empty_logs => "iface/closeoff.pcx",
                     _ => "IFBTN00.PCX",
                 };
                 (control, rect, label, texture)
@@ -112,6 +125,7 @@ impl MfdUtilities {
                             *self = Self::default();
                         } else {
                             self.research = false;
+                            self.empty_logs = false;
                             self.inspecting = true;
                             self.selected = None;
                             self.set_content("Item information".into(), "Select an inventory or held item to inspect. Select ? again to cancel.".into());
@@ -131,6 +145,9 @@ impl MfdUtilities {
                 }
             }
             return true;
+        }
+        if self.empty_logs {
+            return Rect::new(2.0, 124.0, 188.0, 296.0).contains(point);
         }
         if self.research {
             let consumed = self.research_catalog.contains(point);
@@ -188,6 +205,19 @@ impl MfdUtilities {
     }
 
     pub(crate) fn draw(&self, canvas: &mut UiCanvas) {
+        if self.empty_logs {
+            canvas.image(Rect::new(2.0, 124.0, 188.0, 296.0), "iface/pda.pcx");
+            canvas.text_native_fit(
+                Rect::new(17.0, 136.0, 139.0, 12.0),
+                &self.title,
+                crate::ui::MFD_FONT,
+                HAlign::Left,
+                VAlign::Top,
+            );
+            for (rect, line) in self.visible_lines() {
+                canvas.text_native_fit(rect, line, crate::ui::MFD_FONT, HAlign::Left, VAlign::Top);
+            }
+        }
         if self.research {
             self.research_catalog.draw(canvas);
         }
@@ -211,7 +241,9 @@ impl MfdUtilities {
         for (control, rect, label, texture) in self.controls() {
             canvas.image(rect, texture);
             // Native navigation art contains its own glyphs (including the vial).
-            if matches!(control, Control::Close | Control::Previous | Control::Next) {
+            if !label.is_empty()
+                && matches!(control, Control::Close | Control::Previous | Control::Next)
+            {
                 canvas.text_native_fit(rect, label, FONT, HAlign::Center, VAlign::Middle);
             }
         }
@@ -223,7 +255,14 @@ impl MfdUtilities {
             .skip(self.page * PAGE_LINES)
             .take(PAGE_LINES)
             .enumerate()
-            .map(|(i, line)| (Rect::new(460.0, 152.0 + i as f32 * 11.0, 168.0, 11.0), line))
+            .map(|(i, line)| {
+                let rect = if self.empty_logs {
+                    Rect::new(17.0, 170.0 + i as f32 * 12.0, 139.0, 12.0)
+                } else {
+                    Rect::new(460.0, 152.0 + i as f32 * 11.0, 168.0, 11.0)
+                };
+                (rect, line)
+            })
     }
 
     pub(crate) fn debug_elements(&self) -> Vec<crate::game_scene::DebugUiElement> {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6180,6 +6180,35 @@ impl MissionCore {
                 use crate::psi::PsiSelectionAxis;
                 let step = |axis, forward| vec![Effect::StepPsiSelection { axis, forward }];
                 match button {
+                    ReadoutButton::Logs => {
+                        if self.flat_ui.utilities.is_empty_logs() {
+                            self.flat_ui.utilities = Default::default();
+                            return Vec::new();
+                        }
+                        let has_logs = self
+                            .world
+                            .borrow::<UniqueView<QuestInfo>>()
+                            .is_ok_and(|quests| quests.logs_for_reader().next().is_some());
+                        if !has_logs {
+                            self.flat_ui.close();
+                            self.flat_ui.utilities.show_empty_logs();
+                            return Vec::new();
+                        }
+                        let panel = self
+                            .world
+                            .borrow::<UniqueView<MediaPanelEntity>>()
+                            .ok()
+                            .map(|panel| panel.0);
+                        if panel.is_some() && self.flat_ui.active_panel() == panel {
+                            // This button lives inside the interface: dismiss only
+                            // its reader, even if a controller shortcut opened it.
+                            self.flat_ui.close();
+                            Vec::new()
+                        } else {
+                            self.flat_ui.utilities = Default::default();
+                            vec![Effect::ReadLastUnreadLog]
+                        }
+                    }
                     ReadoutButton::CycleAmmo => vec![Effect::CycleAmmo],
                     // The exception: SETTING opens the weapon settings MFD
                     // (the original's own behavior for this button), where the
@@ -7410,7 +7439,7 @@ impl MissionCore {
                     }
                 }
                 Effect::OpenPanel { entity } => {
-                    if self.flat_ui.utilities.is_research() {
+                    if self.flat_ui.utilities.has_left_panel() {
                         self.flat_ui.utilities = Default::default();
                     }
                     // Bind the presentation's single object-panel slot to the
@@ -7593,7 +7622,9 @@ impl MissionCore {
                         })
                         .unwrap_or_default();
                     if candidates.is_empty() {
-                        game_log!(INFO, "no collected audio log is available");
+                        effects.push_back(Effect::ShowMessage {
+                            text: "No collected audio logs.".into(),
+                        });
                         continue;
                     }
                     let resolved = candidates.into_iter().find(|(deck, log)| {

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -244,3 +244,42 @@ for (const vr of [false,true]) {
     assert.deepEqual(await game.player.inventory(),inventory,"returning cursor item preserves inventory");
   });
 }
+
+for (const vr of [false,true]) {
+  test(`Native logs control keeps cyber open and resources follow real awards (${vr ? "VR" : "flat"})`, {
+    skip:process.env.SHOCK2_E2E!=="1",timeout:180_000,
+  },async()=>{
+    await using game=await GameServer.launch({mission:"medsci1.mis",debugFlags:vr?["--vr"]:[]});
+    await game.step({frames:30});await game.player.spawnItem(-52);
+    await game.input.trigger("ToggleUseMode");await game.step({frames:5});
+    const click=async(e:UiElement)=>{if(vr)await clickCanvasWithRay(game,requirePanelPose(await game.ui.state()),canvasCenter(e));else await clickUiElement(game,e);};
+    const logs=async()=>{const e=(await game.ui.state()).readout.find(e=>e.label==="logs");assert.ok(e);return e;};
+    const capture=async(name:string)=>{const out=process.env.ASTRA_LOG_CAPTURE;if(!out)return;await mkdir(out,{recursive:true});const path=`${out}/${vr?"vr":"flat"}-${name}`;await game.screenshot(path+".png",1600);await writeFile(path+".json",JSON.stringify({ui:await game.ui.state(),info:await game.info(),inventory:await game.player.inventory()},null,2));};
+    const inventory=await game.player.inventory();
+    await capture("idle");await click(await logs());
+    assert.equal((await game.ui.state()).mode,"use");assert.equal((await game.ui.state()).active_panel,null);
+    assert.ok((await game.ui.state()).strip!.elements.some(e=>e.label==="utility_text"&&e.text?.includes("No collected logs")),"empty logs render shared PDA feedback");
+    await capture("empty-logs");
+    await click(await logs());
+    assert.equal((await game.ui.state()).mode,"use");
+    assert.ok(!(await game.ui.state()).strip!.elements.some(e=>e.label==="utility_text"&&e.text?.includes("No collected logs")),"second click dismisses empty PDA only");
+    const [disc]=await game.entities.byTemplate(1608);assert.ok(disc);
+    await game.entities.sendMessage(disc.id,{type:"Frob"});await game.step({frames:5});
+    await click(await logs());
+    const reader=(await game.ui.state()).active_panel;assert.ok(reader);
+    assert.ok(reader.elements.some(e=>e.text?.includes("45100")),"native button opens authored Amanpour transcript");
+    await capture("reader");await click(await logs());
+    assert.equal((await game.ui.state()).active_panel,null,"button closes only the reader");assert.equal((await game.ui.state()).mode,"use");
+    const before=(await game.info()).player.stats!;
+    const nanites=(await game.entities.list({filter:"Nanite",limit:100})).entities;
+    let awarded=0;
+    for(const e of nanites){const p=(await game.entities.detail(e.id)).properties;const count=Number(p.find(p=>p.name==="StackCount")?.value??0);if(count>0){await game.entities.sendMessage(e.id,{type:"Frob"});await game.step({frames:3});awarded=count;break;}}
+    assert.ok(awarded>0,"authored nanite pickup");assert.equal((await game.info()).player.stats!.nanites,before.nanites+awarded);
+    const traps=(await game.entities.list({filter:"Experience Trap"})).entities;let experience=0;
+    for(const e of traps){const value=Number((await game.entities.detail(e.id)).properties.find(p=>p.name==="Exp")?.value??0);if(value>0){await game.entities.sendMessage(e.id,{type:"TurnOn"});await game.step({frames:3});experience=value;break;}}
+    assert.ok(experience>0);assert.equal((await game.info()).player.stats!.cyber_modules,before.cyber_modules+experience);
+    const ui=await game.ui.state();
+    for(const [x,value] of [[185,before.nanites+awarded],[224,before.cyber_modules+experience]]){assert.ok(ui.readout_elements.some(e=>e.kind==="text"&&Math.abs(e.rect[0]-x)<.01&&e.text===String(value)),"resource total matches awarded currency");}
+    await capture("awarded");assert.deepEqual(await game.player.inventory(),inventory,"resource awards do not become inventory items");
+  });
+}


### PR DESCRIPTION
The cyber interface now fills the native health-strip wells with live nanite and cyber-module balances and restores the log-disc shortcut in AMMOFULL. Nanites use the same spendable total as purchases, including carried stacks.

The disc opens the existing latest-unread collected-log reader (with its existing readable-log fallback). Pressing it again closes just the reader, preserving the cyber interface. With no logs, it shows a native empty PDA panel with visible feedback and a close button. This shortcut is not yet a full PDA browser.

Validation: 69 focused Rust UI tests pass. Flat and VR runtime scenarios verify real log collection/open/close, visible empty-PDA feedback, and authored nanite/experience awards updating the counters. Code and visual reviews pass. Headset validation remains deferred.

![MFD logs and resources before and after](https://gist.githubusercontent.com/tommy-xr/f2a82145b5048fddc1ee983f405e6c66/raw/astra-mfd-logs-before-after.png)

![Log control, empty feedback and resource awards in flat and VR](https://gist.githubusercontent.com/tommy-xr/f2a82145b5048fddc1ee983f405e6c66/raw/astra-mfd-logs.gif)

Matched native-strips parent/current captures. The disc button opens the collected Amanpour transcript or a visible empty PDA; clicking again preserves the cyber interface. Production script messages prepare the collected log and award 17 nanites/4 modules; normal UI clicks exercise the control. Discrete checkpoints, no headset validation.

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/f2a82145b5048fddc1ee983f405e6c66/raw/astra-mfd-logs-gallery.html)
