### PR TITLE
fix(scripts): hatch annelid egg pods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,6 +507,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_minimal`          | Bare minimum scene for basic testing         |
    | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `DebugCycleWeapon`) |
    | `debug_psi`              | Psi amp casting (auto-equips the amp; select powers with `CyclePsiPower`) |
+   | `debug_annelid`          | Annelid egg pods (goo / grub / swarmer), one per station; walk up to hatch one |
 
    ```bash
    # Use with debug runtime for programmatic control

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8327,22 +8327,20 @@ impl MissionCore {
                     position,
                     orientation,
                     initial_velocity,
+                    options,
                 } => {
                     if let Some(created) = self.create_entity_by_template_name_with_options(
                         asset_cache,
                         &template_name,
                         position,
                         orientation,
-                        CreateEntityOptions {
-                            launch_projectile: true,
-                            ..CreateEntityOptions::default()
-                        },
+                        options,
                     ) {
                         self.physics
                             .set_velocity(created.entity_id, initial_velocity);
                     } else {
                         warn!(
-                            "Tweq emitter {:?} could not resolve authored template {:?}",
+                            "{:?} could not resolve authored template {:?}",
                             source_entity_id, template_name
                         );
                     }

--- a/shock2vr/src/scenes/debug_annelid.rs
+++ b/shock2vr/src/scenes/debug_annelid.rs
@@ -1,0 +1,231 @@
+//! Annelid egg pods, one station per authored kind, tripped by walking up to
+//! them.
+//!
+//! The three pods look identical and differ only in their script, so the bug
+//! "eggs spawn nothing" is invisible in a real level: a pod that opens and
+//! produces nothing is indistinguishable from one that was never near enough
+//! to hatch. Here each kind stands alone at a labeled station with a known
+//! trip radius, so "walk up, watch what comes out" answers the question for
+//! one kind at a time:
+//!
+//! - Goo pod (`GooEgg`)     - a toxic emitter lobbing venom-stimmed goo shots
+//! - Grub pod (`GrubEgg`)   - a crawling annelid
+//! - Swarmer pod (`SwarmerEgg`) - a flying annelid swarm
+//!
+//! Missions trip their pods with an authored "Floor Egg Tripwire" (a once,
+//! player-enter tripwire SwitchLinked to the pod). Runtime link authoring has
+//! no effect of its own, so this scene stands in for that wiring with a
+//! distance check that sends the same `TurnOn` - the pod script sees exactly
+//! what a mission tripwire would send.
+
+use cgmath::{Deg, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, vec3};
+use dark::{importers::FONT_IMPORTER, properties::PropTemplateId};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
+use shipyard::{EntityId, IntoIter, IntoWithId, UniqueView, UniqueViewMut, View};
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::InputContext,
+    mission::{
+        GlobalContext, SpawnLocation,
+        mission_core::{EffectQueue, MissionCore, PlayerInfo},
+    },
+    scripts::{Effect, Message, MessagePayload},
+    time::Time,
+};
+
+use super::debug_common::{
+    DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    boxes_to_geometry, max_player_stats, spawn_at,
+};
+
+struct EggStation {
+    label: &'static str,
+    /// The floor variant of each pod: the wall variants differ only in model
+    /// orientation, and a floor pod sits where a walker can reach it.
+    template_id: i32,
+    /// Station centre along +Z; every pod is the same distance ahead.
+    z: f32,
+}
+
+const STATIONS: &[EggStation] = &[
+    EggStation {
+        label: "Goo pod - toxic",
+        template_id: -1476,
+        z: -6.0,
+    },
+    EggStation {
+        label: "Grub pod - crawler",
+        template_id: -1335,
+        z: 0.0,
+    },
+    EggStation {
+        label: "Swarmer pod - flier",
+        template_id: -1332,
+        z: 6.0,
+    },
+];
+
+/// Stations sit this far along -X, the default view forward at an identity
+/// spawn yaw (same convention as `debug_melee` / `debug_weapons`).
+const STATION_DISTANCE: f32 = 8.0;
+
+/// How close the player must get for a station to hatch. Comfortably smaller
+/// than the 6-unit gap between stations, so approaching one pod never trips
+/// its neighbours - the whole point of separate stations.
+const TRIP_RADIUS: f32 = 2.5;
+
+pub fn create_debug_annelid_scene(
+    global_context: &GlobalContext,
+    game_options: &GameOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> Box<dyn GameScene> {
+    let mut boxes = vec![(
+        vec3(0.16, 0.18, 0.16),
+        vec3(-STATION_DISTANCE / 2.0, -0.5, 0.0),
+        vec3(40.0, 1.0, 40.0),
+    )];
+    // Low kerbs mark each station's footprint so the trip radius is visible
+    // from the spawn rather than something you discover by walking into it.
+    for station in STATIONS {
+        boxes.push((
+            vec3(0.26, 0.30, 0.24),
+            vec3(-STATION_DISTANCE, 0.05, station.z),
+            vec3(2.0 * TRIP_RADIUS, 0.1, 2.0 * TRIP_RADIUS),
+        ));
+    }
+    let (objects, collider) = boxes_to_geometry(&boxes);
+
+    let mut builder = DebugSceneBuilder::new("debug_annelid")
+        .with_spawn_location(SpawnLocation::PositionRotation(
+            vec3(0.0, 2.0, 0.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+        ))
+        .with_physics_geometry(collider);
+    for object in objects {
+        builder = builder.add_scene_object(object);
+    }
+
+    let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
+    for station in STATIONS {
+        let mut label = SceneObject::world_space_text(station.label, font.clone(), 0.0);
+        label.set_transform(
+            Matrix4::from_translation(vec3(-STATION_DISTANCE, 2.4, station.z))
+                * Matrix4::from_nonuniform_scale(
+                    0.10 * engine::measure_text_width(&**font, station.label, 1.0),
+                    0.10,
+                    1.0,
+                )
+                * Matrix4::from_angle_x(Deg(180.0)),
+        );
+        builder = builder.add_scene_object(label);
+    }
+
+    let mut core = builder.build_core(DebugSceneBuildOptions {
+        global_context,
+        game_options,
+        asset_cache,
+        audio_context,
+    });
+    // A hatching pod is a fight; start the player able to survive all three.
+    max_player_stats(&mut core, "debug_annelid");
+
+    println!(
+        "[debug_annelid] Three annelid egg pods stand {STATION_DISTANCE} units ahead, one per kind.\n\
+         Walk within {TRIP_RADIUS} units of a pod (onto its kerb) to trip it, exactly as a\n\
+         mission's Floor Egg Tripwire would. Goo = toxic projectiles, Grub = a crawler,\n\
+         Swarmer = a flying swarm. Each pod trips once."
+    );
+
+    Box::new(HookedDebugScene::new(core, AnnelidHooks::default()))
+}
+
+#[derive(Default)]
+struct AnnelidHooks {
+    populated: bool,
+    /// One entry per station, in `STATIONS` order; `None` until the pod is
+    /// spawned, dropped again once that pod has been tripped.
+    pods: Vec<Option<EntityId>>,
+}
+
+impl DebugSceneHooks for AnnelidHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        _effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if !self.populated {
+            self.populated = true;
+            let spawns = STATIONS
+                .iter()
+                .map(|station| {
+                    spawn_at(
+                        station.template_id,
+                        Point3::new(-STATION_DISTANCE, 0.6, station.z),
+                    )
+                })
+                .collect();
+            core.handle_effects(
+                spawns,
+                global_context,
+                game_options,
+                asset_cache,
+                audio_context,
+            );
+            // Runtime entity ids are assigned at creation and are not stable
+            // across runs, so find each pod by the template it came from.
+            self.pods = STATIONS
+                .iter()
+                .map(|station| {
+                    core.world.run(|v_template: View<PropTemplateId>| {
+                        (&v_template)
+                            .iter()
+                            .with_id()
+                            .find(|(_, template)| template.template_id == station.template_id)
+                            .map(|(id, _)| id)
+                    })
+                })
+                .collect();
+        }
+    }
+
+    /// The trip check belongs here, not beside the populate above: `update` is
+    /// what a paused game skips, so a pod cannot hatch behind the pause menu.
+    fn before_update(
+        &mut self,
+        core: &mut MissionCore,
+        _time: &Time,
+        _input_context: &InputContext,
+        _asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+    ) {
+        let player_position = core.world.run(|player: UniqueView<PlayerInfo>| player.pos);
+        for (index, pod) in self.pods.iter_mut().enumerate() {
+            let Some(entity_id) = *pod else { continue };
+            // Compared on the floor plane: the pod sits at ankle height and
+            // the player's position is their feet, but a VR crouch should not
+            // change how close "close" is.
+            let station_position = vec3(-STATION_DISTANCE, player_position.y, STATIONS[index].z);
+            if (player_position - station_position).magnitude() > TRIP_RADIUS {
+                continue;
+            }
+            // Once, like the authored tripwire: forget the pod so a second
+            // pass over the kerb cannot re-hatch it.
+            *pod = None;
+            core.world.run(|mut effects: UniqueViewMut<EffectQueue>| {
+                effects.push(Effect::Send {
+                    msg: Message {
+                        to: entity_id,
+                        payload: MessagePayload::TurnOn { from: entity_id },
+                    },
+                });
+            });
+        }
+    }
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 
 pub mod cutscene_player;
 pub mod cutscene_skip;
+pub mod debug_annelid;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;
@@ -48,6 +49,7 @@ pub mod main_menu;
 pub mod no_assets;
 
 pub use cutscene_player::CutscenePlayerScene;
+pub use debug_annelid::create_debug_annelid_scene;
 pub use debug_camera::DebugCameraScene;
 pub use debug_gloves::DebugGlovesScene;
 pub use debug_hand_poses::DebugHandPosesScene;
@@ -175,6 +177,7 @@ const DEBUG_SCENES: &[(&str, DebugSceneCtor)] = &[
     ),
     ("debug_ladder", create_debug_ladder_scene),
     ("debug_psi", create_debug_psi_scene),
+    ("debug_annelid", create_debug_annelid_scene),
     ("debug_teleport", |global, options, assets, audio| {
         Box::new(DebugTeleportScene::create(global, options, assets, audio))
     }),

--- a/shock2vr/src/scripts/base_egg.rs
+++ b/shock2vr/src/scripts/base_egg.rs
@@ -1,0 +1,156 @@
+use cgmath::vec3;
+use dark::properties::PropPosition;
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::{
+    mission::entity_creator::CreateEntityOptions, physics::PhysicsWorld, util::vec3_to_point3,
+};
+
+use super::{
+    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    script_util::change_to_last_model,
+};
+
+const SCRIPT_STATE_KEY: &str = "shock2vr.base_egg";
+
+#[derive(Serialize, Deserialize)]
+struct BaseEggState {
+    hatched: bool,
+}
+
+/// What a pod puts into the world when it opens. Retail models this as three
+/// `BaseEgg` subclasses that share the opening and differ only in the objects
+/// they create.
+pub enum EggPayload {
+    /// `GooEgg` - "a toxic egg". The emitter is a `TweqEmitterConfig` object
+    /// that lobs four venom-stimmed "Goo Projectile"s and then destroys
+    /// itself. The cloud is currently decoration: it authors a Venom radius
+    /// stim, but the port applies radius stims only from explosions and the
+    /// radiation source, so the toxin a goo pod actually deals is the globs'
+    /// contact stim.
+    Goo,
+    /// `GrubEgg` - "a crawling-annelid egg".
+    Grub,
+    /// `SwarmerEgg` - "a flying-annelid egg".
+    Swarmer,
+}
+
+impl EggPayload {
+    /// Authored object names, exactly as the retail scripts name them. Looked
+    /// up by name because that is the identity the scripts carry; template ids
+    /// are an implementation detail of the gamesys.
+    fn template_names(&self) -> &'static [&'static str] {
+        match self {
+            EggPayload::Goo => &["Egg Goo Emitter", "EggGooCloud"],
+            EggPayload::Grub => &["Grub"],
+            EggPayload::Swarmer => &["Swarm"],
+        }
+    }
+}
+
+/// An annelid egg pod: retail `BaseEgg` plus one of its three payload
+/// subclasses (`GooEgg` / `GrubEgg` / `SwarmerEgg`).
+///
+/// Missions arm a pod with a once, player-enter tripwire SwitchLinked to it,
+/// so the pod's whole contract is a single `TurnOn`: open (the authored model
+/// tweq swaps `eggcl` for `eggop`) and put the payload into the world at the
+/// pod. Opening alone was already implemented; the payload was not, which is
+/// why every pod in the game hatched into nothing.
+pub struct BaseEgg {
+    payload: EggPayload,
+    hatched: bool,
+}
+
+impl BaseEgg {
+    pub fn new(payload: EggPayload) -> Self {
+        Self {
+            payload,
+            hatched: false,
+        }
+    }
+}
+
+impl Script for BaseEgg {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
+        }
+        // A pod hatches once. Its tripwire is authored ONCE, but a pod can
+        // also be reached by a relayed TurnOn, and a second clutch of grubs
+        // from a shell that is already open is not a thing the game does.
+        if self.hatched {
+            return Effect::NoEffect;
+        }
+
+        let (position, rotation) = {
+            let v_position = world.borrow::<View<PropPosition>>().unwrap();
+            let Ok(position) = v_position.get(entity_id) else {
+                // Nowhere to put a payload. Leave the pod unhatched rather
+                // than latching a shell that produced nothing.
+                return Effect::NoEffect;
+            };
+            (position.position, position.rotation)
+        };
+        self.hatched = true;
+
+        let mut effects = vec![change_to_last_model(world, entity_id)];
+        effects.extend(self.payload.template_names().iter().map(|template_name| {
+            Effect::CreateEntityByTemplateName {
+                source_entity_id: entity_id,
+                template_name: (*template_name).to_owned(),
+                // Lifted clear of the shell along the POD's own up, not the
+                // world's: the wall-mounted variants run these same scripts,
+                // and a world-space lift would push their payload into the
+                // wall. Inside the shell a goo shot splashes on the pod
+                // instead of on the player.
+                position: vec3_to_point3(position + rotation * vec3(0.0, PAYLOAD_LIFT, 0.0)),
+                // The pod's own facing: a wall pod hatches out of the wall.
+                orientation: rotation,
+                // The payloads carry their own motion: the emitter's tweq
+                // launches the goo, and a creature walks or flies.
+                initial_velocity: vec3(0.0, 0.0, 0.0),
+                // Ordinary creation, NOT the emitter's launched-projectile
+                // mode: that path installs the template's authored projectile
+                // sphere, and the Swarm's is zero-radius, so the visible
+                // particle cloud would have nothing to shoot at.
+                options: CreateEntityOptions::default(),
+            }
+        }));
+        Effect::Multiple(effects)
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SCRIPT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &BaseEggState {
+                hatched: self.hatched,
+            },
+            SCRIPT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: BaseEggState = state.decode(1, SCRIPT_STATE_KEY)?;
+        self.hatched = restored.hatched;
+        Ok(())
+    }
+}
+
+/// Height above the pod's origin the payload is created at, in world units
+/// (one unit is 0.76 m) - just above the shell's own sphere.
+const PAYLOAD_LIFT: f32 = 1.2;

