### PR TITLE
feat(vr): add optional downward weight to the held shotgun

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -906,3 +906,20 @@ reduces it. Support removes new extra impulses while existing recoil settles.
 The original kickback, pitch baseline, ammo consumption and pellet behavior
 remain unchanged. These are initial VR handling values requiring headset tuning.
 The optional shotgun weight profile follows as a separate increment.
+
+
+## Optional shotgun weight
+
+Extend `physical_gun_weight` to the shotgun with the same 8-degree maximum
+one-handed bias as the AR. At Strength 1/3/6, a horizontal shotgun settles at
+8/4.8/0 degrees downward. Both fire modes share the same weight because the
+held model has not changed. Active support removes the extra load; acquiring
+the lowered fore-end and lifting it uses the existing two-hand steering.
+
+Enable `--experimental physical_held_items,physical_gun_weight` in VR. The
+existing world-down spring rotates around the calibrated primary palm, and
+firing recoil recovers to the weighted resting pose. No integration or recoil
+coefficients change in this increment. Runtime coverage adds both shotgun
+hands, Strength transitions, support acquisition/release, firing/recovery,
+palm anchoring, fixed head, and a disabled-weight control. Final comfort and
+angle tuning remain a headset validation task.

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -154,8 +154,8 @@ fn handling_profile(model: &str, setting: i32) -> Option<HandlingProfile> {
         ("ar15_h", _) => (8.0, 2.0, 1.0, 8.0),
         // Shotgun modes preserve their heavy backward kick, but add explicit
         // angular handling independent of Agility's vertical suppression.
-        ("sg_h", 1) => (24.0, 4.5, 0.5, 0.0),
-        ("sg_h", _) => (12.0, 3.0, 0.5, 0.0),
+        ("sg_h", 1) => (24.0, 4.5, 0.5, 8.0),
+        ("sg_h", _) => (12.0, 3.0, 0.5, 8.0),
         _ => return None,
     };
     Some(HandlingProfile {
@@ -301,6 +301,7 @@ pub fn gun_weight_target(
 ) -> Option<GunWeightTarget> {
     crate::mission::mission_core::held_item_collision_group(world, gun)?;
     let models = world.borrow::<View<PropModelName>>().ok()?;
+    // Weight belongs to the model, independent of the selected fire mode.
     let profile = handling_profile(&models.get(gun).ok()?.0, 0)?;
     Some(GunWeightTarget {
         anchor,

--- a/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
@@ -15,6 +15,9 @@ import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
 
 for (const [name, template, sag, enabled, hand] of [
   ["pistol", -17, 1, true, "right"],
+  ["shotgun", -19, 8, true, "right"],
+  ["shotgun left hand", -19, 8, true, "left"],
+  ["shotgun without weight flag", -19, 0, false, "right"],
   ["AR", -18, 8, true, "right"],
   ["AR left hand", -18, 8, true, "left"],
   ["AR without weight flag", -18, 0, false, "right"],
@@ -95,7 +98,7 @@ for (const [name, template, sag, enabled, hand] of [
         if (strength !== 1 || !enabled) continue;
 
         // Acquire the actual lowered fore-end first, then lift it to level.
-        // On the AR the neutral socket is outside the sagged socket's grab
+        // On long guns the neutral socket is outside the sagged socket's grab
         // radius. Resolve both poses from the live barrel and primary palm.
         const s = await socket();
         const player = (await game.info()).player;


### PR DESCRIPTION
A one-handed shotgun now has optional downward weight: its muzzle settles 8° below the tracked aim at Strength 1, 4.8° at Strength 3, and stays level at Strength 6. Support from the second hand removes the extra load. Both fire modes use the same weight, with the existing spring rotating around the primary palm.

Stacked on #1487. This changes the shotgun weight profile only; it uses the existing weight integration and recoil behavior.

Enable with `--experimental physical_held_items,physical_gun_weight` (also pass `--vr` when using the debug runtime).

Validation: all three shotgun SDK scenarios passed, covering both hands across Strength levels, support acquisition/lift/release, firing and recovery, fixed palm/head, and the disabled-feature case. SDK build and warnings-as-errors checks for gameplay, debug, and desktop passed. Independent source, duplication, and visual reviews found no issues.

No Quest was connected; headset feel still needs tuning validation. The 8° maximum is an initial value shared with the AR.

![Shotgun right hand Strength progression](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/shotgun-s1-right-comparison.gif)

![Shotgun right hand Strength 1](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/shotgun-s1-right-strength1.png)

![Shotgun left hand Strength progression](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/shotgun-s1-left-comparison.gif)

![Shotgun left hand Strength 1](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/shotgun-s1-left-strength1.png)

![Measured shotgun weight pitch](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/weight-pitch.png)

Both hands produce the same smooth Strength 1→3→6 progression: −8°→−4.807°→approximately 0°. Parent remains level. Fixed tracked hands/head, no firing; maximum primary-palm error 0.000000238 world units. Both experimental flags enabled in both builds.

[CSV](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/weight-traces.csv) · [Measured summary](https://gist.githubusercontent.com/tommy-xr/babc6ff447c49f66de9ecfc0fc77f4ce/raw/2f5cc6e8cd2afead972160c9050f58442cd07a72/weight-summary.json)
