### PR TITLE
feat(vr): distinguish one-handed pistol and rifle angular recoil

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -808,3 +808,52 @@ resetting ongoing spring displacement. The runtime matrix checks nonzero yaw
 only when unsupported, zero yaw at Agility 6, and retained one-handed vertical
 kick at Agility 6. Seeded unit tests isolate the larger/slower AR extra response
 from the independently randomized authored baseline.
+
+
+## Shotgun recoil evaluation
+
+Extend the [angular-handling PR #1482](https://github.com/tommy-xr/shock2quest/pull/1482)
+evaluation to the shotgun's normal and three-shell modes, Strength 1/3/6 and
+one/two hands. Keep gameplay tuning unchanged for this evaluation.
+
+The shotgun's own `GunKick` overrides the generic Weapon template:
+
+| Mode | Authored pitch | Pitch cap | Backward kick | Back cap | Ammo per shot |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Normal | 11.25 degrees | 22.5 degrees | -0.6 | -0.75 | 1 |
+| Three-shell | 22.5 degrees | 22.5 degrees | -0.75 | -0.75 | 3 |
+
+Backward values above are authored Dark units, before conversion to world
+units. Both modes author zero heading kick. The pitch return/limit ratio is
+0.5, giving a slower angular spring than pistol or AR. Sample through frame 320
+at 60 Hz to verify recovery. The three-shell mode uses its authored larger
+impulse once per firing event, rather than multiplying recoil by pellet count.
+
+The shotgun currently uses the generic extra one-handed spring: at Strength 1,
+one hand doubles its authored impulse, while two hands retain the baseline.
+Its normal-mode backward kick is already about 1.7 times the pistol's and
+2.4 times the AR's. The dedicated pistol/AR angular profiles do not apply to
+the shotgun: horizontal kick remains zero, and Agility 6 suppresses its angular
+kick even one-handed. A dedicated shotgun handling profile remains a separate
+tuning gap; this evaluation records the existing behavior without inventing one.
+
+The runtime matrix checks correct one/three-shell consumption, reloads through
+the normal ammo path, verifies support and fixed head pose, and samples the
+shared live muzzle plus gun body. Compare backward travel quantitatively;
+pitch samples retain independently randomized authored magnitudes.
+
+
+Measured peak backward gun-body travel (world units, fixed controllers):
+
+| Strength | Normal, one hand | Normal, two hands | Three-shell, one hand | Three-shell, two hands |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 0.479925 | 0.239965 | 0.599905 | 0.299955 |
+| 3 | 0.349945 | 0.199965 | 0.437431 | 0.249962 |
+| 6 | 0.255959 | 0.159975 | 0.319950 | 0.199965 |
+
+All twelve combinations and four Agility 6 checks pass. The latter confirm
+that the unprofiled shotgun retains zero angular kick at Agility 6 while still
+kicking backward. Actual support stays latched through the captured recoil and
+recovery; the tracked head remains fixed. [Comparison GIFs and raw muzzle
+measurements](https://gist.github.com/tommy-xr/bddb134ab070671f551e77acdf3a42df)
+separate pitch/yaw and endpoint motion from backward gun-body travel.

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -781,3 +781,30 @@ increases and remove the extra load with an active support grip. Ease changes
 through a spring around the primary grip, preserving the tracked hand and head;
 apply the result to the actual held gun and muzzle. Keep weight and shot impulses
 independently tunable and evaluate both with direct muzzle pitch/yaw measurements.
+
+
+## Weapon-specific one-handed angular recoil
+
+The pistol and AR now replace the generic extra angular impulse with explicit
+VR handling profiles. The authored baseline and extra backward kick are unchanged.
+
+| Held model | Extra pitch peak | Extra yaw peak | Angular spring rate | Pitch/yaw caps |
+| --- | ---: | ---: | ---: | --- |
+| Pistol (`atek_h`) | 2 degrees | ±0.75 degrees | 2 | 4 / 1.5 degrees |
+| AR (`ar15_h`) | 8 degrees | ±2 degrees | 1 | 16 / 4 degrees |
+
+The sampled magnitude is 50–100% of the listed peak, before modifiers. Strength
+scales both axes using the existing extra-impulse curve. Agility scales extra yaw
+with Dark's angular modifier, while extra pitch remains at Agility 6. Still Hand
+suppresses both angular axes; the aiming implant reduces both. These profiles
+are intentional VR tuning: they model the AR's greater one-handed control burden,
+not measured recoil energy or collider mass. Unprofiled guns retain the generic
+extra impulse pending weapon-by-weapon tuning. Supported firing uses the original
+baseline (including original Agility behavior) with the established Strength scale.
+
+The extra profile has its own bounded pitch/yaw and return rate, independent of
+the authored caps. Strength and support changes affect new impulses without
+resetting ongoing spring displacement. The runtime matrix checks nonzero yaw
+only when unsupported, zero yaw at Agility 6, and retained one-handed vertical
+kick at Agility 6. Seeded unit tests isolate the larger/slower AR extra response
+from the independently randomized authored baseline.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9166,7 +9166,11 @@ impl MissionCore {
                         );
                     }
                 }