--- a/shock2vr/src/scripts/base_egg.rs
+++ b/shock2vr/src/scripts/base_egg.rs
@@ -47,6 +47,22 @@ impl EggPayload {
             EggPayload::Swarmer => &["Swarm"],
         }
     }
+
+    /// How far above the pod's origin the payload is created, along the POD's
+    /// own up (the wall-mounted variants run these same scripts, so a
+    /// world-space offset would push their payload into the wall).
+    ///
+    /// The goo emitter needs real clearance - it fires from where it stands,
+    /// and inside the shell its globs splash on the pod instead of on the
+    /// player. A creature only needs to clear the shell's mouth: nothing
+    /// grounds it until its own locomotion runs, so a larger offset leaves it
+    /// visibly hovering and a smaller one hides it inside the pod.
+    fn lift(&self) -> f32 {
+        match self {
+            EggPayload::Goo => GOO_MUZZLE_CLEARANCE,
+            EggPayload::Grub | EggPayload::Swarmer => SHELL_MOUTH,
+        }
+    }
 }
 
 /// An annelid egg pod: retail `BaseEgg` plus one of its three payload
@@ -100,17 +116,13 @@ impl Script for BaseEgg {
         };
         self.hatched = true;
 
+        let lift = self.payload.lift();
         let mut effects = vec![change_to_last_model(world, entity_id)];
         effects.extend(self.payload.template_names().iter().map(|template_name| {
             Effect::CreateEntityByTemplateName {
                 source_entity_id: entity_id,
                 template_name: (*template_name).to_owned(),
-                // Lifted clear of the shell along the POD's own up, not the
-                // world's: the wall-mounted variants run these same scripts,
-                // and a world-space lift would push their payload into the
-                // wall. Inside the shell a goo shot splashes on the pod
-                // instead of on the player.
-                position: vec3_to_point3(position + rotation * vec3(0.0, PAYLOAD_LIFT, 0.0)),
+                position: vec3_to_point3(position + rotation * vec3(0.0, lift, 0.0)),
                 // The pod's own facing: a wall pod hatches out of the wall.
                 orientation: rotation,
                 // The payloads carry their own motion: the emitter's tweq
@@ -151,6 +163,11 @@ impl Script for BaseEgg {
     }
 }
 
-/// Height above the pod's origin the payload is created at, in world units
-/// (one unit is 0.76 m) - just above the shell's own sphere.
-const PAYLOAD_LIFT: f32 = 1.2;
+/// How far above a goo pod's origin its emitter stands, in world units (one
+/// unit is 0.76 m) - clear of the shell's own sphere, so the globs leave the
+/// muzzle instead of splashing on the pod that fired them.
+const GOO_MUZZLE_CLEARANCE: f32 = 1.2;
+
+/// The lip of an open pod, measured off the shell's own bounds (its top sits
+/// 0.78 above the origin), so a hatched creature sits in the shell's mouth.
+const SHELL_MOUTH: f32 = 0.8;

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -579,6 +579,12 @@ pub enum Effect {
         position: Point3<f32>,
         orientation: Quaternion<f32>,
         initial_velocity: Vector3<f32>,
+        /// How the fresh entity is built. A Tweq emitter passes
+        /// `launch_projectile` because Dark hands its emissions to
+        /// `launchProjectile`; a payload that is a creature must not, or the
+        /// authored projectile sphere replaces its selection collider (the
+        /// Swarm's is zero-radius, leaving nothing to shoot at).
+        options: CreateEntityOptions,
     },
 
     /// Deploy the authored proximity sensor and link its lifetime to the mine.

--- a/shock2vr/src/scripts/goo_projectile.rs
+++ b/shock2vr/src/scripts/goo_projectile.rs
@@ -1,0 +1,66 @@
+use dark::properties::PropTemplateId;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, internal_collision_type::terminal_impact_effects};
+
+/// The glob a goo egg's emitter lobs - retail `GooProjectile`, "egg splat".
+///
+/// Its `PropCollisionType` is a plain BOUNCE (the gamesys deliberately drops
+/// the projectile archetype's `SLAY_ON_IMPACT`), because retail leaves the
+/// terminal impact to this script's Slay Result instead. So the shared
+/// collision handler stays inert on a goo shot and the splat is applied here:
+/// slay on contact, which delivers the authored contact venom stim to whatever
+/// was hit and leaves the authored corpse spang behind.
+pub struct GooProjectile {
+    impact_handled: bool,
+}
+
+impl GooProjectile {
+    pub fn new() -> Self {
+        Self {
+            impact_handled: false,
+        }
+    }
+}
+
+impl Script for GooProjectile {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let MessagePayload::Collided { with, contact } = msg else {
+            return Effect::NoEffect;
+        };
+        // Globs from one volley pass through each other. The emitter fires
+        // all four straight up from a single point 100 ms apart, so a fresh
+        // one overlaps the previous one still leaving the muzzle; without
+        // this the volley annihilates itself at the pod and no venom ever
+        // reaches the player. Deliberately narrow - only another glob, not
+        // every projectile in the air.
+        if is_same_archetype(world, entity_id, *with) {
+            return Effect::NoEffect;
+        }
+        // One splat per glob: a single contact can queue several messages
+        // before the slay is applied.
+        if self.impact_handled {
+            return Effect::NoEffect;
+        }
+        self.impact_handled = true;
+        terminal_impact_effects(world, physics, entity_id, *with, *contact, true, true)
+    }
+}
+
+/// Whether two entities were created from the same template - i.e. `other` is
+/// another glob from this same volley.
+fn is_same_archetype(world: &World, entity_id: EntityId, other: EntityId) -> bool {
+    let templates = world.borrow::<View<PropTemplateId>>().unwrap();
+    match (templates.get(entity_id), templates.get(other)) {
+        (Ok(mine), Ok(theirs)) => mine.template_id == theirs.template_id,
+        _ => false,
+    }
+}

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -64,81 +64,104 @@ impl Script for InternalCollisionType {
                 // messages before destruction is applied. One projectile has
                 // one terminal impact, including damage, sound and spang.
                 self.impact_handled = true;
-                let initial_effect = if self.collision_flags.contains(CollisionType::SLAY_ON_IMPACT)
-                {
-                    Effect::SlayEntity { entity_id }
-                } else {
-                    Effect::DestroyEntity { entity_id }
-                };
-                let damage_effect = projectile_contact_effects(
+                // NO_COLLISION_SOUND is the authored opt-out.
+                // FULL_COLLISION_SOUND needs no special handling: impact
+                // sounds always play at full volume here (no velocity
+                // scaling).
+                terminal_impact_effects(
                     world,
+                    physics,
                     entity_id,
                     *with,
-                    contact.map(|contact| crate::scripts::DamageImpact {
-                        direction: contact.normal,
-                        point: contact.point,
-                        bone: None,
-                    }),
-                );
-                let mut effects = vec![initial_effect, damage_effect];
-
-                let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
-
-                // Impact effect, from the projectile's authored spang links
-                // (HitSpang matched by victim class, MissSpang fallback) -
-                // the same selection as the fast (raycast) projectile path.
-                // This is what makes slow projectiles (laser/fusion bolts,
-                // grenades) show their authored impact FX. At most one spang
-                // per projectile: an impact starting contact with several
-                // colliders at once (a corner, a creature capsule + its
-                // hitbox proxy) queues multiple Collided messages before the
-                // slay/destroy effect lands.
-                if let Some(template_id) = choose_impact_spang(world, entity_id, *with) {
-                    // The physics collision event carries no contact normal,
-                    // and spang orientation is minor cosmetics, so
-                    // approximate the impact facing with the reversed
-                    // velocity. This is read post-solve, so it may already be
-                    // deflected by the contact; if the solver stopped the
-                    // projectile outright, fall back to straight up.
-                    let facing = physics
-                        .get_velocity(entity_id)
-                        .filter(|v| v.magnitude2() > 1e-6)
-                        .map(|v| -v.normalize())
-                        .unwrap_or(vec3(0.0, 1.0, 0.0));
-                    effects.push(Effect::CreateEntity {
-                        template_id,
-                        position,
-                        orientation: get_rotation_from_forward_vector(facing)
-                            * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
-                        root_transform: Matrix4::identity(),
-                        options: CreateEntityOptions {
-                            transient_fx: true,
-                            ..CreateEntityOptions::default()
-                        },
-                    });
-                }
-
-                // Impact sound (material-tagged collision schema), unless the
-                // collision type opts out. FULL_COLLISION_SOUND needs no
-                // special handling: impact sounds always play at full volume
-                // here (no velocity scaling).
-                if !self
-                    .collision_flags
-                    .contains(CollisionType::NO_COLLISION_SOUND)
-                {
-                    effects.push(play_impact_sound(
-                        world,
-                        entity_id,
-                        *with,
-                        position.to_vec(),
-                    ));
-                }
-
-                Effect::Multiple(effects)
+                    *contact,
+                    self.collision_flags.contains(CollisionType::SLAY_ON_IMPACT),
+                    !self
+                        .collision_flags
+                        .contains(CollisionType::NO_COLLISION_SOUND),
+                )
             }
             _ => Effect::NoEffect,
         }
     }
