### PR TITLE
fix(ui): use correctly scoped high-resolution object icons

### DIFF
--- a/dark/src/util/mod.rs
+++ b/dark/src/util/mod.rs
@@ -56,6 +56,30 @@ pub fn resolve_texture_name(asset_cache: &AssetCache, requested: &str) -> Option
     Some(resolved)
 }
 
+/// Resolve icon art without the model-texture `txt16/` search. Object icons
+/// prefer their family before considering legacy bare names (also used for
+/// report portraits). An explicitly qualified request stays in that family.
+/// Within a family, preserve mod precedence and prefer DDS/PNG over PCX.
+pub fn resolve_object_icon_name(asset_cache: &AssetCache, requested: &str) -> Option<String> {
+    let stem = Path::new(requested).with_extension("");
+    let stem = stem.to_str()?.to_ascii_lowercase();
+    let resolve = |stem: &str| {
+        let candidates = engine::texture_format::DECODABLE_EXTENSIONS
+            .iter()
+            .map(|ext| format!("{stem}.{ext}"))
+            .collect::<Vec<_>>();
+        asset_cache
+            .asset_paths()
+            .resolve_first(asset_cache.base_path().to_owned(), &candidates)
+    };
+    if !stem.contains('/') {
+        if let Some(name) = resolve(&format!("objicon/{stem}")) {
+            return Some(name);
+        }
+    }
+    resolve(&stem)
+}
+
 /// Resolve the diffuse texture used by a Dark LGMD object material.
 ///
 /// 25th Anniversary replacement models can attach a `.mtl` render-material
@@ -415,6 +439,40 @@ mod tests {
             .map(|(name, bytes)| ((*name).to_owned(), bytes.to_vec()))
             .collect();
         AssetCache::new(String::new(), Box::new(FakeAssetPath(assets)))
+    }
+
+    #[test]
+    fn ui_icons_prefer_their_family_and_high_resolution_encoding() {
+        let assets = cache(&[
+            ("disc.dds", b"model texture"),
+            ("disc.pcx", b"model texture"),
+            ("objicon/disc.pcx", b"classic icon"),
+            ("objicon/disc.png", b"remastered icon"),
+            ("iface/frame.pcx", b"classic frame"),
+            ("iface/frame.dds", b"remastered frame"),
+            ("mport.pcx", b"legacy portrait"),
+        ]);
+        assert_eq!(
+            super::resolve_object_icon_name(&assets, "DISC.PCX").as_deref(),
+            Some("objicon/disc.png")
+        );
+        assert_eq!(
+            super::resolve_object_icon_name(&assets, "iface/frame.pcx").as_deref(),
+            Some("iface/frame.dds")
+        );
+        assert_eq!(
+            super::resolve_object_icon_name(&assets, "mport.pcx").as_deref(),
+            Some("mport.pcx")
+        );
+        assert_eq!(
+            super::resolve_object_icon_name(&assets, "iface/disc.pcx"),
+            None
+        );
+        let classic = cache(&[("objicon/disc.pcx", b"classic icon")]);
+        assert_eq!(
+            super::resolve_object_icon_name(&classic, "disc.png").as_deref(),
+            Some("objicon/disc.pcx")
+        );
     }
 
     #[test]

--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -133,3 +133,22 @@ in classic and 25AE artwork so the HD art's removed labels remain readable.
 This first sheet reports base levels, not temporary boosted-stat segments.
 Upgrade purchases remain at trainers. TECH/CMBT/PSI pages and their navigation
 controls are deferred; no inactive tabs are presented as working controls.
