### PR TITLE
feat(mfd): add read-only character statistics

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -111,3 +111,16 @@ Opening the cyber interface currently releases a support grip for pointing,
 so the freed hand reads EMPTY and a two-handed weapon appears only once. If
 that interaction policy changes, add an explicit SUPPORTING state rather than
 representing the support hand as another owner.
+
+### Character MFD
+
+The native MFD control (IFBTN20/21, at 460,430) toggles a read-only character
+sheet in the original right STATS panel. It shows the five trained base levels
+in retail order and acquired OS upgrade icons/names. Bars use shkstats.cpp's
+33,22 origin, 17-pixel horizontal step and 26-pixel row step; acquired traits
+pack left-to-right at 35-pixel spacing. Label bands are replaced consistently
+in classic and 25AE artwork so the HD art's removed labels remain readable.
+
+This first sheet reports base levels, not temporary boosted-stat segments.
+Upgrade purchases remain at trainers. TECH/CMBT/PSI pages and their navigation
+controls are deferred; no inactive tabs are presented as working controls.

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -2547,6 +2547,19 @@ mod tests {
     }
 
     #[test]
+    fn character_panel_preserves_carried_items_and_toggles_without_actions() {
+        let (world, mut host, item, _) = drag_world();
+        host.cursor_item = Some(make_cursor_item(&world, item));
+        assert!(press_edge(&mut host, &world, (476.0, 450.0)).is_empty());
+        assert!(host.utilities.is_open());
+        assert!(press_edge(&mut host, &world, (530.0, 200.0)).is_empty());
+        assert_eq!(host.held_entity(), Some(item));
+        assert!(press_edge(&mut host, &world, (476.0, 450.0)).is_empty());
+        assert!(!host.utilities.is_open());
+        assert_eq!(host.held_entity(), Some(item));
+    }
+
+    #[test]
     fn inspect_click_does_not_lift_wield_or_frob_an_inventory_item() {
         let (world, mut host, item, _) = drag_world();
         assert!(press_edge(&mut host, &world, (166.0, 440.0)).is_empty());

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -2,7 +2,7 @@
 
 use cgmath::Vector2;
 use engine::assets::asset_cache::AssetCache;
-use shipyard::{EntitiesView, EntityId, Get, View, World};
+use shipyard::{EntitiesView, EntityId, Get, UniqueView, View, World};
 
 use crate::{
     scripts::gui::wrap_text,
@@ -10,12 +10,21 @@ use crate::{
 };
 
 const PANEL: Rect = Rect::new(450.0, 124.0, 188.0, 248.0);
+const CHARACTER_PANEL: Rect = Rect::new(450.0, 124.0, 188.0, 296.0);
+const CHARACTER_STATS: [(&str, crate::player_stats::Stat); 5] = [
+    ("STRENGTH", crate::player_stats::Stat::Strength),
+    ("ENDURANCE", crate::player_stats::Stat::Endurance),
+    ("PSIONICS", crate::player_stats::Stat::PsionicAbility),
+    ("AGILITY", crate::player_stats::Stat::Agility),
+    ("CYBER", crate::player_stats::Stat::CyberAffinity),
+];
 const FONT: &str = "mainfont.fon";
 const PAGE_LINES: usize = 16;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Control {
     Inspect,
+    Character,
     Research,
     Map,
     Close,
@@ -28,6 +37,8 @@ pub(crate) struct MfdUtilities {
     inspecting: bool,
     research: bool,
     empty_logs: bool,
+    character: bool,
+    character_stats: crate::player_stats::PlayerStats,
     map_requested: bool,
     research_catalog: super::research_overview::ResearchCatalog,
     selected: Option<EntityId>,
@@ -56,7 +67,11 @@ impl MfdUtilities {
         }
     }
     pub(crate) fn is_open(&self) -> bool {
-        self.inspecting || self.selected.is_some() || self.research || self.empty_logs
+        self.inspecting
+            || self.selected.is_some()
+            || self.research
+            || self.empty_logs
+            || self.character
     }
     pub(crate) fn take_map_request(&mut self) -> bool {
         std::mem::take(&mut self.map_requested)
@@ -65,9 +80,14 @@ impl MfdUtilities {
         self.inspecting
     }
     fn controls(&self) -> Vec<(Control, Rect, &'static str, &'static str)> {
-        // Retail shkiface.cpp iface_rects[3..6], on BIOFULL at (2, 414).
+        // Retail shkiface.cpp iface_rects[2..6], on the bottom bio/ammo strips.
         // Keep art, hit testing, and debug discovery on these same canvas rects.
         let mut controls = vec![
+            (
+                Control::Character,
+                Rect::new(460.0, 430.0, 32.0, 40.0),
+                "MFD",
+            ),
             (Control::Inspect, Rect::new(150.0, 431.0, 32.0, 18.0), "?"),
             (
                 Control::Research,
@@ -76,6 +96,9 @@ impl MfdUtilities {
             ),
             (Control::Map, Rect::new(150.0, 451.0, 32.0, 18.0), "MAP"),
         ];
+        if self.character {
+            controls.push((Control::Close, Rect::new(455.0, 132.0, 20.0, 21.0), ""));
+        }
         if self.empty_logs {
             controls.push((Control::Close, Rect::new(165.0, 132.0, 20.0, 21.0), ""));
         }
@@ -92,6 +115,9 @@ impl MfdUtilities {
             .into_iter()
             .map(|(control, rect, label)| {
                 let texture = match control {
+                    Control::Character if self.character => "iface/ifbtn21.pcx",
+                    Control::Character => "iface/ifbtn20.pcx",
+                    Control::Close if self.character => "iface/closeoff.pcx",
                     Control::Inspect if self.inspecting => "iface/ifbtn31.pcx",
                     Control::Inspect => "iface/ifbtn30.pcx",
                     Control::Research if self.research => "iface/ifbtn41.pcx",
@@ -120,12 +146,18 @@ impl MfdUtilities {
         {
             if pressed {
                 match control {
+                    Control::Character => {
+                        let open = !self.character;
+                        *self = Self::default();
+                        self.character = open;
+                    }
                     Control::Inspect => {
                         if self.inspecting {
                             *self = Self::default();
                         } else {
                             self.research = false;
                             self.empty_logs = false;
+                            self.character = false;
                             self.inspecting = true;
                             self.selected = None;
                             self.set_content("Item information".into(), "Select an inventory or held item to inspect. Select ? again to cancel.".into());
@@ -145,6 +177,9 @@ impl MfdUtilities {
                 }
             }
             return true;
+        }
+        if self.character {
+            return CHARACTER_PANEL.contains(point);
         }
         if self.empty_logs {
             return Rect::new(2.0, 124.0, 188.0, 296.0).contains(point);
@@ -184,6 +219,23 @@ impl MfdUtilities {
         assets: &mut AssetCache,
         info: &dark::ss2_entity_info::SystemShock2EntityInfo,
     ) {
+        if self.character {
+            if let Ok(quests) = world.borrow::<UniqueView<crate::quest_info::QuestInfo>>() {
+                self.character_stats = quests.player_stats().clone();
+            }
+            self.title = "OS UPGRADES".into();
+            self.lines = self
+                .character_stats
+                .os_traits
+                .iter()
+                .take(4)
+                .map(|id| crate::scripts::gui::trait_name(*id).to_owned())
+                .collect();
+            if self.lines.is_empty() {
+                self.lines = vec!["No OS upgrades".into(), "installed.".into()];
+            }
+            return;
+        }
         if self.research {
             self.research_catalog.refresh(world, assets, info);
             return;
@@ -205,6 +257,60 @@ impl MfdUtilities {
     }
 
     pub(crate) fn draw(&self, canvas: &mut UiCanvas) {
+        if self.character {
+            canvas.image(CHARACTER_PANEL, "iface/stats.pcx");
+            for (rect, label) in self.character_labels() {
+                // 25AE removes the baked labels; cover the classic label bands
+                // too, then draw one shared layer. Cover the original glyphs'
+                // final pixel row; arrows begin immediately afterward at y=22.
+                canvas.cropped_image(
+                    Rect { h: 14.0, ..rect },
+                    "iface/stats.pcx",
+                    Rect::new(40.0, 134.0, 80.0, 6.0),
+                    Vector2::new(188.0, 296.0),
+                );
+                canvas.text_native_fit(
+                    rect,
+                    &label,
+                    crate::ui::MFD_FONT,
+                    HAlign::Left,
+                    VAlign::Top,
+                );
+            }
+            for (row, (_, stat)) in CHARACTER_STATS.iter().enumerate() {
+                for level in 0..self
+                    .character_stats
+                    .stat_level(*stat)
+                    .clamp(0, crate::player_stats::STAT_CAP)
+                {
+                    canvas.image(
+                        Rect::new(
+                            483.0 + level as f32 * 17.0,
+                            146.0 + row as f32 * 26.0,
+                            20.0,
+                            14.0,
+                        ),
+                        "iface/skilstat.pcx",
+                    );
+                }
+            }
+            for (slot, id) in self.character_stats.os_traits.iter().take(4).enumerate() {
+                canvas.image(
+                    Rect::new(487.0 + slot as f32 * 35.0, 268.0, 32.0, 32.0),
+                    &crate::scripts::gui::trait_icon(*id),
+                );
+            }
+            canvas.text_native_fit(
+                Rect::new(465.0, 314.0, 159.0, 12.0),
+                &self.title,
+                crate::ui::MFD_FONT,
+                HAlign::Left,
+                VAlign::Top,
+            );
+            for (rect, line) in self.visible_lines() {
+                canvas.text_native_fit(rect, line, crate::ui::MFD_FONT, HAlign::Left, VAlign::Top);
+            }
+        }
         if self.empty_logs {
             canvas.image(Rect::new(2.0, 124.0, 188.0, 296.0), "iface/pda.pcx");
             canvas.text_native_fit(
@@ -249,6 +355,23 @@ impl MfdUtilities {
         }
     }
 
+    /// Shared stat-label rectangles for rendering and debug inspection.
+    fn character_labels(&self) -> Vec<(Rect, String)> {
+        if !self.character {
+            return Vec::new();
+        }
+        CHARACTER_STATS
+            .iter()
+            .enumerate()
+            .map(|(row, (name, stat))| {
+                (
+                    Rect::new(480.0, 132.0 + row as f32 * 26.0, 148.0, 12.0),
+                    format!("{name} {}", self.character_stats.stat_level(*stat)),
+                )
+            })
+            .collect()
+    }
+
     fn visible_lines(&self) -> impl Iterator<Item = (Rect, &String)> {
         self.lines
             .iter()
@@ -258,6 +381,8 @@ impl MfdUtilities {
             .map(|(i, line)| {
                 let rect = if self.empty_logs {
                     Rect::new(17.0, 170.0 + i as f32 * 12.0, 139.0, 12.0)
+                } else if self.character {
+                    Rect::new(465.0, 332.0 + i as f32 * 12.0, 159.0, 12.0)
                 } else {
                     Rect::new(460.0, 152.0 + i as f32 * 11.0, 168.0, 11.0)
                 };
@@ -275,6 +400,7 @@ impl MfdUtilities {
                     text: Some(label.into()),
                     label: Some(
                         match control {
+                            Control::Character => "character_stats",
                             Control::Inspect => "inspect",
                             Control::Research => "research_overview",
                             Control::Map => "map",
@@ -294,6 +420,17 @@ impl MfdUtilities {
             } else {
                 Vec::new()
             })
+            .chain(self.character_labels().into_iter().map(|(r, text)| {
+                crate::game_scene::DebugUiElement {
+                    kind: "text".into(),
+                    texture: None,
+                    text: Some(text),
+                    label: Some("character_stat".into()),
+                    entity_id: None,
+                    rect: [r.x, r.y, r.w, r.h],
+                    screen_rect: [r.x, r.y, r.w, r.h],
+                }
+            }))
             .chain(self.visible_lines().map(|(rect, line)| {
                 let r = [rect.x, rect.y, rect.w, rect.h];
                 crate::game_scene::DebugUiElement {

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -211,7 +211,7 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 
 /// The trait icon art (`TRAIT01.PCX`..`TRAIT16.PCX`; `TRAIT00.PCX` is the
 /// empty-slot art).
-fn trait_icon(trait_id: u8) -> String {
+pub(crate) fn trait_icon(trait_id: u8) -> String {
     format!("trait{:02}.pcx", trait_id)
 }
 

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -283,3 +283,28 @@ for (const vr of [false,true]) {
     await capture("awarded");assert.deepEqual(await game.player.inventory(),inventory,"resource awards do not become inventory items");
   });
 }
+
+for (const vr of [false,true]) {
+  test(`Native character stats display five live levels without mutation (${vr ? "VR" : "flat"})`,{skip:process.env.SHOCK2_E2E!=="1",timeout:180_000},async()=>{
+    await using game=await GameServer.launch({mission:"medsci1.mis",debugFlags:vr?["--vr"]:[]});
+    await game.step({frames:30});await game.player.spawnItem(-52);await game.input.trigger("ToggleUseMode");await game.step({frames:5});
+    const click=async(e:UiElement)=>{if(vr)await clickCanvasWithRay(game,requirePanelPose(await game.ui.state()),canvasCenter(e));else await clickUiElement(game,e);};
+    const button=async()=>{const e=(await game.ui.state()).strip!.elements.find(e=>e.label==="character_stats");assert.ok(e);return e;};
+    const capture=async(name:string)=>{const out=process.env.ASTRA_STATS_CAPTURE;if(!out)return;await mkdir(out,{recursive:true});const path=`${out}/${vr?"vr":"flat"}-${name}`;await game.screenshot(path+".png",1600);await writeFile(path+".json",JSON.stringify({ui:await game.ui.state(),info:await game.info()},null,2));};
+    await capture("idle");
+    const inventory=await game.player.inventory();const original=(await game.info()).player.stats;
+    await click(await button());assert.equal((await button()).texture?.toLowerCase(),"iface/ifbtn21.pcx");
+    await capture("base");await click(await button());assert.ok(!(await game.ui.state()).strip!.elements.some(e=>e.label==="character_stat"));
+    assert.deepEqual((await game.info()).player.stats,original);assert.deepEqual(await game.player.inventory(),inventory);
+    // Explicit debug fixture to expose every bar length; panel reads remain inert.
+    await game.player.setStats({strength:6,endurance:4,psionic_ability:2,agility:5,cyber_affinity:3});
+    const stats=(await game.info()).player.stats!;
+    await click(await button());
+    const labels=(await game.ui.state()).strip!.elements.filter(e=>e.label==="character_stat").map(e=>e.text);
+    assert.deepEqual(labels,[`STRENGTH ${stats.strength}`,`ENDURANCE ${stats.endurance}`,`PSIONICS ${stats.psionic_ability}`,`AGILITY ${stats.agility}`,`CYBER ${stats.cyber_affinity}`]);
+    await capture("varied");
+    const close=(await game.ui.state()).strip!.elements.find(e=>e.label==="utility_close");assert.ok(close);await click(close);
+    assert.ok(!(await game.ui.state()).strip!.elements.some(e=>e.label==="character_stat"));assert.equal((await game.ui.state()).mode,"use");
+    assert.deepEqual((await game.info()).player.stats,stats);assert.deepEqual(await game.player.inventory(),inventory);
+  });
+}


### PR DESCRIPTION
The native MFD button now opens a read-only character sheet in the original right-hand STATS panel. It shows the five trained base levels in retail order plus acquired OS upgrade icons and names. Opening, reading, and closing it never spends modules or changes carried items.

The shared canvas uses the original bar, trait, close-button, and IFBTN20/21 coordinates. Classic baked label bands are covered before drawing the same labels used with 25AE artwork. This first sheet shows base levels; temporary boost segments and TECH/CMBT/PSI pages remain separate work.

Validation: 61 focused Rust UI tests pass. Flat/VR runtime scenarios verify live values, varied 6/4/2/5/3 bar counts, toggle/close behavior, and unchanged character/inventory state. A real Tank purchase at an OS station was saved and loaded in VR to verify the acquired icon and name. Code/duplication reviews pass; final captures verify both presentations. Headset validation remains deferred.

![Native character statistics before and after](https://gist.githubusercontent.com/tommy-xr/93fc0367e87c37e284ebb4041f47b792/raw/astra-mfd-stats-before-after.png)

![Character statistics and acquired O/S trait in flat and VR](https://gist.githubusercontent.com/tommy-xr/93fc0367e87c37e284ebb4041f47b792/raw/astra-mfd-stats.gif)

Native STATS panel shows five live levels and matching arrows. Varied 6/4/2/5/3 values are an explicit debug fixture; Tank was acquired through the real MedSci2 O/S machine and its saved character loaded in VR. Toggle/close leave inventory and stats unchanged. Matched parent/current idle setup, discrete checkpoints, no headset validation.

![Native five-stat panel](https://gist.githubusercontent.com/tommy-xr/93fc0367e87c37e284ebb4041f47b792/raw/astra-mfd-stats-panel.png)

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/93fc0367e87c37e284ebb4041f47b792/raw/astra-mfd-stats-gallery.html)