+}
+
+/// The one terminal impact a projectile has: slay-or-destroy, contact-stim
+/// damage, the authored spang, and the material impact sound.
+///
+/// Shared with `GooProjectile`, whose retail script applies its Slay Result on
+/// collision instead of declaring it in `PropCollisionType` - so the goo shot
+/// needs this behavior with `slay` and `play_sound` supplied by the script
+/// rather than read off the authored flags. Callers own the once-per-
+/// projectile latch.
+pub(super) fn terminal_impact_effects(
+    world: &World,
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+    with: EntityId,
+    contact: Option<crate::physics::CollisionContact>,
+    slay: bool,
+    play_sound: bool,
+) -> Effect {
+    let initial_effect = if slay {
+        Effect::SlayEntity { entity_id }
+    } else {
+        Effect::DestroyEntity { entity_id }
+    };
+    let damage_effect = projectile_contact_effects(
+        world,
+        entity_id,
+        with,
+        contact.map(|contact| crate::scripts::DamageImpact {
+            direction: contact.normal,
+            point: contact.point,
+            bone: None,
+        }),
+    );
+    let mut effects = vec![initial_effect, damage_effect];
+
+    let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+
+    // Impact effect, from the projectile's authored spang links
+    // (HitSpang matched by victim class, MissSpang fallback) -
+    // the same selection as the fast (raycast) projectile path.
+    // This is what makes slow projectiles (laser/fusion bolts,
+    // grenades) show their authored impact FX. At most one spang
+    // per projectile: an impact starting contact with several
+    // colliders at once (a corner, a creature capsule + its
+    // hitbox proxy) queues multiple Collided messages before the
+    // slay/destroy effect lands.
+    if let Some(template_id) = choose_impact_spang(world, entity_id, with) {
+        // The physics collision event carries no contact normal,
+        // and spang orientation is minor cosmetics, so
+        // approximate the impact facing with the reversed
+        // velocity. This is read post-solve, so it may already be
+        // deflected by the contact; if the solver stopped the
+        // projectile outright, fall back to straight up.
+        let facing = physics
+            .get_velocity(entity_id)
+            .filter(|v| v.magnitude2() > 1e-6)
+            .map(|v| -v.normalize())
+            .unwrap_or(vec3(0.0, 1.0, 0.0));
+        effects.push(Effect::CreateEntity {
+            template_id,
+            position,
+            orientation: get_rotation_from_forward_vector(facing)
+                * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
+            root_transform: Matrix4::identity(),
+            options: CreateEntityOptions {
+                transient_fx: true,
+                ..CreateEntityOptions::default()
+            },
+        });
+    }
+
+    // Impact sound (material-tagged collision schema); whether it plays at all
+    // is the caller's decision.
+    if play_sound {
+        effects.push(play_impact_sound(world, entity_id, with, position.to_vec()));
+    }
+
+    Effect::Multiple(effects)
 }
 
 #[cfg(test)]

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -8,6 +8,7 @@ pub mod stasis;
 mod apparition;
 mod auto_install_soft;
 mod base_button;
