### PR TITLE
feat(debug): tune VR gun handling with live stat overrides

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,6 +230,29 @@ free-camera switches. Values are read every frame, so a change is live on the
 next one, and the same registry is exposed over HTTP by the debug runtime
 (`GET`/`POST /v1/dev-params`) for headless runs.
 
+#### Testing VR weapon handling at different stats
+
+Open `debug_weapons` from the Developer scene list and pick up a gun from the
+bench. Hold the left Menu button to pause, then open **Developer**. The
+**Gun STR ovrd** and **Gun AGI ovrd** rows override Strength and Agility for
+physical gun handling: `0` follows your character, and `1`–`6` selects a test
+level. Use the row arrows, return to the game, and repeat while holding the
+same weapon. Decrease both back to `0` to restore character-driven handling.
+
+The pen starts with maxed character stats, so try STR `1`, `3`, `6` with AGI
+`1` first; compare one hand with the fore-end supported. Then hold STR at `3`
+and vary AGI `1`, `3`, `6`. Strength reduces recoil and downward muzzle weight;
+Agility reduces angular recoil (the extra one-handed pitch remains at AGI 6).
+These knobs do not change weapon skill, shot spread, inventory capacity,
+movement, or your saved character sheet. They remain active across scene/load
+changes in the running process and reset on app restart. Hand-motion inertia
+is not implemented yet.
+
+Desktop/debug VR testing needs
+`--vr --experimental physical_held_items,physical_gun_weight`. Automated tests
+can set the same knobs through `game.devParams.set("gun_strength_override", 3)`
+and `game.devParams.set("gun_agility_override", 1)`; `reset(key)` restores `0`.
+
 **Free camera** detaches the view from the player: the camera stays where it
 was while the pawn stands still, so you can watch the simulation from outside
 without perturbing it. Nothing in the simulation follows it - AI keeps reading

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -923,3 +923,19 @@ coefficients change in this increment. Runtime coverage adds both shotgun
 hands, Strength transitions, support acquisition/release, firing/recovery,
 palm anchoring, fixed head, and a disabled-weight control. Final comfort and
 angle tuning remain a headset validation task.
