### PR TITLE
feat(vr): give shotgun modes one-handed pitch and yaw recoil

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -829,13 +829,13 @@ units. Both modes author zero heading kick. The pitch return/limit ratio is
 at 60 Hz to verify recovery. The three-shell mode uses its authored larger
 impulse once per firing event, rather than multiplying recoil by pellet count.
 
-The shotgun currently uses the generic extra one-handed spring: at Strength 1,
+At the #1482 baseline, the shotgun used the generic extra one-handed spring: at Strength 1,
 one hand doubles its authored impulse, while two hands retain the baseline.
 Its normal-mode backward kick is already about 1.7 times the pistol's and
 2.4 times the AR's. The dedicated pistol/AR angular profiles do not apply to
-the shotgun: horizontal kick remains zero, and Agility 6 suppresses its angular
-kick even one-handed. A dedicated shotgun handling profile remains a separate
-tuning gap; this evaluation records the existing behavior without inventing one.
+the shotgun in that baseline: horizontal kick is zero, and Agility 6 suppresses
+its angular kick even one-handed. The dedicated profile below closes this gap;
+the baseline measurements remain here for comparison.
 
 The runtime matrix checks correct one/three-shell consumption, reloads through
 the normal ammo path, verifies support and fixed head pose, and samples the
@@ -888,3 +888,21 @@ Transient spring state is recreated with the held body, including after load.
 Validation covers Strength 1/3/6, both AR hands, pistol, disabled flag, primary
 palm placement, smooth support/stat transitions, and shots returning to the
 weighted resting aim. Headset comfort and final angles remain device tuning.