+mod base_egg;
 mod base_elevator;
 mod base_light;
 mod base_monster;
@@ -29,6 +30,7 @@ mod energy_station;
 mod energy_weapon;
 mod exp_cookie;
 mod frob_qb;
+mod goo_projectile;
 pub mod gui;
 pub mod healing_item;
 mod homing;
@@ -150,6 +152,7 @@ use self::trap_signal::TrapSignal;
 use self::{
     auto_install_soft::AutoInstallSoft,
     base_button::BaseButton,
+    base_egg::{BaseEgg, EggPayload},
     base_elevator::BaseElevator,
     base_light::BaseLight,
     base_monster::BaseMonster,
@@ -167,6 +170,7 @@ use self::{
     energy_weapon::EnergyWeapon,
     exp_cookie::ExpCookie,
     frob_qb::FrobQB,
+    goo_projectile::GooProjectile,
     impact_sound::HeldItemImpactSound,
     internal_collision_type::InternalCollisionType,
     internal_explosion::InternalExplosion,
@@ -955,9 +959,16 @@ impl ScriptWorld {
 
             // AI stuff
             "trapsignal" => Box::new(TrapSignal::new()),
-            "gooegg" => Box::new(Tweqable::new()),
-            "grubegg" => Box::new(Tweqable::new()),
-            "swarmeregg" => Box::new(Tweqable::new()),
+            "gooegg" => Box::new(BaseEgg::new(EggPayload::Goo)),
+            "grubegg" => Box::new(BaseEgg::new(EggPayload::Grub)),
+            "swarmeregg" => Box::new(BaseEgg::new(EggPayload::Swarmer)),
+            "gooprojectile" => Box::new(GooProjectile::new()),
+            // The flying annelid a swarmer pod hatches. Its retail script owns
+            // the swarm's flocking; the port's `swarmer` AI is still a stub, so
+            // a hatched swarm is a damageable particle cloud that does not yet
+            // chase. Mapped explicitly so the pod can hatch at all - the
+            // fallback would panic on load.
+            "swarm" => Box::new(NoopScript::new()),
             "containerscript" => gui_script(Box::new(ContainerGui::loot_container())),
 
             "lootable" => Box::new(NoopScript::new()),

--- a/shock2vr/src/systems/tweq.rs
+++ b/shock2vr/src/systems/tweq.rs
@@ -10,7 +10,12 @@ use dark::{
 };
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, UniqueViewMut, View, ViewMut};
 
-use crate::{mission::EffectQueue, scripts::Effect, time::Time, util::vec3_to_point3};
+use crate::{
+    mission::{EffectQueue, entity_creator::CreateEntityOptions},
+    scripts::Effect,
+    time::Time,
+    util::vec3_to_point3,
+};
 
 ///
 /// run_tweq
@@ -74,6 +79,10 @@ pub fn run_tweq(
                     position: vec3_to_point3(position.position),
                     orientation: position.rotation,
                     initial_velocity: authored_velocity / SCALE_FACTOR,
+                    options: CreateEntityOptions {
+                        launch_projectile: true,
+                        ..CreateEntityOptions::default()
+                    },
                 });
             }
 

