### PR TITLE
feat(vr): add live recoil axis and one-hand penalty scales

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -248,6 +248,20 @@ movement, or your saved character sheet. They remain active across scene/load
 changes in the running process and reset on app restart. Hand-motion inertia
 is not implemented yet.
 
+**Back scale**, **Pitch scale**, and **Yaw scale** independently
+multiply new recoil impulses on each axis, for both one-handed and supported
+shots. Each ranges from `0` to `3`, defaults to `1`, and uses `0.1` steps. `0`
+disables new recoil on that axis; existing recoil settles normally. Authored
+travel limits and recovery rates still apply, so high gains can reach the caps.
+These scales do not change downward weight or restore pitch/yaw suppressed by
+Agility or Still Hand. For a first balance experiment, try back `0.3`, pitch `1.5`,
+yaw `1`, with STR `1` and AGI `1`; these are test values, not new defaults.
+**1-hand scale** multiplies only the extra one-handed recoil after Strength:
+`0` removes that penalty, `1` keeps the current amount, and up to `3` increases
+it. The axis gains still apply to both baseline and extra recoil; supported
+shots retain baseline recoil regardless of this setting. Downward weight is
+separate. Return all four scales to `1` to restore the profiles.
+
 Quest enables physical held guns, downward gun weight, and particles by default.
 Desktop/debug VR testing needs
 `--vr --experimental physical_held_items,physical_gun_weight`. Automated tests

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -948,3 +948,17 @@ startup, and explicitly keeps `render_particles` on for projectile orbs/trails.
 No launch-file or feature-flag edit is needed: use the Developer scene list to
 enter `debug_weapons`, then change the handling stat overrides as described
 above. Desktop/debug runtime experimental defaults remain unchanged.