+
+
+## Dedicated shotgun one-handed handling
+
+The measured shotgun evaluation above is the baseline. Add a dedicated extra
+angular profile while preserving its authored backward kick and supported
+recoil. Normal mode adds up to 12 degrees of pitch and ±3 degrees of yaw;
+three-shell mode adds up to 24 degrees and ±4.5 degrees. Each samples 50–100%
+of its peak before modifiers, with the shotgun's slower angular spring rate
+of 0.5. Extra pitch/yaw caps are twice those profile magnitudes.
+
+Strength reduces both extra axes through the established one-handed curve.
+Agility reduces horizontal recoil, while the extra vertical response remains
+at Agility 6. Still Hand suppresses angular recoil and the aiming implant
+reduces it. Support removes new extra impulses while existing recoil settles.
+The original kickback, pitch baseline, ammo consumption and pellet behavior
+remain unchanged. These are initial VR handling values requiring headset tuning.
+The optional shotgun weight profile follows as a separate increment.

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -131,7 +131,7 @@ pub fn shot_impulse(world: &World, gun: EntityId) -> Option<(RecoilImpulse, Reco
     let model = world.borrow::<View<PropModelName>>().ok()?;
     let extra = one_hand_impulse(
         authored,
-        &model.get(gun).ok()?.0,
+        handling_profile(&model.get(gun).ok()?.0, setting),
         agility,
         still_hand,
         aiming,
@@ -147,10 +147,15 @@ struct HandlingProfile {
     sag: f32,
 }
 
-fn handling_profile(model: &str) -> Option<HandlingProfile> {
-    let (pitch, yaw, rate, sag) = match model.to_ascii_lowercase().trim_end_matches(".bin") {
-        "atek_h" => (2.0, 0.75, 2.0, 1.0),
-        "ar15_h" => (8.0, 2.0, 1.0, 8.0),
+fn handling_profile(model: &str, setting: i32) -> Option<HandlingProfile> {
+    let model = model.to_ascii_lowercase();
+    let (pitch, yaw, rate, sag) = match (model.trim_end_matches(".bin"), setting) {
+        ("atek_h", _) => (2.0, 0.75, 2.0, 1.0),
+        ("ar15_h", _) => (8.0, 2.0, 1.0, 8.0),
+        // Shotgun modes preserve their heavy backward kick, but add explicit
+        // angular handling independent of Agility's vertical suppression.
+        ("sg_h", 1) => (24.0, 4.5, 0.5, 0.0),
+        ("sg_h", _) => (12.0, 3.0, 0.5, 0.0),
         _ => return None,
     };
     Some(HandlingProfile {
@@ -161,12 +166,12 @@ fn handling_profile(model: &str) -> Option<HandlingProfile> {
     })
 }
 
-/// Deliberate VR tuning: forward-heavy rifles need more angular correction
+/// Deliberate VR tuning: forward-heavy long guns need more angular correction
 /// one-handed. This replaces the generic extra angular kick for these models;
 /// authored two-hand kick and the existing extra backward kick are preserved.
 fn one_hand_impulse<R: Rng + ?Sized>(
     authored: RecoilImpulse,
-    model: &str,
+    profile: Option<HandlingProfile>,
     agility: i32,
     still_hand: bool,
     aiming: bool,
@@ -174,7 +179,7 @@ fn one_hand_impulse<R: Rng + ?Sized>(
 ) -> RecoilImpulse {
     let Some(HandlingProfile {
         pitch, yaw, rate, ..
-    }) = handling_profile(model)
+    }) = profile
     else {
         return authored;
     };
@@ -296,7 +301,7 @@ pub fn gun_weight_target(
 ) -> Option<GunWeightTarget> {
     crate::mission::mission_core::held_item_collision_group(world, gun)?;
     let models = world.borrow::<View<PropModelName>>().ok()?;
-    let profile = handling_profile(&models.get(gun).ok()?.0)?;
+    let profile = handling_profile(&models.get(gun).ok()?.0, 0)?;
     Some(GunWeightTarget {
         anchor,
         forward: crate::weapon_muzzle::resolve(world, gun).axis,
@@ -471,13 +476,53 @@ mod tests {
         let extra = |model, agility, still| {
             one_hand_impulse(
                 authored,
-                model,
+                handling_profile(model, 0),
                 agility,
                 still,
                 false,
                 &mut StdRng::seed_from_u64(7),
             )
         };
+        let shotgun = |setting, agility, still, aiming| {
+            one_hand_impulse(
+                authored,
+                handling_profile("sg_h", setting),
+                agility,
+                still,
+                aiming,
+                &mut StdRng::seed_from_u64(7),
+            )
+        };
+        let normal = shotgun(0, 1, false, false);
+        let triple = shotgun(1, 1, false, false);
+        assert!((triple.pitch / normal.pitch - 2.0).abs() < 0.01);
+        assert!((triple.heading / normal.heading - 1.5).abs() < 0.01);
+        for setting in [0, 1] {
+            let low = shotgun(setting, 1, false, false);
+            let agile = shotgun(setting, 6, false, false);
+            assert_eq!(low.pitch, agile.pitch);
+            assert_eq!(agile.heading, 0.0);
+            assert!(low.heading.abs() > 0.0);
+            assert_eq!(low.back, authored.back);
+            assert_eq!(low.back_limit, authored.back_limit);
+            assert_eq!(low.back_rate, authored.back_rate);
+            let still = shotgun(setting, 1, true, false);
+            assert_eq!((still.pitch, still.heading), (0.0, 0.0));
+            assert!(shotgun(setting, 1, false, true).pitch < low.pitch);
+            let (_, stronger) = vr_impulses(authored, low, 6, false);
+            assert!(stronger.unwrap().pitch < low.pitch);
+            let (supported, extra) = vr_impulses(authored, low, 1, true);
+            assert!(extra.is_none());
+            assert_eq!(supported.pitch, authored.pitch);
+            assert_eq!(supported.back, authored.back);
+            let mut spring = RecoilState::default();
+            for _ in 0..300 {
+                spring.kick(low);
+                spring.step(1.0 / 60.0);
+                assert!(spring.pitch.position.abs() <= low.pitch_limit);
+                assert!(spring.heading.position.abs() <= low.heading_limit);
+            }
+        }
         let pistol = extra("atek_h", 1, false);
         let ar = extra("ar15_h", 1, false);
         assert!(ar.pitch > pistol.pitch * 3.9);
@@ -498,7 +543,7 @@ mod tests {
         let low = vr_impulses(authored, ar, 1, false).1.unwrap();
         let high = vr_impulses(authored, ar, 6, false).1.unwrap();
         assert!(high.pitch < low.pitch && high.heading.abs() < low.heading.abs());
-        assert_eq!(extra("sg_h", 1, false).pitch, authored.pitch);
+        assert_eq!(extra("fsn_h", 1, false).pitch, authored.pitch);
         let mut state = RecoilState::default();
         for _ in 0..200 {
             state.kick(ar);

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -16,8 +16,8 @@ import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
 for (const [name, template, profiled, setting] of [
   ["pistol", -17, true, 0],
   ["AR", -18, true, 0],
-  ["shotgun", -19, false, 0],
-  ["shotgun-triple", -19, false, 1],
+  ["shotgun", -19, true, 0],
+  ["shotgun-triple", -19, true, 1],
 ] as const) {
   test(
     `${name} recoil decreases with Strength and genuine support removes the extra spring`,


### PR DESCRIPTION
One-handed shotgun fire previously had no horizontal recoil, and Agility 6 removed all angular kick. Add dedicated normal and three-shell angular profiles: Strength reduces both extra axes, while Agility improves horizontal stability without eliminating vertical kick. Normal adds up to 12 degrees pitch/3 yaw; three-shell adds 24/4.5, using the shotgun's slower spring response.

The authored backward kick and supported baseline remain unchanged. Still Hand and aiming modifiers remain effective; profile caps bound repeated impulses. Shotgun weight is left at zero for the next separate layer.

Validation: 10 recoil/weight unit tests, SDK build and warnings-as-errors checks passed. All 12 shotgun Strength/grip combinations plus4 Agility6 cases passed, including ammo/reload, yaw, retained vertical recoil, fixed head, backward scaling and recovery. Every backward peak matches the previous evaluation. Independent source, duplication and visual reviews found no actionable issues. No Quest was connected; these are initial VR tuning values.

![Agility 6 retains vertical shotgun kick](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/agility6-shotgun-comparison.gif)

![Agility 6 matched peak](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/agility6-shotgun-peak.png)

Agility 6, Strength 1: parent pitch/yaw 0°/0°; current sampled pitch 7.079° with yaw still 0°. Body kickback remains exactly 0.479925 world units.

![shotgun Agility 1 matched firing](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun-comparison.gif)

![shotgun matched peak](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun-peak.png)

![shotgun-triple Agility 1 matched firing](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun-triple-comparison.gif)

![shotgun-triple matched peak](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun-triple-peak.png)

![Separate measured pitch yaw and endpoint travel](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/muzzle-pitch-yaw.png)

Same fixed controllers, head and widened camera; no idle weight. Normal consumes 1 round, triple 3. Agility 1 angular samples are independently randomized, so individual before/after pitch magnitudes are not an exact ordering test.

[CSV](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/muzzle-traces.csv) · [SVG](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/muzzle-pitch-yaw.svg) · [Capture summary](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/capture-summary.json) · [Normal raw](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun.json) · [Triple raw](https://gist.githubusercontent.com/tommy-xr/1bd448eff04d5bde4f2c89e1cc73a3b9/raw/ad74615f904f1074152e62d75c1aa8f2a4c7d5da/shotgun-triple.json)