--- a/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
+++ b/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Every annelid egg pod in the game used to hatch into nothing: all three
+// scripts (GooEgg / GrubEgg / SwarmerEgg) were mapped to the plain model tweq,
+// so a pod opened its shell and produced no payload.
+//
+// Driven in `debug_annelid`, which places one pod of each kind and nothing
+// else. A shipped level is the wrong bench here: its pods are armed with
+// authored tripwires that the player's own spawn can already have sprung, so
+// "did MY TurnOn hatch it" is not answerable there. The pods themselves are the
+// shipped gamesys templates running the shipped scripts.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+
+/** Pod template -> the gamesys template its script must create. */
+const HATCHES: { pod: number; payload: number; what: string }[] = [
+  // GooEgg creates two objects; assert the cloud, because the emitter destroys
+  // itself the moment its four shots are away. The shots are the second test.
+  { pod: -1476, payload: -438, what: "EggGooCloud" },
+  { pod: -1335, payload: -182, what: "Grub" },
+  { pod: -1332, payload: -183, what: "Swarm" },
+];
+
+test(
+  "each annelid egg pod hatches its authored payload on TurnOn",
+  { skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_annelid" });
+    // The bench spawns its pods on the first stepped frame.
+    await game.step({ frames: 30 });
+
+    for (const { pod, payload, what } of HATCHES) {
+      const [target] = await game.entities.byTemplate(pod);
+      assert.ok(target, `the bench should place template ${pod}`);
+
+      const before = new Set(
+        (await game.entities.byTemplate(payload)).map((entity) => entity.id),
+      );
+      await game.entities.sendMessage(target.id, { type: "TurnOn" });
+      // Enough to deliver the message and apply the hatch effects.
+      await game.step({ frames: 5 });
+      const hatched = (await game.entities.byTemplate(payload)).filter(
+        (entity) => !before.has(entity.id),
+      );
+
+      assert.equal(hatched.length, 1, `template ${pod} should hatch a ${what}`);
+    }
+  },
+);
+
+test(
+  "a goo pod's emitted shots survive their own volley and fly",
+  { skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_annelid" });
+    await game.step({ frames: 30 });
+    const [pod] = await game.entities.byTemplate(-1476);
+    assert.ok(pod, "the goo station should hold a Floor Pod");
+
+    await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+    // The emitter releases its four shots 100 ms apart, all from one point and
+    // all straight up - they used to annihilate each other at the muzzle.
+    await game.step({ frames: 45 });
+
+    const shots = await game.entities.byTemplate(-1557);
+    assert.equal(shots.length, 4, "all four goo shots should still be alive");
+    const heights = shots.map((shot) => shot.position[1]!);
+    assert.ok(
+      Math.max(...heights) - Math.min(...heights) > 0.5,
+      `the volley should be strung out in flight, got ${heights.join(", ")}`,
+    );
+
+    // ...and then splat. GooProjectile owns the terminal impact (its authored
+    // collision type is a plain BOUNCE, so the shared handler is inert on a
+    // glob) - without it the globs never slay, and the venom is never
+    // delivered to whatever they land on. They arc back down onto the pod.
+    await game.step({ frames: 600 });
+    assert.equal(
+      (await game.entities.byTemplate(-1557)).length,
+      0,
+      "every goo shot should have splatted",
+    );
+    // grubspang is the glob's authored corpse, one per splat.
+    assert.equal(
+      (await game.entities.byTemplate(-2540)).length,
+      4,
+      "each splat should leave its authored spang",
+    );
+  },
+);