+
+## UI bitmap resolution
+
+Object-icon elements first resolve the `objicon/` family, preventing names such
+as `DISC` from selecting the unrelated model texture in `obj/txt16`. Both classic
+CRF and anniversary KPF mounts expose that namespace. Legacy non-object previews
+may still use bare names when no object icon exists; explicit family paths remain
+explicit.
+
+For object icons, the shared canvas chooses DDS/PNG variants before PCX within
+each mount, retaining
+mod-layer priority. Replacement texel dimensions do not enlarge inventory icons:
+when available, the same family's classic PCX supplies their authored layout size.
+Both flat and VR then draw the same resolved image into the same rectangle.
+
+Ordinary panel backgrounds and controls keep their requested encoding. The HD
+variants omit baked labels such as MAP, INVENTORY, EQUIP, and RESEARCH; upgrading
+those safely requires separately emitted labels first. Do not globally substitute
+PNG/DDS for these bitmaps based on filename alone.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -255,8 +255,8 @@ fn mod_layer_may_override(family: &str, archive: &str) -> bool {
 /// Mount one resource family, matching the options its `.crf` counterpart uses.
 ///
 /// `strings` must not collapse basenames (translated tables share them), and
-/// `iface` and `bitmap` register family-qualified keys because their basenames
-/// collide with object textures. Getting these wrong is silent: the wrong
+/// `iface`, `bitmap`, and `objicon` register family-qualified keys because
+/// their basenames collide with object textures. Getting these wrong is silent: the wrong
 /// string table or the wrong texture simply resolves first.
 fn mount_family(
     archive: String,
@@ -265,7 +265,9 @@ fn mount_family(
 ) -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
     match family {
         "strings" => ZipAssetPath::with_prefix_opts(archive, prefix, false, None),
-        "iface" | "bitmap" => ZipAssetPath::with_prefix_opts(archive, prefix, true, Some(family)),
+        "iface" | "bitmap" | "objicon" => {
+            ZipAssetPath::with_prefix_opts(archive, prefix, true, Some(family))
+        }
         _ => ZipAssetPath::with_prefix(archive, prefix),
     }
 }
@@ -363,7 +365,7 @@ pub fn game_asset_mounts(
             ZipAssetPath::new(resource_path("res/intrface.crf")),
             ZipAssetPath::new(resource_path("res/mesh.crf")),
             ZipAssetPath::new(resource_path("res/motions.crf")),
-            ZipAssetPath::new(resource_path("res/objicon.crf")),
+            ZipAssetPath::with_namespace(resource_path("res/objicon.crf"), "objicon"),
             ZipAssetPath::new(resource_path("res/snd.crf")),
             ZipAssetPath::new(resource_path("res/snd2.crf")),
             ZipAssetPath::new(resource_path("res/song.crf")),
@@ -2549,42 +2551,51 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn particle_bitmap_namespace_avoids_object_texture_collisions() {
-        for prefix in ["", "data/res/bitmap/", "bitmap/"] {
-            let root = crate::test_support::TempDir::new("particle-bitmap-family");
-            let object_archive = root.path().join("obj.zip");
-            let bitmap_archive = root.path().join("bitmap.zip");
-            let sprite = format!("{prefix}BLOOD.PCX");
-            crate::test_support::write_archive(
-                &object_archive,
-                &[("obj/txt16/BLOOD.PCX", b"red object blood")],
-            );
-            crate::test_support::write_archive(
-                &bitmap_archive,
-                &[(&sprite, b"blue particle glow")],
-            );
-            let mounts = AssetPath::combine(vec![
-                ZipAssetPath::with_prefix(object_archive.to_string_lossy().into_owned(), "obj/"),
-                mount_family(
-                    bitmap_archive.to_string_lossy().into_owned(),
-                    prefix,
-                    "bitmap",
-                ),
-            ]);
-            for (name, expected) in [
-                ("blood.pcx", "red object blood"),
-                ("bitmap/blood.pcx", "blue particle glow"),
+    fn sprite_namespaces_avoid_object_texture_collisions() {
+        for family in ["bitmap", "objicon"] {
+            for prefix in [
+                String::new(),
+                format!("data/res/{family}/"),
+                format!("{family}/"),
             ] {
-                let reader = mounts
-                    .get_reader(String::new(), name.to_owned())
-                    .expect("qualified bitmap must resolve");
-                let mut bytes = Vec::new();
-                reader.borrow_mut().read_to_end(&mut bytes).unwrap();
-                assert_eq!(
-                    bytes,
-                    expected.as_bytes(),
-                    "wrong family for {name} in {prefix}"
+                let root = crate::test_support::TempDir::new("particle-bitmap-family");
+                let object_archive = root.path().join("obj.zip");
+                let bitmap_archive = root.path().join("bitmap.zip");
+                let sprite = format!("{prefix}BLOOD.PCX");
+                crate::test_support::write_archive(
+                    &object_archive,
+                    &[("obj/txt16/BLOOD.PCX", b"red object blood")],
                 );
+                crate::test_support::write_archive(
+                    &bitmap_archive,
+                    &[(&sprite, b"blue particle glow")],
+                );
+                let mounts = AssetPath::combine(vec![
+                    ZipAssetPath::with_prefix(
+                        object_archive.to_string_lossy().into_owned(),
+                        "obj/",
+                    ),
+                    mount_family(
+                        bitmap_archive.to_string_lossy().into_owned(),
+                        &prefix,
+                        family,
+                    ),
+                ]);
+                for (name, expected) in [
+                    ("blood.pcx".to_owned(), "red object blood"),
+                    (format!("{family}/blood.pcx"), "blue particle glow"),
+                ] {
+                    let reader = mounts
+                        .get_reader(String::new(), name.to_owned())
+                        .expect("qualified bitmap must resolve");
+                    let mut bytes = Vec::new();
+                    reader.borrow_mut().read_to_end(&mut bytes).unwrap();
+                    assert_eq!(
+                        bytes,
+                        expected.as_bytes(),
+                        "wrong family for {name} in {prefix}"
+                    );
+                }
             }
         }
     }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -1029,8 +1029,32 @@ fn place_image(
     alpha: f32,
     kind: ImageKind,
 ) -> PlacedElement {
-    let loaded = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(kind));
-    let (position, size) = drawn_rect(position, size, texture_px(&loaded), kind);
+    // Upgrade object icons, whose art is self-contained. Ordinary UI bitmaps
+    // may contain baked labels that HD replacements omit (MAP/RESEARCH/etc.),
+    // so keep their requested encoding until their labels are drawn separately.
+    let texture = if kind.transparent_index_0() {
+        dark::util::resolve_object_icon_name(asset_cache, texture)
+            .unwrap_or_else(|| texture.to_owned())
+    } else {
+        texture.to_owned()
+    };
+    let loaded = asset_cache.get_ext(&TEXTURE_IMPORTER, &texture, &texture_options(kind));
+    // Replacement icons have more texels, not a larger inventory footprint.
+    // Keep the classic bitmap's authored size while drawing the upgraded art.
+    let authored = if matches!(kind, ImageKind::ObjectIcon | ImageKind::ObjectIconFit) {
+        let original = std::path::Path::new(&texture).with_extension("pcx");
+        asset_cache
+            .get_ext_opt(
+                &TEXTURE_IMPORTER,
+                original.to_str().unwrap(),
+                &texture_options(kind),
+            )
+            .map(|original| texture_px(&original))
+            .unwrap_or_else(|| texture_px(&loaded))
+    } else {
+        texture_px(&loaded)
+    };
+    let (position, size) = drawn_rect(position, size, authored, kind);
     PlacedElement {
         rect: Rect::new(position.x, position.y, size.x, size.y),
         alpha,


### PR DESCRIPTION
The cyber-interface log control and inventory object icons could resolve bare names such as `DISC.PCX` to model textures from `obj/txt16`. Object-icon drawing now prefers the `objicon/` family, exposed by both classic CRF and anniversary KPF mounts, so the log control uses the blue disk-case icon.

Within the correct family, DDS/PNG replacements take precedence over PCX while preserving mod-layer priority. Replacement icons keep their classic PCX layout dimensions: the 64×64 anniversary disk occupies the original 32×32 footprint. Resolution happens in shared canvas placement for both flat and VR.

This upgrade is deliberately limited to object icons. The HD panel backdrops omit baked labels such as MAP, INVENTORY, EQUIP, and RESEARCH; those panels retain their requested artwork until their labels are drawn separately.

Validation: 223 focused UI tests, the icon-family/encoding regression, and classic/base-KPF/mod-KPF namespace tests passed. Matching flat/VR captures verify the native disk control and a provisioned inventory hypo; they do not claim an audio log was placed into ordinary inventory (the provisioning API correctly rejects that non-pickup item). Research captures verify panel captions and specimen/report layout. Code and duplication reviews passed. No headset validation.

![Object icon family and modern format comparison](https://gist.githubusercontent.com/tommy-xr/82c193e4fc5cb7644a22bbd20ba5fbb6/raw/astra-ui-art.gif)

Matched flat/VR MedSci1 captures show the correct disk-case Logs icon and sharper inventory hypo. PNG/DDS preference applies to object icons; native panel artwork keeps its labels. The hypo is provisioned through the debug inventory API. Audio logs are not ordinary inventory items, so no inventory-disk placement is claimed.

![Flat before and after](https://gist.githubusercontent.com/tommy-xr/82c193e4fc5cb7644a22bbd20ba5fbb6/raw/astra-ui-art-flat-before-after.png)

![VR before and after](https://gist.githubusercontent.com/tommy-xr/82c193e4fc5cb7644a22bbd20ba5fbb6/raw/astra-ui-art-vr-before-after.png)

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/82c193e4fc5cb7644a22bbd20ba5fbb6/raw/astra-ui-art-gallery.html), including final research specimen/report and log-reader screenshots. No headset validation.