-                Effect::KickHeldGun { entity_id, impulse } => {
+                Effect::KickHeldGun {
+                    entity_id,
+                    impulse,
+                    one_hand,
+                } => {
                     let strength = self
                         .world
                         .borrow::<UniqueView<QuestInfo>>()
@@ -9175,6 +9179,7 @@ impl MissionCore {
                     self.physics.kick_held_gun(
                         entity_id,
                         impulse,
+                        one_hand,
                         strength,
                         self.interaction.is_supported(entity_id),
                     );

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3308,6 +3308,7 @@ impl PhysicsWorld {
         &mut self,
         entity: EntityId,
         impulse: crate::weapon_recoil::RecoilImpulse,
+        one_hand: crate::weapon_recoil::RecoilImpulse,
         strength: i32,
         supported: bool,
     ) {
@@ -3316,7 +3317,8 @@ impl PhysicsWorld {
         }
         let handle = self.entity_id_to_body[&entity];
         if let Some(drive) = self.held_item_drives.get_mut(&handle) {
-            let (baseline, extra) = crate::weapon_recoil::vr_impulses(impulse, strength, supported);
+            let (baseline, extra) =
+                crate::weapon_recoil::vr_impulses(impulse, one_hand, strength, supported);
             drive.recoil.kick(baseline);
             if let Some(extra) = extra {
                 drive.one_hand_recoil.kick(extra);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -724,6 +724,7 @@ pub enum Effect {
     KickHeldGun {
         entity_id: EntityId,
         impulse: crate::weapon_recoil::RecoilImpulse,
+        one_hand: crate::weapon_recoil::RecoilImpulse,
     },
     PlayEnvironmentalSound {
         audio_handle: AudioHandle,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -640,8 +640,12 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
         }
     }
     if is_gunshot {
-        if let Some(impulse) = crate::weapon_recoil::shot_impulse(world, entity_id) {
-            effects.push(Effect::KickHeldGun { entity_id, impulse });
+        if let Some((impulse, one_hand)) = crate::weapon_recoil::shot_impulse(world, entity_id) {
+            effects.push(Effect::KickHeldGun {
+                entity_id,
+                impulse,
+                one_hand,
+            });
         }
     }
     ShotOutcome::Fired(Effect::Multiple(effects))

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -3,7 +3,8 @@
 //! damping=14 response is integrated analytically, without frame-rate drift.
 use cgmath::{InnerSpace, Vector3, vec3};
 use dark::properties::{
-    GunKickSetting, Link, Links, PropGunKick, PropGunState, PropImplantDesc, PropPlayerGun,
+    GunKickSetting, Link, Links, PropGunKick, PropGunState, PropImplantDesc, PropModelName,
+    PropPlayerGun,
 };
 use rand::Rng;
 use shipyard::{EntityId, Get, UniqueView, View, World};
@@ -15,29 +16,31 @@ pub struct RecoilImpulse {
     pub back: f32,
     pub pitch_limit: f32,
     pub back_limit: f32,
+    pub heading_limit: f32,
     pub angular_rate: f32,
     pub back_rate: f32,
     pub forward: Vector3<f32>,
 }
 
 /// Intentional VR control tuning, separate from Dark's Agility modifier.
-/// Caps and spring rates remain authored: changing Strength/support affects
+/// Caps and spring rates remain fixed: changing Strength/support affects
 /// future impulses, never the pose or recovery of an already moving spring.
 pub fn vr_impulses(
     impulse: RecoilImpulse,
+    one_hand: RecoilImpulse,
     strength: i32,
     supported: bool,
 ) -> (RecoilImpulse, Option<RecoilImpulse>) {
     let above_minimum = (strength.clamp(1, 6) - 1) as f32;
-    let scaled = |scale| RecoilImpulse {
+    let scaled = |impulse: RecoilImpulse, scale| RecoilImpulse {
         pitch: impulse.pitch * scale,
         heading: impulse.heading * scale,
         back: impulse.back * scale,
         ..impulse
     };
     (
-        scaled(1.0 / (1.0 + 0.1 * above_minimum)),
-        (!supported).then(|| scaled(1.0 / (1.0 + 0.3 * above_minimum))),
+        scaled(impulse, 1.0 / (1.0 + 0.1 * above_minimum)),
+        (!supported).then(|| scaled(one_hand, 1.0 / (1.0 + 0.3 * above_minimum))),
     )
 }
 
@@ -97,7 +100,7 @@ fn aiming_implant(world: &World) -> bool {
 }
 
 /// Called only after the shared firing gate succeeds, once per shell (not pellet).
-pub fn shot_impulse(world: &World, gun: EntityId) -> Option<RecoilImpulse> {
+pub fn shot_impulse(world: &World, gun: EntityId) -> Option<(RecoilImpulse, RecoilImpulse)> {
     // Keep the flat/nonphysical firing path free of recoil RNG draws.
     crate::mission::mission_core::held_item_collision_group(world, gun)?;
     let (kicks, states, guns) = world
@@ -115,15 +118,54 @@ pub fn shot_impulse(world: &World, gun: EntityId) -> Option<RecoilImpulse> {
         .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
         .is_ok_and(|powers| powers.is_active(-1107));
     let mut rng = rand::thread_rng();
-    Some(authored_impulse(
+    let aiming = aiming_implant(world);
+    let authored = authored_impulse(
         kick,
         flags,
         agility,
         still_hand,
-        aiming_implant(world),
+        aiming,
         crate::weapon_muzzle::resolve(world, gun).axis,
         &mut rng,
-    ))
+    );
+    let model = world.borrow::<View<PropModelName>>().ok()?;
+    let extra = one_hand_impulse(
+        authored,
+        &model.get(gun).ok()?.0,
+        agility,
+        still_hand,
+        aiming,
+        &mut rng,
+    );
+    Some((authored, extra))
+}
+
+/// Deliberate VR tuning: forward-heavy rifles need more angular correction
+/// one-handed. This replaces the generic extra angular kick for these models;
+/// authored two-hand kick and the existing extra backward kick are preserved.
+fn one_hand_impulse<R: Rng + ?Sized>(
+    authored: RecoilImpulse,
+    model: &str,
+    agility: i32,
+    still_hand: bool,
+    aiming: bool,
+    rng: &mut R,
+) -> RecoilImpulse {
+    let (pitch, yaw, rate) = match model.to_ascii_lowercase().trim_end_matches(".bin") {
+        "atek_h" => (2.0, 0.75, 2.0),
+        "ar15_h" => (8.0, 2.0, 1.0),
+        _ => return authored,
+    };
+    RecoilImpulse {
+        // Strength scales this later. Agility affects horizontal stability,
+        // without making a heavy gun effortless vertically at Agility 6.
+        pitch: kick_angle(pitch, 1, 1, still_hand, aiming, rng),
+        heading: kick_angle(yaw, 3, agility, still_hand, aiming, rng),
+        pitch_limit: pitch * 2.0,
+        heading_limit: yaw * 2.0,
+        angular_rate: rate,
+        ..authored
+    }
 }
 
 fn authored_impulse<R: Rng + ?Sized>(
@@ -155,6 +197,7 @@ fn authored_impulse<R: Rng + ?Sized>(
         back: kick.kick_back / dark::SCALE_FACTOR,
         pitch_limit: kick.kick_pitch_max_degrees.abs(),
         back_limit: kick.kick_back_max.abs() / dark::SCALE_FACTOR,
+        heading_limit: f32::MAX,
         angular_rate: recovery_rate(
             kick.kick_angular_return_rate_degrees,
             kick.kick_pitch_max_degrees,
@@ -220,6 +263,7 @@ impl RecoilState {
             impulse.back,
             impulse.pitch_limit,
             impulse.back_limit,
+            impulse.heading_limit,
             impulse.angular_rate,
             impulse.back_rate,
             impulse.forward.x,
@@ -232,6 +276,7 @@ impl RecoilState {
             || impulse.back_rate <= 0.0
             || impulse.pitch_limit < 0.0
             || impulse.back_limit < 0.0
+            || impulse.heading_limit < 0.0
             || Vector3::unit_y().cross(impulse.forward).magnitude2() < 1e-8
         {
             return;
@@ -248,7 +293,7 @@ impl RecoilState {
             return (vec3(0.0, 0.0, 0.0), Quaternion::new(1.0, 0.0, 0.0, 0.0));
         };
         self.pitch.step(dt, i.angular_rate, i.pitch_limit);
-        self.heading.step(dt, i.angular_rate, f32::MAX);
+        self.heading.step(dt, i.angular_rate, i.heading_limit);
         self.back.step(dt, i.back_rate, i.back_limit);
         let forward = i.forward.normalize();
         let right = Vector3::unit_y().cross(forward).normalize();
@@ -265,6 +310,59 @@ mod tests {
     use super::*;
     use rand::{SeedableRng, rngs::StdRng};
     #[test]
+    fn one_hand_profiles_separate_vertical_load_from_agility_and_preserve_baseline() {
+        let authored = RecoilImpulse {
+            pitch: 3.0,
+            heading: 0.0,
+            back: -0.1,
+            pitch_limit: 4.0,
+            heading_limit: f32::MAX,
+            back_limit: 0.2,
+            angular_rate: 2.0,
+            back_rate: 1.0,
+            forward: -Vector3::unit_x(),
+        };
+        let extra = |model, agility, still| {
+            one_hand_impulse(
+                authored,
+                model,
+                agility,
+                still,
+                false,
+                &mut StdRng::seed_from_u64(7),
+            )
+        };
+        let pistol = extra("atek_h", 1, false);
+        let ar = extra("ar15_h", 1, false);
+        assert!(ar.pitch > pistol.pitch * 3.9);
+        assert!(ar.heading.abs() > pistol.heading.abs() * 2.6);
+        assert!(ar.angular_rate < pistol.angular_rate);
+        assert_eq!(ar.back, authored.back);
+        let agile = extra("ar15_h", 6, false);
+        assert_eq!(agile.pitch, ar.pitch);
+        assert_eq!(agile.heading, 0.0);
+        let middle = extra("ar15_h", 3, false);
+        assert!(middle.heading.abs() < ar.heading.abs());
+        let still = extra("ar15_h", 1, true);
+        assert_eq!((still.pitch, still.heading), (0.0, 0.0));
+        assert_eq!(still.back, authored.back);
+        let (base, penalty) = vr_impulses(authored, ar, 1, true);
+        assert_eq!((base.pitch, base.heading, base.back), (3.0, 0.0, -0.1));
+        assert!(penalty.is_none());
+        let low = vr_impulses(authored, ar, 1, false).1.unwrap();
+        let high = vr_impulses(authored, ar, 6, false).1.unwrap();
+        assert!(high.pitch < low.pitch && high.heading.abs() < low.heading.abs());
+        assert_eq!(extra("sg_h", 1, false).pitch, authored.pitch);
+        let mut state = RecoilState::default();
+        for _ in 0..200 {
+            state.kick(ar);
+            state.step(1.0 / 60.0);
+            assert!(state.heading.position.abs() <= ar.heading_limit);
+            assert!(state.pitch.position.abs() <= ar.pitch_limit);
+        }
+    }
+
+    #[test]
     fn strength_reduces_both_new_impulses_without_changing_recovery_or_caps() {
         let authored = RecoilImpulse {
             pitch: 7.0,
@@ -272,13 +370,14 @@ mod tests {
             back: -0.1,
             pitch_limit: 10.0,
             back_limit: 0.2,
+            heading_limit: f32::MAX,
             angular_rate: 1.0,
             back_rate: 2.0,
             forward: -Vector3::unit_x(),
         };
         let mut previous = (f32::MAX, f32::MAX);
         for strength in [1, 3, 6] {
-            let (base, extra) = vr_impulses(authored, strength, false);
+            let (base, extra) = vr_impulses(authored, authored, strength, false);
             let extra = extra.unwrap();
             assert!(base.pitch < previous.0 && extra.pitch < previous.1);
             previous = (base.pitch, extra.pitch);
@@ -286,16 +385,22 @@ mod tests {
             assert_eq!(extra.back_limit, authored.back_limit);
             assert_eq!(base.angular_rate, authored.angular_rate);
             assert_eq!(extra.back_rate, authored.back_rate);
-            let (supported, penalty) = vr_impulses(authored, strength, true);
+            let (supported, penalty) = vr_impulses(authored, authored, strength, true);
             assert!(penalty.is_none());
             assert_eq!(supported.pitch, base.pitch);
             assert_eq!(supported.back, base.back);
         }
-        assert_eq!(vr_impulses(authored, 1, true).0.pitch, authored.pitch);
-        assert_eq!(vr_impulses(authored, -2, true).0.pitch, authored.pitch);
         assert_eq!(
-            vr_impulses(authored, 99, true).0.pitch,
-            vr_impulses(authored, 6, true).0.pitch
+            vr_impulses(authored, authored, 1, true).0.pitch,
+            authored.pitch
+        );
+        assert_eq!(
+            vr_impulses(authored, authored, -2, true).0.pitch,
+            authored.pitch
+        );
+        assert_eq!(
+            vr_impulses(authored, authored, 99, true).0.pitch,
+            vr_impulses(authored, authored, 6, true).0.pitch
         );
     }
 
@@ -307,23 +412,24 @@ mod tests {
             back: -0.1,
             pitch_limit: 10.0,
             back_limit: 0.2,
+            heading_limit: f32::MAX,
             angular_rate: 1.0,
             back_rate: 1.0,
             forward: -Vector3::unit_x(),
         };
         let mut penalty = RecoilState::default();
-        penalty.kick(vr_impulses(authored, 1, false).1.unwrap());
+        penalty.kick(vr_impulses(authored, authored, 1, false).1.unwrap());
         penalty.step(0.1);
         let mut uninterrupted = penalty;
         // A supported follow-up shot has no new penalty; the old spring remains.
-        if let Some(extra) = vr_impulses(authored, 6, true).1 {
+        if let Some(extra) = vr_impulses(authored, authored, 6, true).1 {
             penalty.kick(extra);
         }
         assert_eq!(penalty.step(0.1), uninterrupted.step(0.1));
         assert!(penalty.pitch.position > 0.0);
         // Losing support adds velocity, without resetting accumulated displacement.
         let before = penalty.step(0.0);
-        penalty.kick(vr_impulses(authored, 6, false).1.unwrap());
+        penalty.kick(vr_impulses(authored, authored, 6, false).1.unwrap());
         assert_eq!(penalty.step(0.0), before);
         penalty.step(5.0);
         assert!(penalty.pitch.position.abs() < 1e-6);
@@ -340,6 +446,7 @@ mod tests {
                 back: -0.1,
                 pitch_limit: 10.0,
                 back_limit: 0.2,
+                heading_limit: f32::MAX,
                 angular_rate: 1.0,
                 back_rate: 1.0,
                 forward,
@@ -362,6 +469,7 @@ mod tests {
             back: -0.1,
             pitch_limit: 10.0,
             back_limit: 0.2,
+            heading_limit: f32::MAX,
             angular_rate: 1.0,
             back_rate: 1.0,
             forward: Vector3::unit_y(),

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -13,9 +13,11 @@ import {
 } from "./helpers/vr-hand.js";
 import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
 
-for (const [name, template] of [
-  ["pistol", -17],
-  ["AR", -18],
+for (const [name, template, profiled, setting] of [
+  ["pistol", -17, true, 0],
+  ["AR", -18, true, 0],
+  ["shotgun", -19, false, 0],
+  ["shotgun-triple", -19, false, 1],
 ] as const) {
   test(
     `${name} recoil decreases with Strength and genuine support removes the extra spring`,
@@ -42,6 +44,21 @@ for (const [name, template] of [
         Math.SQRT1_2,
       ]);
       await game.step({ frames: 180 });
+      if (setting) {
+        await game.input.trigger("CycleGunSetting");
+        await game.step({ frames: 2 });
+      }
+      const ammoUsage = setting ? 3 : 1;
+      const ensureShotAmmo = async () => {
+        if (ammoOf(await game.entities.detail(gun.id)) >= ammoUsage) return;
+        // The shotgun's three-shell matrix exceeds one magazine. Supply both
+        // authored clip types and reload through the normal selected-ammo path.
+        await game.player.spawnItem(-42);
+        await game.player.spawnItem(-43);
+        await game.input.trigger("Reload");
+        await game.step({ frames: 180 });
+        assert.ok(ammoOf(await game.entities.detail(gun.id)) >= ammoUsage);
+      };
       const head = (await game.info()).player.camera_rotation;
       const body = async () =>
         (await game.physics.bodies({ entityId: gun.id })).bodies[0]!;
@@ -89,6 +106,7 @@ for (const [name, template] of [
         for (const supported of [false, true]) {
           await support(supported);
           await game.step({ frames: 180 });
+          await ensureShotAmmo();
           const initial = await body();
           const initialDetail = await game.entities.detail(gun.id);
           const ammo = ammoOf(initialDetail);
@@ -108,7 +126,10 @@ for (const [name, template] of [
               ...muzzleFrameOf(await game.entities.detail(gun.id)),
             });
           }
-          assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+          assert.equal(
+            ammoOf(await game.entities.detail(gun.id)),
+            ammo - ammoUsage,
+          );
           assert.deepEqual((await game.info()).player.camera_rotation, head);
           assert.ok(
             muzzle.some(
@@ -132,10 +153,12 @@ for (const [name, template] of [
             ),
           );
           assert.ok(
-            supported ? yaw < 0.0001 : yaw > 0.001,
-            `one-hand handling adds horizontal recoil; supported=${supported}, yaw=${yaw}`,
+            supported || !profiled ? yaw < 0.0001 : yaw > 0.001,
+            `profiled one-hand handling adds horizontal recoil; supported=${supported}, profiled=${profiled}, yaw=${yaw}`,
           );
-          for (let frame = 26; frame <= 200; frame += 6) {
+          // Shotgun pitch has a slower authored return/limit ratio (0.5).
+          const recoveryFrames = template === -19 ? 320 : 200;
+          for (let frame = 26; frame <= recoveryFrames; frame += 6) {
             await game.step({ frames: 6 });
             muzzle.push({
               frame,
@@ -194,7 +217,14 @@ for (const [name, template] of [
         await writeFile(
           join(output, `${name.toLowerCase()}.json`),
           JSON.stringify(
-            { weapon: name, agility: 1, standard: 6, hz: 60, measurements },
+            {
+              weapon: name,
+              setting,
+              agility: 1,
+              standard: 6,
+              hz: 60,
+              measurements,
+            },
             null,
             2,
           ) + "\n",
@@ -258,6 +288,7 @@ for (const [name, template] of [
       for (const supported of [false, true]) {
         await support(supported);
         await game.step({ frames: 180 });
+        await ensureShotAmmo();
         const initial = muzzleFrameOf(await game.entities.detail(gun.id));
         const ammo = ammoOf(await game.entities.detail(gun.id));
         await game.input.set("right_hand.trigger", 1);
@@ -276,11 +307,14 @@ for (const [name, template] of [
             ),
           );
         }
-        assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+        assert.equal(
+          ammoOf(await game.entities.detail(gun.id)),
+          ammo - ammoUsage,
+        );
         assert.ok(yaw < 0.0001, `Agility 6 suppresses horizontal kick: ${yaw}`);
         assert.ok(
-          supported ? pitch < 0.0001 : pitch > 0.002,
-          `Agility 6 keeps extra one-hand vertical load; supported=${supported}, pitch=${pitch}`,
+          supported || !profiled ? pitch < 0.0001 : pitch > 0.002,
+          `Agility 6 retains vertical load only for a dedicated profile; supported=${supported}, profiled=${profiled}, pitch=${pitch}`,
         );
         assert.deepEqual((await game.info()).player.camera_rotation, head);
         await game.step({ frames: 300 });

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -121,7 +121,19 @@ for (const [name, template] of [
             muzzle.some(
               (sample) => sample.forward[1] > initialMuzzle.forward[1] + 0.005,
             ),
-            "subsequent shots aim along the recoiling barrel",
+            "the live barrel direction rises during recoil",
+          );
+          const yaw = Math.max(
+            ...muzzle.map((sample) =>
+              Math.abs(
+                sample.forward[0] * initialMuzzle.forward[2] -
+                  sample.forward[2] * initialMuzzle.forward[0],
+              ),
+            ),
+          );
+          assert.ok(
+            supported ? yaw < 0.0001 : yaw > 0.001,
+            `one-hand handling adds horizontal recoil; supported=${supported}, yaw=${yaw}`,
           );
           for (let frame = 26; frame <= 200; frame += 6) {
             await game.step({ frames: 6 });
@@ -240,6 +252,38 @@ for (const [name, template] of [
           );
         }
         assert.deepEqual((await game.info()).player.camera_rotation, head);
+      }
+      await game.step({ frames: 300 });
+      await game.player.setStats({ agility: 6 });
+      for (const supported of [false, true]) {
+        await support(supported);
+        await game.step({ frames: 180 });
+        const initial = muzzleFrameOf(await game.entities.detail(gun.id));
+        const ammo = ammoOf(await game.entities.detail(gun.id));
+        await game.input.set("right_hand.trigger", 1);
+        let pitch = 0;
+        let yaw = 0;
+        for (let frame = 0; frame < 30; frame++) {
+          await game.step({ frames: 1 });
+          if (frame === 0) await game.input.set("right_hand.trigger", 0);
+          const current = muzzleFrameOf(await game.entities.detail(gun.id));
+          pitch = Math.max(pitch, current.forward[1] - initial.forward[1]);
+          yaw = Math.max(
+            yaw,
+            Math.abs(
+              current.forward[0] * initial.forward[2] -
+                current.forward[2] * initial.forward[0],
+            ),
+          );
+        }
+        assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+        assert.ok(yaw < 0.0001, `Agility 6 suppresses horizontal kick: ${yaw}`);
+        assert.ok(
+          supported ? pitch < 0.0001 : pitch > 0.002,
+          `Agility 6 keeps extra one-hand vertical load; supported=${supported}, pitch=${pitch}`,
+        );
+        assert.deepEqual((await game.info()).player.camera_rotation, head);
+        await game.step({ frames: 300 });
       }
     },
   );


### PR DESCRIPTION
Give the one-handed pistol and AR separate vertical/horizontal recoil profiles. The pistol adds a smaller, faster angular response; the AR adds a larger, slower response. Strength reduces both extra axes, while Agility improves horizontal stability without eliminating one-handed vertical kick. Active support retains the existing authored baseline and Strength scale.

The added pitch/yaw is explicit VR tuning, independent of the authored extra backward kick. Still Hand and aiming-implant modifiers remain effective. Profile caps bound repeated shots; changing support affects future impulses without resetting ongoing springs. Other guns retain their existing extra impulse pending tuning.

Validation: 1,647 gameplay tests passed (2 ignored); warnings-as-errors checks and SDK build passed. The runtime matrix passed all 12 Strength 1/3/6 one/two-hand cases plus 4 Agility 6 cases, verifying yaw, retained vertical load, recovery, ammo, fixed head and support transitions. Independent source/duplication and visual reviews found no actionable issues. No Quest was connected; headset feel remains to be validated.

![PISTOL matched one-hand firing](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/pistol-s1-one-comparison.gif)

![PISTOL matched one-hand firing](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/pistol-s1-one-comparison.png)

![AR matched one-hand firing](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/ar-s1-one-comparison.gif)

![AR matched one-hand firing](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/ar-s1-one-comparison.png)

![Separate measured pitch and yaw](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/muzzle-pitch-yaw.png)

Matched requests, fixed tracked hands/head; Strength1, Agility1, Standard6 in firing captures. Angular random samples are independent. Plot covers Strength1/3/6 one/two hands: all two-hand yaw stays zero. Endpoint travel includes translation and rotation of the gun.

[CSV](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/muzzle-traces.csv) · [SVG](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/muzzle-pitch-yaw.svg) · [Summary](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/muzzle-summary.json) · [Pistol raw](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/pistol.json) · [AR raw](https://gist.githubusercontent.com/tommy-xr/73ad19d8310655cb0d0d617bd7787e2e/raw/6ae9f6044ad09a1437a85f71e494223c552add48/ar.json)


### Shotgun evaluation

Evaluate both shotgun modes with the existing generic one-handed penalty; no shotgun tuning was changed. At Strength 1, measured peak backward gun-body travel is:

| Mode | One hand | Two hands |
| --- | ---: | ---: |
| Normal | 0.479925 | 0.239965 |
| Three-shell | 0.599905 | 0.299955 |

Normal-mode one-handed kickback is approximately 1.7× the pistol's and 2.4× the AR's. All 12 shotgun Strength 1/3/6 and grip combinations passed, plus four Agility 6 checks. Tests verify correct 1/3-shell consumption, normal reload behavior, fixed head, backward scaling and full recovery through frame 320. Support remains attached throughout the two-handed captures.

The shotgun still has zero authored yaw and no dedicated angular handling profile; Agility 6 suppresses its angular recoil even one-handed. This remains a documented tuning gap. Pitch samples are independently randomized, so the quantitative comparison above uses deterministic backward travel.

Shotgun evaluation of existing recoil behavior, with physical held items enabled and idle weight disabled.

![shotgun one versus two hands](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun-comparison.gif)

![shotgun peak comparison](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun-peak.png)

![shotgun-triple one versus two hands](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun-triple-comparison.gif)

![shotgun-triple peak comparison](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun-triple-peak.png)

![Shotgun measured pitch yaw and muzzle travel](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/muzzle-pitch-yaw.png)

Strength1 capture body kickback: normal one/two hands 0.480/0.240; triple 0.600/0.300 world units. Normal consumes1 round; triple3. Support remains latched throughout every two-hand firing/recovery frame, and head pose stays fixed. Angular samples are independently randomized; this is a grip comparison, not an engine before/after change.

[CSV](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/muzzle-traces.csv) · [SVG](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/muzzle-pitch-yaw.svg) · [Capture measurements](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/capture-summary.json) · [Normal raw](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun.json) · [Triple raw](https://gist.githubusercontent.com/tommy-xr/bddb134ab070671f551e77acdf3a42df/raw/c1ade13608694ce22c1ab921b9a7fc71fec303fb/shotgun-triple.json)