### PR DESCRIPTION
## The bug

Every annelid egg pod in the game hatched into nothing. All three retail scripts were mapped to the plain model tweq in `scripts/mod.rs`:

```rust
"gooegg"     => Box::new(Tweqable::new()),
"grubegg"    => Box::new(Tweqable::new()),
"swarmeregg" => Box::new(Tweqable::new()),
```

so a pod swapped `eggcl` for `eggop` and stopped there. Measured on a shipped hydro1 pod before this change: `TurnOn` delivered, model became `eggop`, entity count unchanged.

Two more pieces were missing behind it — `GooProjectile` and `swarm` were unmapped entirely, so both would have hit `PanicOnLoadScript` the moment anything actually hatched. That is why the top-level bug had never surfaced as a crash.

## The fix

Implements retail `BaseEgg` plus its three payload subclasses. A pod opens and creates its authored objects at its own pose:

| Pod | Script | Payload |
| --- | --- | --- |
| Goo (`-1476` / `-1475`) | `GooEgg` | `Egg Goo Emitter` + `EggGooCloud` — the emitter's tweq lobs four venom-stimmed `Goo Projectile`s, then destroys itself |
| Grub (`-1335` / `-1333`) | `GrubEgg` | `Grub` |
| Swarmer (`-1332` / `-1331`) | `SwarmerEgg` | `Swarm` |

