### PR TITLE
feat(quest): enable physical guns and projectile particles by default

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -248,6 +248,7 @@ movement, or your saved character sheet. They remain active across scene/load
 changes in the running process and reset on app restart. Hand-motion inertia
 is not implemented yet.
 
+Quest enables physical held guns, downward gun weight, and particles by default.
 Desktop/debug VR testing needs
 `--vr --experimental physical_held_items,physical_gun_weight`. Automated tests
 can set the same knobs through `game.devParams.set("gun_strength_override", 3)`

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -939,3 +939,12 @@ spread, movement, or backpack capacity. They persist only for the running
 process, including across mission/save loads; return both to zero when done.
 See [the headset test recipe](../DEVELOPMENT.md#testing-vr-weapon-handling-at-different-stats).
 Agility-driven lag during rapid hand rotation remains a separate future feature.
+
+
+### Quest defaults for headset validation
+
+The Quest runtime enables `physical_held_items` and `physical_gun_weight` at
+startup, and explicitly keeps `render_particles` on for projectile orbs/trails.
+No launch-file or feature-flag edit is needed: use the Developer scene list to
+enter `debug_weapons`, then change the handling stat overrides as described
+above. Desktop/debug runtime experimental defaults remain unchanged.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -543,12 +543,20 @@ fn main() {
     let now = Instant::now();
     let engine = engine::android();
     let bundle_storage = engine.get_storage();
-    let experimental_features = HashSet::new();
+    // Quest has no launch-flag UI: ship the physical gun path, including
+    // recoil/contact feedback and downward weight. Handling can be compared
+    // live through the Developer panel's Strength/Agility overrides.
+    let experimental_features = HashSet::from([
+        "physical_held_items".to_owned(),
+        "physical_gun_weight".to_owned(),
+    ]);
     let mission = quest_config::configured_mission();
     let game_init_started = Instant::now();
     let options: GameOptions = GameOptions {
         mission: mission.clone(),
         experimental_features,
+        // Projectile orbs/trails are authored particles, not optional polish.
+        render_particles: true,
         debug_skeletons: false,
         ..GameOptions::default()
     };


### PR DESCRIPTION
Quest now enables physical held guns and downward gun weight at startup, so the weapon-workstream behavior can be tested in-headset without a feature-flag UI or launch edits. This enables the existing gun collision, recoil and contact-feedback paths; no physics tuning changes are introduced here.

Projectile particles are explicitly enabled in the Quest options. They were already enabled by the parent/default configuration; this preserves that behavior for authored projectile orbs and trails.

Stacked on #1489, which adds live handling-only Strength/Agility controls. Open Developer → Scenes → `debug_weapons`, pick up a gun, then use **Gun STR ovrd** and **Gun AGI ovrd** (0=character; 1–6=test level). Desktop/debug launch defaults are unchanged.

Validation: Android release APK build, formatting and independent source review passed. Installed the exact build on Quest 3; package timestamp changed to 2026-09-09 18:16:09 and flags contain no DEBUGGABLE. Runtime reached READY, a focused XR session, and advancing frames. The compositor capture shows both stat controls legibly in stereo.

Device interaction was left to the wearer after the panel changed without injected input. No automated on-device firing or stat-change assertions are claimed. The underlying recoil/weight paths and live overrides passed the deterministic SDK checks in the parent layers; #1488 documents the shotgun weight behavior. This PR changes startup options only.


![Quest 3 Developer panel](https://gist.githubusercontent.com/tommy-xr/c81819081c246b9300b84158f6030ea2/raw/ee74e06aa721f8c260223c361a16c2a9d693d4ba/quest-developer.png)

Quest 3 after installing release APK be7c4b2c: readable Developer override rows in the active weapon test scene. No remote game input was injected.

![Passive Quest 3 stereo recording](https://gist.githubusercontent.com/tommy-xr/c81819081c246b9300b84158f6030ea2/raw/ee74e06aa721f8c260223c361a16c2a9d693d4ba/quest-passive.gif)

Passive two-second recording while the wearer appeared to interact. This is device-after evidence, not a matched device before/after or automated firing test.

Installed APK SHA-256 matches the supplied release artifact; no DEBUGGABLE flag. READY/FOCUSED and advancing focused frames confirmed, 1680×1760 per eye at 90Hz. Mission selector restored to medsci1.mis; temporary debug-port/forward removed; Guardian/proximity automation restored. App deliberately left running for the wearer.
