### PR TITLE
feat(vr): let low Strength pull a held rifle muzzle downward

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -765,7 +765,7 @@ Plot pitch and yaw separately from endpoint vertical and backward travel.
 Stock pistol and AR have zero authored heading kick: that is the current
 baseline, not evidence that horizontal handling has been implemented.
 
-## Next: weapon-specific one-handed handling
+## Handling design (implemented in the layers below)
 
 Keep the authored two-handed recoil baseline. Add an explicit VR one-handed
 angular handling profile: the AR should be harder to control than the pistol,
@@ -857,3 +857,34 @@ kicking backward. Actual support stays latched through the captured recoil and
 recovery; the tracked head remains fixed. [Comparison GIFs and raw muzzle
 measurements](https://gist.github.com/tommy-xr/bddb134ab070671f551e77acdf3a42df)
 separate pitch/yaw and endpoint motion from backward gun-body travel.
+
+
+## Optional downward gun weight
+
+Enable both experiments with
+`--experimental physical_held_items,physical_gun_weight` in VR. The weight flag
+is separate so headset testing can compare the same recoil with and without
+weight. At Strength 1, a horizontal one-handed AR has an 8-degree downward bias;
+the pistol has 1 degree. Multiply by `(6 - Strength) / 5` (Strength clamped 1–6),
+so Strength 3 gives 4.8 / 0.6 degrees and Strength 6 gives zero. Other weapons
+have no weight profile yet. Agility affects firing stability, not this bias.
+
+The spring target is world-down torque around the calibrated primary palm.
+Rolling the wrist does not turn gravity sideways; aiming vertically removes
+the horizontal lever arm. Three components of the world angular bias use the
+existing analytic spring, with a fixed 8-degree total bound. Strength changes
+and active support set a new equilibrium without resetting current displacement
+or velocity. A second hand removes the added load; the two-hand aiming system
+still determines the direction from the controllers.
+
+The weight rotation is applied to the physical held target around its scaled
+primary anchor before shot recoil and the existing translation sweep. The gun,
+gloves and live muzzle therefore share the result. Tracking inputs and the head
+are unchanged. As with the underlying held implementation, this does not add
+rotational collision sweeps. Weight is an intentional feel approximation, not
+real force feedback, fatigue, or a measured mass/centre-of-mass simulation.
+Transient spring state is recreated with the held body, including after load.
+
+Validation covers Strength 1/3/6, both AR hands, pistol, disabled flag, primary
+palm placement, smooth support/stat transitions, and shots returning to the
+weighted resting aim. Headset comfort and final angles remain device tuning.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -116,6 +116,11 @@ pub trait PlayerInteraction {
         false
     }
 
+    /// Primary palm anchor in scaled held-model coordinates, when fitted.
+    fn held_grip_anchor(&self, _entity: EntityId) -> Option<Vector3<f32>> {
+        None
+    }
+
     /// Entities under the reticle/hands, for the hover-highlight overlay.
     fn highlighted_entities(&self) -> Vec<EntityId>;
 
@@ -284,6 +289,11 @@ struct HeldGrip {
 }
 
 impl HeldGrip {
+    fn primary_anchor(&self, palm: Vector3<f32>) -> Option<Vector3<f32>> {
+        let grip = self.resolved.as_ref()?;
+        Some(grip.rotation.conjugate().rotate_vector(palm - grip.offset))
+    }
+
     /// Resolve the physical weapon pose, undoing melee's contact-origin split.
     fn physical_model_pose(&self, world: &World) -> Option<GripPose> {
         use shipyard::{Get, View};
@@ -376,10 +386,7 @@ impl VrInteraction {
             let base_rotation = poses[primary].rotation.normalize() * grip.rotation;
             let primary_palm = poses[primary].point(rig[primary].palm);
             // Scaled model-space anchors, independent of the melee contact-origin split.
-            let primary_anchor = grip
-                .rotation
-                .conjugate()
-                .rotate_vector(rig[primary].palm - grip.offset);
+            let primary_anchor = held.primary_anchor(rig[primary].palm)?;
             let handedness = if primary == 0 {
                 Handedness::Left
             } else {
@@ -1167,6 +1174,19 @@ impl PlayerInteraction for VrInteraction {
 
         left_msgs.append(&mut right_msgs);
         left_msgs
+    }
+
+    fn held_grip_anchor(&self, entity: EntityId) -> Option<Vector3<f32>> {
+        let rig = self.grip_kinematics.as_ref()?;
+        for (index, hand) in [&self.left_hand, &self.right_hand].into_iter().enumerate() {
+            if hand.get_held_entity() == Some(entity) {
+                let held = self.fitted_grips[index].as_ref()?;
+                return (held.entity == entity)
+                    .then(|| held.primary_anchor(rig[index].palm))
+                    .flatten();
+            }
+        }
+        None
     }
 
     fn is_supported(&self, entity: EntityId) -> bool {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4609,6 +4609,32 @@ impl MissionCore {
             }
         }
 
+        // Weight is an independent VR experiment. Configure the existing held
+        // drive after acquisition/fitting so all physics substeps share it.
+        let (left, right) = self.interaction.held_entities();
+        let strength = self
+            .world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|q| q.player_stats().strength)
+            .unwrap_or(1);
+        for gun in [left, right].into_iter().flatten() {
+            let target = game_options
+                .experimental_features
+                .contains("physical_gun_weight")
+                .then(|| self.interaction.held_grip_anchor(gun))
+                .flatten()
+                .and_then(|anchor| {
+                    crate::weapon_recoil::gun_weight_target(
+                        &self.world,
+                        gun,
+                        anchor,
+                        strength,
+                        self.interaction.is_supported(gun),
+                    )
+                });
+            self.physics.set_held_gun_weight(gun, target);
+        }
+
         // The physical VR reload: a clip carried into the other hand's weapon
         // loads it. Runs after the hands have been updated so the held pair is
         // this frame's.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2744,6 +2744,8 @@ pub struct PlayerHandle {
 /// authoritative rendered/contact body.
 #[derive(Clone, Copy)]
 struct HeldItemDrive {
+    weight: crate::weapon_recoil::GunWeightState,
+    weight_target: Option<crate::weapon_recoil::GunWeightTarget>,
     recoil: crate::weapon_recoil::RecoilState,
     one_hand_recoil: crate::weapon_recoil::RecoilState,
     target: RigidBodyHandle,
@@ -3267,6 +3269,8 @@ impl PhysicsWorld {
             self.held_item_drives.insert(
                 handle,
                 HeldItemDrive {
+                    weight: crate::weapon_recoil::GunWeightState::default(),
+                    weight_target: None,
                     recoil: crate::weapon_recoil::RecoilState::default(),
                     one_hand_recoil: crate::weapon_recoil::RecoilState::default(),
                     target,
@@ -3302,6 +3306,32 @@ impl PhysicsWorld {
         self.entity_id_to_body
             .get(&entity_id)
             .is_some_and(|handle| self.held_item_drives.contains_key(handle))
+    }
+
+    pub fn set_held_gun_weight(
+        &mut self,
+        entity: EntityId,
+        target: Option<crate::weapon_recoil::GunWeightTarget>,
+    ) {
+        if !self.is_held_inert(entity) {
+            return;
+        }
+        let handle = self.entity_id_to_body[&entity];
+        if let Some(drive) = self.held_item_drives.get_mut(&handle) {
+            drive.weight_target = target.filter(|t| {
+                [
+                    t.anchor.x,
+                    t.anchor.y,
+                    t.anchor.z,
+                    t.forward.x,
+                    t.forward.y,
+                    t.forward.z,
+                    t.degrees,
+                ]
+                .into_iter()
+                .all(f32::is_finite)
+            });
+        }
     }
 
     pub fn kick_held_gun(
@@ -4670,6 +4700,18 @@ impl PhysicsWorld {
                 continue;
             };
             if let Some(drive) = self.held_item_drives.get_mut(&weapon) {
+                if let Some(weight) = drive.weight_target {
+                    let anchor =
+                        desired.translation.vector + desired.rotation * vec_to_nvec(weight.anchor);
+                    let forward = nvec_to_cgmath(desired.rotation * vec_to_nvec(weight.forward));
+                    let rotation =
+                        drive
+                            .weight
+                            .step(self.integration_parameters.dt, forward, weight.degrees);
+                    desired.rotation = quat_to_nquat(rotation) * desired.rotation;
+                    desired.translation.vector =
+                        anchor - desired.rotation * vec_to_nvec(weight.anchor);
+                }
                 let (offset, rotation) = drive.recoil.step(self.integration_parameters.dt);
                 let (extra_offset, extra_rotation) =
                     drive.one_hand_recoil.step(self.integration_parameters.dt);

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -140,6 +140,27 @@ pub fn shot_impulse(world: &World, gun: EntityId) -> Option<(RecoilImpulse, Reco
     Some((authored, extra))
 }
 
+struct HandlingProfile {
+    pitch: f32,
+    yaw: f32,
+    rate: f32,
+    sag: f32,
+}
+
+fn handling_profile(model: &str) -> Option<HandlingProfile> {
+    let (pitch, yaw, rate, sag) = match model.to_ascii_lowercase().trim_end_matches(".bin") {
+        "atek_h" => (2.0, 0.75, 2.0, 1.0),
+        "ar15_h" => (8.0, 2.0, 1.0, 8.0),
+        _ => return None,
+    };
+    Some(HandlingProfile {
+        pitch,
+        yaw,
+        rate,
+        sag,
+    })
+}
+
 /// Deliberate VR tuning: forward-heavy rifles need more angular correction
 /// one-handed. This replaces the generic extra angular kick for these models;
 /// authored two-hand kick and the existing extra backward kick are preserved.
@@ -151,10 +172,11 @@ fn one_hand_impulse<R: Rng + ?Sized>(
     aiming: bool,
     rng: &mut R,
 ) -> RecoilImpulse {
-    let (pitch, yaw, rate) = match model.to_ascii_lowercase().trim_end_matches(".bin") {
-        "atek_h" => (2.0, 0.75, 2.0),
-        "ar15_h" => (8.0, 2.0, 1.0),
-        _ => return authored,
+    let Some(HandlingProfile {
+        pitch, yaw, rate, ..
+    }) = handling_profile(model)
+    else {
+        return authored;
     };
     RecoilImpulse {
         // Strength scales this later. Agility affects horizontal stability,
@@ -230,6 +252,16 @@ impl Spring {
         let peak = ((-4.0 * peak_time).exp() - (-10.0 * peak_time).exp()) / 6.0;
         self.velocity += amount * rate / peak;
     }
+    fn step_toward(&mut self, dt: f32, target: f32) {
+        if dt <= 0.0 || !dt.is_finite() {
+            return;
+        }
+        // Integrate error around a moving equilibrium with the same analytic
+        // spring as firing recoil. Preserve displacement and velocity on change.
+        self.position -= target;
+        self.step(dt, 1.0, f32::MAX);
+        self.position += target;
+    }
     fn step(&mut self, dt: f32, rate: f32, limit: f32) {
         if dt <= 0.0 || !dt.is_finite() {
             return;
@@ -243,6 +275,76 @@ impl Spring {
         if self.position.abs() > limit {
             self.position = self.position.clamp(-limit, limit);
             self.velocity = 0.0;
+        }
+    }
+}
+
+/// A continuously updated weight bias. The anchor is in scaled model space.
+#[derive(Clone, Copy, Debug)]
+pub struct GunWeightTarget {
+    pub anchor: Vector3<f32>,
+    pub forward: Vector3<f32>,
+    pub degrees: f32,
+}
+
+pub fn gun_weight_target(
+    world: &World,
+    gun: EntityId,
+    anchor: Vector3<f32>,
+    strength: i32,
+    supported: bool,
+) -> Option<GunWeightTarget> {
+    crate::mission::mission_core::held_item_collision_group(world, gun)?;
+    let models = world.borrow::<View<PropModelName>>().ok()?;
+    let profile = handling_profile(&models.get(gun).ok()?.0)?;
+    Some(GunWeightTarget {
+        anchor,
+        forward: crate::weapon_muzzle::resolve(world, gun).axis,
+        degrees: if supported {
+            0.0
+        } else {
+            profile.sag * (6 - strength.clamp(1, 6)) as f32 / 5.0
+        },
+    })
+}
+
+/// Spring the world-space angular bias, so rolled wrists still sag downward
+/// and pointing vertically smoothly removes the lever arm. This is a bounded
+/// handling approximation, not a calibrated mass/centre-of-mass simulation.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GunWeightState {
+    rotation: [Spring; 3],
+}
+impl GunWeightState {
+    pub fn step(
+        &mut self,
+        dt: f32,
+        forward: Vector3<f32>,
+        degrees: f32,
+    ) -> cgmath::Quaternion<f32> {
+        use cgmath::{Deg, Quaternion, Rotation3};
+        if ![forward.x, forward.y, forward.z, degrees]
+            .into_iter()
+            .all(f32::is_finite)
+            || forward.magnitude2() < 1e-8
+        {
+            return Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        }
+        let target = forward.normalize().cross(-Vector3::unit_y()) * degrees.clamp(0.0, 8.0);
+        let target = [target.x, target.y, target.z];
+        for (spring, target) in self.rotation.iter_mut().zip(target) {
+            spring.step_toward(dt, target);
+        }
+        let angle = vec3(
+            self.rotation[0].position,
+            self.rotation[1].position,
+            self.rotation[2].position,
+        );
+        let magnitude = angle.magnitude();
+        if magnitude < 1e-8 {
+            Quaternion::new(1.0, 0.0, 0.0, 0.0)
+        } else {
+            Quaternion::from_axis_angle(angle / magnitude, Deg(magnitude.min(8.0)))
         }
     }
 }
@@ -309,6 +411,50 @@ impl RecoilState {
 mod tests {
     use super::*;
     use rand::{SeedableRng, rngs::StdRng};
+    #[test]
+    fn weight_follows_world_gravity_and_smoothly_releases_without_frame_drift() {
+        use cgmath::Rotation;
+        for forward in [-Vector3::unit_x(), Vector3::unit_x(), -Vector3::unit_z()] {
+            let mut slow = GunWeightState::default();
+            let mut fast = GunWeightState::default();
+            for _ in 0..120 {
+                slow.step(1.0 / 60.0, forward, 8.0);
+            }
+            for _ in 0..240 {
+                fast.step(1.0 / 120.0, forward, 8.0);
+            }
+            let before = slow.step(0.0, forward, 8.0).rotate_vector(forward);
+            let other = fast.step(0.0, forward, 8.0).rotate_vector(forward);
+            assert!((before - other).magnitude() < 1e-5);
+            assert!((before.y + 8.0_f32.to_radians().sin()).abs() < 0.001);
+            // Stat/support changes change the target, not the current pose.
+            assert!(
+                (slow.step(0.0, forward, 0.0).rotate_vector(forward) - before).magnitude() < 1e-6
+            );
+            let first = slow.step(1.0 / 60.0, forward, 0.0).rotate_vector(forward);
+            assert!((first - before).magnitude() < 0.001);
+            for _ in 0..240 {
+                slow.step(1.0 / 60.0, forward, 0.0);
+            }
+            assert!(
+                (slow.step(0.0, forward, 0.0).rotate_vector(forward) - forward).magnitude() < 1e-5
+            );
+        }
+        for forward in [Vector3::unit_y(), -Vector3::unit_y()] {
+            let mut state = GunWeightState::default();
+            assert_eq!(
+                state.step(1.0, forward, 8.0).rotate_vector(forward),
+                forward
+            );
+        }
+        let mut state = GunWeightState::default();
+        for i in 0..1000 {
+            let forward = vec3((i as f32).sin(), 0.0, (i as f32).cos());
+            let q = state.step(1.0 / 60.0, forward, 8.0);
+            assert!(q.s.is_finite() && q.v.magnitude() <= (4.0_f32.to_radians()).sin() + 1e-6);
+        }
+    }
+
     #[test]
     fn one_hand_profiles_separate_vertical_load_from_agility_and_preserve_baseline() {
         let authored = RecoilImpulse {

--- a/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer, type Vec3 } from "../src/index.js";
+import {
+  add,
+  sub,
+  aimVrHandAt,
+  quatConjugate,
+  quatFromTo,
+  quatMultiply,
+  quatRotate,
+  type Quat,
+} from "./helpers/vr-hand.js";
+import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
+
+for (const [name, template, sag, enabled, hand] of [
+  ["pistol", -17, 1, true, "right"],
+  ["AR", -18, 8, true, "right"],
+  ["AR left hand", -18, 8, true, "left"],
+  ["AR without weight flag", -18, 0, false, "right"],
+] as const) {
+  test(
+    `${name}: Strength and support remove downward weight around the palm`,
+    { skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000 },
+    async (context) => {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        debugFlags: [
+          "--vr",
+          "--experimental",
+          enabled
+            ? "physical_held_items,physical_gun_weight"
+            : "physical_held_items",
+        ],
+      });
+      await game.step({ frames: 10 });
+      await game.player.setStats({ skills: { standard_weapons: 6 } });
+      const gun = await cycleToWeapon(game, (e) => e.template_id === template, {
+        settleFrames: 90,
+      });
+      const other = hand === "right" ? "left" : "right";
+      await aimVrHandAt(game, gun.position!, 0.45, 1, 0, { hand });
+      await game.step({ frames: 8 });
+      assert.equal(
+        (await game.info()).player[
+          hand === "left" ? "wielded_entity_id" : "right_hand_entity_id"
+        ],
+        gun.id,
+      );
+      await game.input.set("head.rotation", [0, 0, 0, 1]);
+      await game.input.set(`${hand}_hand.position`, [0, 1, 0]);
+      await game.input.set(`${hand}_hand.rotation`, [
+        0,
+        Math.SQRT1_2,
+        0,
+        Math.SQRT1_2,
+      ]);
+      await game.step({ frames: 300 });
+      const head = (await game.info()).player.camera_rotation;
+      const muzzle = async () =>
+        muzzleFrameOf(await game.entities.detail(gun.id));
+      const pitch = async () =>
+        (Math.asin((await muzzle()).forward[1]) * 180) / Math.PI;
+      const socket = async () =>
+        (await game.info()).player.hand_grips.find((g) => g.hand === hand)!
+          .support!;
+      const palmIsAnchored = async () => {
+        const s = await socket();
+        const a = s.primary_palm,
+          b = s.visible_primary_palm;
+        assert.ok(
+          Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z) < 0.002,
+          "weight rotates around the primary palm",
+        );
+        assert.deepEqual((await game.info()).player.camera_rotation, head);
+      };
+      for (const strength of [1, 3, 6]) {
+        const previous = await pitch();
+        await game.player.setStats({ strength });
+        await game.step({ frames: 1 });
+        assert.ok(
+          Math.abs((await pitch()) - previous) < 0.5,
+          "Strength changes must not snap the gun",
+        );
+        await game.step({ frames: 300 });
+        const expected = (-sag * (6 - strength)) / 5;
+        assert.ok(
+          Math.abs((await pitch()) - expected) < 0.05,
+          `Strength ${strength}: expected ${expected}, got ${await pitch()}`,
+        );
+        await palmIsAnchored();
+        context.diagnostic(
+          JSON.stringify({ name, strength, pitch: await pitch() }),
+        );
+        if (strength !== 1 || !enabled) continue;
+
+        // Acquire the actual lowered fore-end first, then lift it to level.
+        // On the AR the neutral socket is outside the sagged socket's grab
+        // radius. Resolve both poses from the live barrel and primary palm.
+        const s = await socket();
+        const player = (await game.info()).player;
+        const level = quatFromTo((await muzzle()).forward, [-1, 0, 0]);
+        const anchor: Vec3 = [
+          s.primary_palm.x,
+          s.primary_palm.y,
+          s.primary_palm.z,
+        ];
+        const p: Vec3 = [
+          s.controller_position.x,
+          s.controller_position.y,
+          s.controller_position.z,
+        ];
+        const q = s.controller_rotation;
+        const inverse = quatConjugate(player.rotation);
+        await game.input.set(
+          `${other}_hand.position`,
+          quatRotate(inverse, sub(p, player.position)),
+        );
+        await game.input.set(
+          `${other}_hand.rotation`,
+          quatMultiply(inverse, [q.v.x, q.v.y, q.v.z, q.s] as Quat),
+        );
+        await game.input.set(`${other}_hand.squeeze`, 1);
+        await game.step({ frames: 1 });
+        assert.equal(
+          (await socket()).attached,
+          true,
+          "acquire the live lowered support socket",
+        );
+        await game.input.set(
+          `${other}_hand.position`,
+          quatRotate(
+            inverse,
+            sub(
+              add(anchor, quatRotate(level, sub(p, anchor))),
+              player.position,
+            ),
+          ),
+        );
+        await game.input.set(
+          `${other}_hand.rotation`,
+          quatMultiply(
+            inverse,
+            quatMultiply(level, [q.v.x, q.v.y, q.v.z, q.s] as Quat),
+          ),
+        );
+        await game.input.set(`${other}_hand.squeeze`, 1);
+        let last = await pitch();
+        for (let frame = 0; frame < 30; frame++) {
+          await game.step({ frames: 1 });
+          const current = await pitch();
+          assert.ok(
+            // Shared support aiming interpolates with a 60 ms time constant:
+            // lifting the controller by 8 degrees can move about 2 degrees
+            // in one 60 Hz frame, independently of the slower weight spring.
+            Math.abs(current - last) < 3,
+            `support must interpolate, not apply the whole lift at once: ${last} -> ${current}`,
+          );
+          last = current;
+        }
+        assert.equal((await socket()).attached, true);
+        await game.step({ frames: 300 });
+        assert.ok(
+          Math.abs(await pitch()) < 0.1,
+          `support removes sag: ${await pitch()}`,
+        );
+        await palmIsAnchored();
+        await game.input.set(`${other}_hand.squeeze`, 0);
+        last = await pitch();
+        for (let frame = 0; frame < 30; frame++) {
+          await game.step({ frames: 1 });
+          const current = await pitch();
+          assert.ok(
+            Math.abs(current - last) < 1,
+            "releasing support eases weight back in",
+          );
+          last = current;
+        }
+        await game.step({ frames: 300 });
+        assert.ok(Math.abs((await pitch()) + sag) < 0.05);
+        await palmIsAnchored();
+
+        const ammo = ammoOf(await game.entities.detail(gun.id));
+        const before = await pitch();
+        await game.input.set(`${hand}_hand.trigger`, 1);
+        let peak = before;
+        for (let frame = 0; frame < 30; frame++) {
+          await game.step({ frames: 1 });
+          if (frame === 0) await game.input.set(`${hand}_hand.trigger`, 0);
+          peak = Math.max(peak, await pitch());
+        }
+        assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+        assert.ok(
+          peak > before + 1,
+          "shot recoil remains visible above the downward weight bias",
+        );
+        await game.step({ frames: 300 });
+        assert.ok(
+          Math.abs((await pitch()) - before) < 0.05,
+          "recoil returns to the weighted rest pose",
+        );
+        await palmIsAnchored();
+      }
+    },
+  );
+}


### PR DESCRIPTION
Add optional downward weight for one-handed guns: at Strength 1 a horizontal AR sags 8 degrees around the primary palm, while the pistol sags 1 degree. Higher Strength reduces the bias linearly to zero at 6; an active second-hand grip removes the added load. World-space springs ease transitions and keep gravity pointing down when the wrist rolls.

Enable with `--vr --experimental physical_held_items,physical_gun_weight`. The separate weight flag allows comparison with the same firing recoil. The physical gun, gloves and live muzzle share the weighted pose; the tracked head remains unchanged. Unprofiled guns have no weight bias yet. This is initial VR handling tuning, not measured mass or force feedback; headset feel remains to be validated.

Validation: 10 recoil/weight unit tests and 6 interaction tests passed; warnings-as-errors checks and SDK build passed. Runtime scenarios cover pistol and both AR hands at Strength 1/3/6, actual support acquisition/lifting/release, palm anchoring, fixed head, firing above the weight bias and recovery to weighted rest. The disabled-flag scenario stays level. Independent source, duplication and visual reviews completed. Existing rotation-only wall penetration remains a limitation of the underlying translation sweep.

![ar-s1-right Strength progression](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/ar-s1-right-comparison.gif)

![ar-s1-right Strength 1 before/after](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/ar-s1-right-strength1.png)

![ar-s1-left Strength progression](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/ar-s1-left-comparison.gif)

![ar-s1-left Strength 1 before/after](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/ar-s1-left-strength1.png)

![pistol-s1-right Strength progression](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/pistol-s1-right-comparison.gif)

![pistol-s1-right Strength 1 before/after](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/pistol-s1-right-strength1.png)

![Measured idle pitch](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/weight-pitch.png)

Fixed tracked hand/head, no firing. Same requests on parent and current builds with both experimental flags. Strength changes 1→3→6; AR sag starts at8°, pistol1°, and eases to level. Measured primary-palm error stays below0.000002 world units.

[CSV](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/weight-traces.csv) · [Measured summary](https://gist.githubusercontent.com/tommy-xr/336fe8682717d14edcebe5f3e472020a/raw/800b7b4e65b8442fb4bd6a931e0a9a8c40f5c6ac/weight-summary.json)