Hatching latches once and rides the standard `script_state_key` / `save_state` / `restore_state` hooks across save/load. The payload is created at the pod's own rotation and lifted along the pod's own up, so the wall-mounted variants (which run these same scripts) hatch out of the wall rather than into it.

`GooProjectile` owns its own terminal impact: the gamesys drops the projectile archetype's `SLAY_ON_IMPACT` down to a plain `BOUNCE` because retail leaves the splat to the script's Slay Result, so `InternalCollisionType` is inert on a glob. Its slay / damage / spang / sound body is **extracted** out of `InternalCollisionType` into a shared `terminal_impact_effects` rather than copied.

Globs from one volley pass through each other. The emitter fires all four straight up from a single point 100 ms apart, so each one overlapped the previous one still leaving the muzzle — confirmed by logging the collision partner, `GOO_DEBUG goo hit ... name="Goo Projectile"` — and the volley annihilated itself at the pod.

`Effect::CreateEntityByTemplateName` grows an `options` field. It forced `launch_projectile`, which is correct for a Tweq emitter (Dark hands its emissions to `launchProjectile`) but wrong for a creature payload: that path installs the template's authored projectile sphere, and the Swarm's is zero-radius, leaving the visible particle cloud with nothing to shoot at. Measured after the fix — Swarm now carries a real 0.2-unit `selectable` body, Grub 0.4.