+
+
+### Live per-axis recoil tuning
+
+Developer parameters `gun_kickback_scale`, `gun_pitch_scale`, and `gun_yaw_scale`
+multiply new baseline and extra one-hand impulses independently (0–3, step0.1,
+default1). Zero disables new kick on that axis. Existing spring motion, recovery
+rates, authored caps, downward weight, and character stats are unchanged.
+Use the [headset test recipe](../DEVELOPMENT.md#testing-vr-weapon-handling-at-different-stats)
+to rebalance excessive backward travel against muzzle rise; tuning does not
+bypass Agility/Still Hand suppression. `gun_one_hand_scale` (**1-hand scale**, same range/default) additionally scales
+only the extra one-handed spring after Strength. Zero removes the penalty;
+support and baseline recoil are unchanged, and per-axis gains still apply.
+Values are process-local like other dev parameters; restart resets them.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -151,6 +151,15 @@ dev_params! {
     /// affects physical gun recoil and optional weight; Agility affects recoil.
     GUN_STRENGTH_OVERRIDE = float("gun_strength_override", "Gun STR ovrd", 0.0, 0.0, 6.0, 1.0),
     GUN_AGILITY_OVERRIDE = float("gun_agility_override", "Gun AGI ovrd", 0.0, 0.0, 6.0, 1.0),
+    /// Per-axis gain for new physical gun recoil impulses (baseline and extra
+    /// one-hand spring). 1 preserves the profile; 0 disables new kick on that
+    /// axis. Existing displacement caps and recovery rates remain unchanged.
+    GUN_KICKBACK_SCALE = float("gun_kickback_scale", "Back scale", 1.0, 0.0, 3.0, 0.1),
+    GUN_PITCH_SCALE = float("gun_pitch_scale", "Pitch scale", 1.0, 0.0, 3.0, 0.1),
+    GUN_YAW_SCALE = float("gun_yaw_scale", "Yaw scale", 1.0, 0.0, 3.0, 0.1),
+    /// Additional one-handed recoil only; support already removes this spring.
+    /// Applied alongside per-axis gains after Strength, without changing weight.
+    GUN_ONE_HAND_SCALE = float("gun_one_hand_scale", "1-hand scale", 1.0, 0.0, 3.0, 0.1),
     /// Ceiling on how fast a physically simulated held melee weapon may be
     /// driven onto its tracked-hand target, in world units per second.
     ///

--- a/shock2vr/src/weapon_recoil.rs
+++ b/shock2vr/src/weapon_recoil.rs
@@ -33,14 +33,20 @@ pub fn vr_impulses(
 ) -> (RecoilImpulse, Option<RecoilImpulse>) {
     let above_minimum = (strength.clamp(1, 6) - 1) as f32;
     let scaled = |impulse: RecoilImpulse, scale| RecoilImpulse {
-        pitch: impulse.pitch * scale,
-        heading: impulse.heading * scale,
-        back: impulse.back * scale,
+        pitch: impulse.pitch * scale * crate::dev_params::get(crate::dev_params::GUN_PITCH_SCALE),
+        heading: impulse.heading * scale * crate::dev_params::get(crate::dev_params::GUN_YAW_SCALE),
+        back: impulse.back * scale * crate::dev_params::get(crate::dev_params::GUN_KICKBACK_SCALE),
         ..impulse
     };
     (
         scaled(impulse, 1.0 / (1.0 + 0.1 * above_minimum)),
-        (!supported).then(|| scaled(one_hand, 1.0 / (1.0 + 0.3 * above_minimum))),
+        (!supported).then(|| {
+            scaled(
+                one_hand,
+                crate::dev_params::get(crate::dev_params::GUN_ONE_HAND_SCALE)
+                    / (1.0 + 0.3 * above_minimum),
+            )
+        }),
     )
 }
 

--- a/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-strength-recoil.e2e.test.ts
@@ -58,10 +58,11 @@ for (const [name, template, profiled, setting, overrides] of [
       const ammoUsage = setting ? 3 : 1;
       const ensureShotAmmo = async () => {
         if (ammoOf(await game.entities.detail(gun.id)) >= ammoUsage) return;
-        // The shotgun's three-shell matrix exceeds one magazine. Supply both
-        // authored clip types and reload through the normal selected-ammo path.
-        await game.player.spawnItem(-42);
-        await game.player.spawnItem(-43);
+        // Longer matrices exceed one magazine. Supply authored clip types
+        // and reload through the normal selected-ammo path.
+        for (const clip of template === -17 ? [-31, -32, -307] : [-42, -43]) {
+          await game.player.spawnItem(clip);
+        }
         await game.input.trigger("Reload");
         await game.step({ frames: 180 });
         assert.ok(ammoOf(await game.entities.detail(gun.id)) >= ammoUsage);
@@ -332,6 +333,101 @@ for (const [name, template, profiled, setting, overrides] of [
         );
         assert.deepEqual((await game.info()).player.camera_rotation, head);
         await game.step({ frames: 300 });
+      }
+      if (overrides) {
+        await support(false);
+        await game.devParams.set("gun_strength_override", 1);
+        await game.devParams.set("gun_agility_override", 1);
+        for (const [
+          backScale,
+          pitchScale,
+          yawScale,
+          penaltyScale,
+          supported,
+        ] of [
+          [0.3, 0, 0, 1, false],
+          [0, 1.5, 0, 1, false],
+          [0, 0, 1.5, 1, false],
+          [1, 0, 0, 0, false],
+          [1, 0, 0, 0.5, false],
+          [1, 0, 0, 0, true],
+          [1, 0, 0, 3, true],
+        ] as const) {
+          await support(supported);
+          await game.step({ frames: 300 });
+          await game.devParams.set("gun_kickback_scale", backScale);
+          await game.devParams.set("gun_pitch_scale", pitchScale);
+          await game.devParams.set("gun_yaw_scale", yawScale);
+          await game.devParams.set("gun_one_hand_scale", penaltyScale);
+          await ensureShotAmmo();
+          const initial = await body();
+          const muzzle = muzzleFrameOf(await game.entities.detail(gun.id));
+          const ammo = ammoOf(await game.entities.detail(gun.id));
+          await game.input.set("right_hand.trigger", 1);
+          let back = 0,
+            pitch = 0,
+            yaw = 0;
+          for (let frame = 0; frame < 30; frame++) {
+            await game.step({ frames: 1 });
+            if (frame === 0) await game.input.set("right_hand.trigger", 0);
+            const current = muzzleFrameOf(await game.entities.detail(gun.id));
+            back = Math.max(
+              back,
+              Math.abs((await body()).position[0] - initial.position[0]),
+            );
+            pitch = Math.max(
+              pitch,
+              Math.abs(current.forward[1] - muzzle.forward[1]),
+            );
+            yaw = Math.max(
+              yaw,
+              Math.abs(
+                current.forward[0] * muzzle.forward[2] -
+                  current.forward[2] * muzzle.forward[0],
+              ),
+            );
+          }
+          assert.equal(ammoOf(await game.entities.detail(gun.id)), ammo - 1);
+          assert.ok(
+            pitchScale ? pitch > 0.002 : pitch < 0.0001,
+            `pitch scale ${pitchScale}: ${pitch}`,
+          );
+          assert.ok(
+            yawScale ? yaw > 0.001 : yaw < 0.0001,
+            `yaw scale ${yawScale}: ${yaw}`,
+          );
+          assert.ok(
+            Math.abs(
+              back -
+                value(1, true) *
+                  (1 + (supported ? 0 : penaltyScale)) *
+                  backScale,
+            ) < 0.003,
+            `back scale ${backScale}: ${back}`,
+          );
+          assert.deepEqual((await game.info()).player.stats, character);
+          assert.deepEqual((await game.info()).player.camera_rotation, head);
+          context.diagnostic(
+            JSON.stringify({
+              backScale,
+              pitchScale,
+              yawScale,
+              penaltyScale,
+              supported,
+              back,
+              pitch,
+              yaw,
+            }),
+          );
+        }
+        for (const key of [
+          "gun_kickback_scale",
+          "gun_pitch_scale",
+          "gun_yaw_scale",
+          "gun_one_hand_scale",
+        ]) {
+          assert.equal((await game.devParams.reset(key)).value, 1);
+        }
       }
     },
   );


### PR DESCRIPTION
VR recoil can now be balanced in-headset with four live Developer controls: **Back scale**, **Pitch scale**, **Yaw scale**, and **1-hand scale**. This lets excessive backward travel be reduced independently from muzzle rise and horizontal kick.

All four range from 0 to 3 in 0.1 steps and default to 1 (current behavior). Axis gains multiply new baseline and extra one-handed impulses. The one-hand gain affects only the extra spring: 0 removes that penalty, 0.5 halves it, and support still removes the extra spring entirely. Strength scaling and the existing Agility/Still Hand modifiers remain in effect.

Existing recoil settles normally when a value changes. Recovery rates, travel caps, downward gun weight and character stats are unchanged; high gains can reach the existing caps. Values last for the process and reset on restart; return all four to 1 to restore profiles.

Stacked on #1490. In `debug_weapons`, hold left Menu → Developer and scroll one row to see all four controls. A starting experiment for the reported balance is back0.3/pitch1.5/yaw1, then one-hand0.5, at STR1/AGI1. These are suggested test values, not changed defaults.

Validation: 10 recoil/weight unit tests passed; SDK runtime passed 15 actual-shot checks including default Strength/support behavior, isolated axes, 30% backward travel, muted axes, zero/half one-hand penalty, supported invariance, ammunition use and unchanged character/head state. SDK build, formatting, warnings-as-errors gameplay/debug/desktop checks and Android release APK build passed. Independent source and visual reviews were clean; duplication scan found no actionable duplication.

Flat and VR controls were clicked, scrolled and reset through real input. Updated APK is built; installation is deferred while the wearer may be using the current Quest session.

![flat recoil controls before/after](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/flat-comparison.gif)

![flat tuned recoil controls](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/flat-tuned.png)

![flat one-hand penalty disabled](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/flat-onehand-zero.png)

![vr recoil controls before/after](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/vr-comparison.gif)

![vr tuned recoil controls](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/vr-tuned.png)

![vr one-hand penalty disabled](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/vr-onehand-zero.png)

Real pointer/controller-ray input sets back0.3, pitch1.5, yaw1.0; exercises one-hand penalty0.5 and0; then restores all four scales to1.0. Scrolled hitboxes and values verified in both presentations; all labels fit. Parent receives identical requests but lacks these rows. GIFs are paced UI walkthroughs.

[Exact script](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/recoil-scales-capture.mjs) · [Flat state history](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/after-flat-history.json) · [VR state history](https://gist.githubusercontent.com/tommy-xr/bd657798241739271a40d89743984c7b/raw/70110fafd7e8d1b64c419abfce04d7f361e159e1/after-vr-history.json)