+
+
+### Live weapon-handling stat overrides
+
+The Developer panel now exposes `gun_strength_override` (**Gun STR ovrd**) and
+`gun_agility_override` (**Gun AGI ovrd**). Zero follows the character sheet;
+1–6 selects a live handling-only test level, including lowering a max-stat
+`debug_weapons` character. Strength feeds both recoil and optional downward
+weight; Agility feeds the existing physical gun angular recoil path. The same
+shared registry supplies the flat/VR panel and debug HTTP API.
+
+Overrides never mutate character stats or saves and do not change proficiency,
+spread, movement, or backpack capacity. They persist only for the running
+process, including across mission/save loads; return both to zero when done.
+See [the headset test recipe](../DEVELOPMENT.md#testing-vr-weapon-handling-at-different-stats).
+Agility-driven lag during rapid hand rotation remains a separate future feature.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -146,6 +146,11 @@ dev_params! {
     /// shares its single flat projection between flat and `--vr` mode, so this
     /// override reaches both there.)
     FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override", 0.0, 0.0, 120.0, 1.0),
+    /// Weapon-handling test overrides only: 0 follows the character sheet,
+    /// 1–6 selects a live test level without changing stats or saves. Strength
+    /// affects physical gun recoil and optional weight; Agility affects recoil.
+    GUN_STRENGTH_OVERRIDE = float("gun_strength_override", "Gun STR ovrd", 0.0, 0.0, 6.0, 1.0),
+    GUN_AGILITY_OVERRIDE = float("gun_agility_override", "Gun AGI ovrd", 0.0, 0.0, 6.0, 1.0),
     /// Ceiling on how fast a physically simulated held melee weapon may be
     /// driven onto its tracked-hand target, in world units per second.
     ///

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4612,11 +4612,7 @@ impl MissionCore {
         // Weight is an independent VR experiment. Configure the existing held
         // drive after acquisition/fitting so all physics substeps share it.
         let (left, right) = self.interaction.held_entities();
-        let strength = self
-            .world
-            .borrow::<UniqueView<QuestInfo>>()
-            .map(|q| q.player_stats().strength)
-            .unwrap_or(1);
+        let strength = crate::weapon_recoil::handling_strength(&self.world);
         for gun in [left, right].into_iter().flatten() {
             let target = game_options
                 .experimental_features
@@ -9197,11 +9193,7 @@ impl MissionCore {
                     impulse,
                     one_hand,
                 } => {
-                    let strength = self
-                        .world
-                        .borrow::<UniqueView<QuestInfo>>()
-                        .map(|q| q.player_stats().strength)
-                        .unwrap_or(1);
+                    let strength = crate::weapon_recoil::handling_strength(&self.world);
                     self.physics.kick_held_gun(
                         entity_id,
                         impulse,

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -99,6 +99,19 @@ fn aiming_implant(world: &World) -> bool {
         })
 }
 
+/// Live Strength for physical gun recoil and weight only. The developer knob
+/// never writes the character sheet (inventory capacity/movement stay real).
+pub fn handling_strength(world: &World) -> i32 {
+    let override_level = crate::dev_params::get(crate::dev_params::GUN_STRENGTH_OVERRIDE) as i32;
+    if override_level > 0 {
+        return override_level;
+    }
+    world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|q| q.player_stats().strength)
+        .unwrap_or(1)
+}
+
 /// Called only after the shared firing gate succeeds, once per shell (not pellet).
 pub fn shot_impulse(world: &World, gun: EntityId) -> Option<(RecoilImpulse, RecoilImpulse)> {
     // Keep the flat/nonphysical firing path free of recoil RNG draws.
@@ -109,10 +122,15 @@ pub fn shot_impulse(world: &World, gun: EntityId) -> Option<(RecoilImpulse, Reco
     let setting = states.get(gun).map(|s| s.setting).unwrap_or(0);
     let kick = kicks.get(gun).ok()?.setting(setting);
     let flags = guns.get(gun).ok()?.flags;
-    let agility = world
-        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
-        .map(|q| q.player_stats().agility)
-        .unwrap_or(1);
+    let override_agility = crate::dev_params::get(crate::dev_params::GUN_AGILITY_OVERRIDE) as i32;
+    let agility = if override_agility > 0 {
+        override_agility
+    } else {
+        world
+            .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+            .map(|q| q.player_stats().agility)
+            .unwrap_or(1)
+    };
     // Shipped Still Hand template, verified against gamesys (power id 2).
     let still_hand = world
         .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()

--- a/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-weight.e2e.test.ts
@@ -13,21 +13,22 @@ import {
 } from "./helpers/vr-hand.js";
 import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
 
-for (const [name, template, sag, enabled, hand] of [
-  ["pistol", -17, 1, true, "right"],
-  ["shotgun", -19, 8, true, "right"],
-  ["shotgun left hand", -19, 8, true, "left"],
-  ["shotgun without weight flag", -19, 0, false, "right"],
-  ["AR", -18, 8, true, "right"],
-  ["AR left hand", -18, 8, true, "left"],
-  ["AR without weight flag", -18, 0, false, "right"],
+for (const [name, template, sag, enabled, hand, overrides] of [
+  ["pistol", -17, 1, true, "right", false],
+  ["shotgun", -19, 8, true, "right", false],
+  ["shotgun left hand", -19, 8, true, "left", false],
+  ["shotgun without weight flag", -19, 0, false, "right", false],
+  ["AR", -18, 8, true, "right", false],
+  ["AR left hand", -18, 8, true, "left", false],
+  ["AR without weight flag", -18, 0, false, "right", false],
+  ["shotgun overrides", -19, 8, true, "right", true],
 ] as const) {
   test(
     `${name}: Strength and support remove downward weight around the palm`,
     { skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000 },
     async (context) => {
       await using game = await GameServer.launch({
-        mission: "medsci1.mis",
+        mission: overrides ? "debug_weapons" : "medsci1.mis",
         debugFlags: [
           "--vr",
           "--experimental",
@@ -38,6 +39,8 @@ for (const [name, template, sag, enabled, hand] of [
       });
       await game.step({ frames: 10 });
       await game.player.setStats({ skills: { standard_weapons: 6 } });
+      const character = (await game.info()).player.stats;
+      if (overrides) assert.equal(character?.strength, 6);
       const gun = await cycleToWeapon(game, (e) => e.template_id === template, {
         settleFrames: 90,
       });
@@ -77,9 +80,13 @@ for (const [name, template, sag, enabled, hand] of [
         );
         assert.deepEqual((await game.info()).player.camera_rotation, head);
       };
-      for (const strength of [1, 3, 6]) {
+      for (const testLevel of overrides ? [0, 1, 3, 6, 1, 0] : [1, 3, 6]) {
+        const strength = testLevel || character!.strength;
         const previous = await pitch();
-        await game.player.setStats({ strength });
+        if (overrides) {
+          await game.devParams.set("gun_strength_override", testLevel);
+          assert.deepEqual((await game.info()).player.stats, character);
+        } else await game.player.setStats({ strength });
         await game.step({ frames: 1 });
         assert.ok(
           Math.abs((await pitch()) - previous) < 0.5,
@@ -95,7 +102,7 @@ for (const [name, template, sag, enabled, hand] of [
         context.diagnostic(
           JSON.stringify({ name, strength, pitch: await pitch() }),
         );
-        if (strength !== 1 || !enabled) continue;
+        if (strength !== 1 || !enabled || overrides) continue;
 
         // Acquire the actual lowered fore-end first, then lift it to level.
         // On long guns the neutral socket is outside the sagged socket's grab

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -13,22 +13,29 @@ import {
 } from "./helpers/vr-hand.js";
 import { ammoOf, cycleToWeapon, muzzleFrameOf } from "./helpers/weapon.js";
 
-for (const [name, template, profiled, setting] of [
-  ["pistol", -17, true, 0],
-  ["AR", -18, true, 0],
-  ["shotgun", -19, true, 0],
-  ["shotgun-triple", -19, true, 1],
+for (const [name, template, profiled, setting, overrides] of [
+  ["pistol", -17, true, 0, false],
+  ["AR", -18, true, 0, false],
+  ["shotgun", -19, true, 0, false],
+  ["shotgun-triple", -19, true, 1, false],
+  ["pistol overrides", -17, true, 0, true],
 ] as const) {
   test(
     `${name} recoil decreases with Strength and genuine support removes the extra spring`,
     { skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000 },
     async (context) => {
       await using game = await GameServer.launch({
-        mission: "medsci1.mis",
+        mission: overrides ? "debug_weapons" : "medsci1.mis",
         debugFlags: ["--vr", "--experimental", "physical_held_items"],
       });
       await game.step({ frames: 10 });
       await game.player.setStats({ skills: { standard_weapons: 6 } });
+      const character = (await game.info()).player.stats;
+      if (overrides) {
+        assert.equal(character?.strength, 6);
+        assert.equal(character?.agility, 6);
+        await game.devParams.set("gun_agility_override", 1);
+      }
       const gun = await cycleToWeapon(game, (e) => e.template_id === template, {
         settleFrames: 90,
       });
@@ -102,7 +109,9 @@ for (const [name, template, profiled, setting] of [
         muzzle: (ReturnType<typeof muzzleFrameOf> & { frame: number })[];
       }[] = [];
       for (const strength of [1, 3, 6]) {
-        await game.player.setStats({ strength });
+        if (overrides)
+          await game.devParams.set("gun_strength_override", strength);
+        else await game.player.setStats({ strength });
         for (const supported of [false, true]) {
           await support(supported);
           await game.step({ frames: 180 });
@@ -284,7 +293,12 @@ for (const [name, template, profiled, setting] of [
         assert.deepEqual((await game.info()).player.camera_rotation, head);
       }
       await game.step({ frames: 300 });
-      await game.player.setStats({ agility: 6 });
+      if (overrides) {
+        // Reset follows the real Agility 6 again; neither override trained the player.
+        await game.devParams.reset("gun_agility_override");
+        await game.devParams.reset("gun_strength_override");
+        assert.deepEqual((await game.info()).player.stats, character);
+      } else await game.player.setStats({ agility: 6 });
       for (const supported of [false, true]) {
         await support(supported);
         await game.step({ frames: 180 });


### PR DESCRIPTION
The max-stat `debug_weapons` pen now supports live Strength and Agility comparisons through the existing Developer panel. **Gun STR ovrd** and **Gun AGI ovrd** use `0` for the character's stat and `1`–`6` for a handling-only override, so the same held gun can be tested at lower levels without rebuilding or editing a save.

Strength feeds both physical recoil and optional downward weight. Agility feeds physical angular recoil. These controls leave character stats, weapon proficiency/spread, movement, and inventory capacity unchanged. Values last for the running process (including scene/load changes); reset to zero or restart to restore character-driven handling. Rapid-hand-motion inertia remains future work.

Open Developer → Scenes → `debug_weapons`, pick up a gun, then hold left Menu to pause and open Developer. Compare STR1/3/6 at AGI1, one hand versus supported, then AGI1/3/6 at fixed STR3. Desktop/debug VR needs `--vr --experimental physical_held_items,physical_gun_weight`; the next PR enables those features by default on Quest.

Validation: 1,696 gameplay tests passed (2 ignored); debug build, warnings-as-errors gameplay/debug/desktop checks, formatting and SDK build passed. SDK scenarios verify max-stat overrides, six Strength/grip recoil combinations, Agility reset, bidirectional weight changes and unchanged character stats. Real panel-arrow, scroll and reset-to-zero interactions passed in both presentations. Independent source and visual reviews were clean; duplication review found no actionable duplication (4 queries/9,719 candidates, 695 clone pairs, 3,732 indexed items).

![flat Developer controls before/after](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/flat-comparison.gif)

![flat override labels and values](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/flat-changed.png)

![vr Developer controls before/after](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/vr-comparison.gif)

![vr override labels and values](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/vr-changed.png)

Real flat pointer / VR controller-ray clicks exercise both arrows, scrolling, and decrement-to-zero reset. Both overrides reach2, decrease correctly, and return to0 (character stats). Labels fit without ellipsis in both presentations. Parent receives the same input sequence and lacks the new rows. GIF is a paced UI walkthrough.

[Capture script](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/weapon-stats-capture.mjs) · [Flat state history](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/after-flat-history.json) · [VR state history](https://gist.githubusercontent.com/tommy-xr/79f399a9923b2b2828a1a2b66c33bdd4/raw/27eaf401fd1c7ddb81109815887ada410c8461e4/after-vr-history.json)