## Verification

New bench: `cargo dbgr --mission debug_annelid` — one pod of each kind at a labeled station, tripped by walking within 2.5 units, the way a mission's authored `Floor Egg Tripwire` trips its pod.

New e2e (`tools/shock2-sdk/test/annelid-eggs.e2e.test.ts`), both confirmed **red without this change**:

- each pod hatches its authored payload on `TurnOn`;
- the four goo shots survive their own volley, string out in flight, then all splat and leave their four authored `grubspang` corpses.

`cargo test -p shock2vr` 1696 passed; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Known gaps, unchanged by this PR

- `grub` and `swarmer` AI are still `NoopScript` stubs in `base_monster.rs`, so a hatched creature does not chase yet. The pods deliver; the creatures sit.
- Retail `BaseEgg` plays a `pod_exp` schema on opening. The port's environmental-sound lookup is tag-based with no schema-name path, so the hatch is silent.
- `EggGooCloud` has no lifetime and lingers at the pod. It is also decoration today: it authors a Venom *radius* stim, and the port applies radius stims only from explosions and the radiation source, so the toxin a goo pod actually deals is the globs' contact stim.

## Visual evidence

![Goo pod hatching](https://gist.githubusercontent.com/tommy-xr/41e6195dfa1e266451352a9626c34271/raw/annelid-goo-hatch.gif)

<sub>`debug_annelid`, goo station: the pod's shell opens and the hatched emitter lobs its four goo globs up and back down onto the pod, each ending in a splat. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

All three stations tripped, each showing its own payload - the swarmer's flying `Swarm` cloud (near), the `Grub` crawler seated in its shell's mouth (middle), and the goo station's volley in flight (far):

![All three pods hatched](https://gist.githubusercontent.com/tommy-xr/41e6195dfa1e266451352a9626c34271/raw/d6199718246b2336c1e4f4c1b1d852684b07c08b/annelid-three-stations.png)

## Before → after

Same deterministic sequence (`TurnOn` the goo pod, step 45 frames), with the three egg scripts mapped back to the plain model tweq for the "before":

![before/after](https://gist.githubusercontent.com/tommy-xr/41e6195dfa1e266451352a9626c34271/raw/annelid-before-after.png)


