### PR TITLE
fix(physics): launch emitted projectiles with their authored velocity

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -516,8 +516,14 @@ pub struct PropPhysDimensions {
     pub offset0: Vector3<f32>,
     pub offset1: Vector3<f32>,
     pub size: Vector3<f32>,
-    pub unk1: u32,
-    pub unk2: u32,
+    /// Treat this model as a point when tested against world terrain.
+    pub point_vs_terrain: u32,
+    /// Treat this model as a point against anything that is not "special".
+    ///
+    /// The original also uses it as a collision *filter*: two models that both
+    /// set it and are both non-special never collide with each other, which is
+    /// what keeps a stream of projectiles from detonating on one another.
+    pub point_vs_not_special: u32,
 }
 
 /// `P$MovingTer` - marks a physical object as authored moving terrain.
@@ -2136,6 +2142,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$CfgTweqRo",
+            PropTweqRotateConfig::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$StTweqRot",
             PropTweqRotateState::read,
             identity,
@@ -2253,8 +2265,8 @@ fn read_prop_phys_dimensions<T: io::Read + io::Seek>(
     let offset0 = read_vec3(reader) / SCALE_FACTOR;
     let offset1 = read_vec3(reader) / SCALE_FACTOR;
     let size = read_vec3(reader) / SCALE_FACTOR;
-    let unk1 = read_u32(reader);
-    let unk2 = read_u32(reader);
+    let point_vs_terrain = read_u32(reader);
+    let point_vs_not_special = read_u32(reader);
 
     PropPhysDimensions {
         radius0,
@@ -2262,8 +2274,8 @@ fn read_prop_phys_dimensions<T: io::Read + io::Seek>(
         offset0,
         offset1,
         size,
-        unk1,
-        unk2,
+        point_vs_terrain,
+        point_vs_not_special,
     }
 }
 

--- a/dark/src/properties/prop_tweq.rs
+++ b/dark/src/properties/prop_tweq.rs
@@ -74,6 +74,72 @@ impl PropTweqRotateState {
     }
 }
 
+/// One axis of a rotate tweq: how fast it turns and between which angles.
+///
+/// The original stores this as a `rate-low-high` triple per axis, in degrees
+/// (rate is degrees per second).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+pub struct TweqAxisLimits {
+    pub rate: f32,
+    pub low: f32,
+    pub high: f32,
+}
+
+/// `P$CfgTweqRo` - the authored spin of a rotate tweq.
+///
+/// Laid out as the original's vector-tweq config: the shared 8-byte base
+/// config, then a `rate-low-high` triple for each of the three axes, then the
+/// primary axis index and padding (48 bytes total). Without it every rotating
+/// object in the port turns at one hardcoded rate, which is wrong for anything
+/// whose spin has an observable consequence - a Tweq emitter's facing sets the
+/// direction its emissions are launched in.
+#[derive(Debug, Component, Clone, Deserialize, Serialize)]
+pub struct PropTweqRotateConfig {
+    pub animation_config: TweqAnimationConfig,
+    pub halt: TweqHalt,
+    /// Per-axis spin, in the original's axis order.
+    pub axes: [TweqAxisLimits; 3],
+    /// Index into [`Self::axes`] of the axis the original treats as primary.
+    pub primary_axis: u8,
+}
+
+impl PropTweqRotateConfig {
+    pub fn read<T: io::Seek + io::Read>(reader: &mut T, _len: u32) -> PropTweqRotateConfig {
+        let _tweq_type = read_u8(reader);
+        let _curve = read_u8(reader);
+        let animation_config_bits = read_u8(reader);
+        let animation_config =
+            TweqAnimationConfig::from_bits(animation_config_bits.into()).unwrap();
+        let halt_bits = read_u8(reader);
+        let halt: TweqHalt = num_traits::FromPrimitive::from_u8(halt_bits).unwrap();
+        let _misc = read_u16(reader);
+        let _rate = read_u16(reader);
+
+        let mut axes = [TweqAxisLimits {
+            rate: 0.0,
+            low: 0.0,
+            high: 0.0,
+        }; 3];
+        for axis in axes.iter_mut() {
+            axis.rate = read_single(reader);
+            axis.low = read_single(reader);
+            axis.high = read_single(reader);
+        }
+        let primary_axis = read_u8(reader);
+        // pad[3] - the original pads the struct back to a 4-byte boundary.
+        for _ in 0..3 {
+            let _pad = read_u8(reader);
+        }
+
+        PropTweqRotateConfig {
+            animation_config,
+            halt,
+            axes,
+            primary_axis,
+        }
+    }
+}
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTweqModelState {
     pub animation_state: TweqAnimationState,
@@ -264,7 +330,10 @@ impl PropTweqDeleteConfig {
 mod tests {
     use std::io::Cursor;
 
-    use super::{PropTweqEmitterConfig, PropTweqModelState, TweqAnimationState};
+    use super::{
+        PropTweqEmitterConfig, PropTweqModelState, PropTweqRotateConfig, TweqAnimationState,
+        TweqAxisLimits,
+    };
 
     #[test]
     fn model_state_reads_the_authored_frame_number() {
@@ -279,6 +348,44 @@ mod tests {
 
         assert!(state.animation_state.contains(TweqAnimationState::REVERSE));
         assert_eq!(state.frame, 4);
+    }
+
+    #[test]
+    fn rotate_config_reads_the_per_axis_rate_limits_and_primary_axis() {
+        // sTweqVectorConfig: an 8-byte base config, three (rate, low, high)
+        // float triples, then primary_axis + 3 pad = 48 bytes.
+        let mut raw = vec![
+            0x00, // type
+            0x00, // curve
+            0x00, // anim config
+            0x00, // halt action
+            0x00, 0x00, // misc
+            0x00, 0x00, // rate
+        ];
+        for (rate, low, high) in [
+            (0.0f32, 0.0f32, 0.0f32),
+            (0.0, 0.0, 0.0),
+            (50.0, 0.0, 360.0),
+        ] {
+            raw.extend_from_slice(&rate.to_le_bytes());
+            raw.extend_from_slice(&low.to_le_bytes());
+            raw.extend_from_slice(&high.to_le_bytes());
+        }
+        raw.push(2); // primary_axis
+        raw.extend_from_slice(&[0, 0, 0]); // pad
+        assert_eq!(raw.len(), 48);
+
+        let config = PropTweqRotateConfig::read(&mut Cursor::new(raw), 48);
+        assert_eq!(config.primary_axis, 2);
+        assert_eq!(
+            config.axes[2],
+            TweqAxisLimits {
+                rate: 50.0,
+                low: 0.0,
+                high: 360.0
+            }
+        );
+        assert_eq!(config.axes[0].rate, 0.0);
     }
 
     #[test]

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1999,8 +1999,8 @@ mod tests {
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: Vector3::zero(),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
         ));
 
@@ -2051,8 +2051,8 @@ mod tests {
             offset0: vec3(9.0, 8.0, 7.0),
             offset1: vec3(-6.0, -5.0, -4.0),
             size: Vector3::zero(),
-            unk1: 0,
-            unk2: 0,
+            point_vs_terrain: 0,
+            point_vs_not_special: 0,
         }
     }
 
@@ -2410,8 +2410,8 @@ mod tests {
                 offset0: vec3(0.0, 0.36, 0.0),
                 offset1: Vector3::zero(),
                 size: Vector3::zero(),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
         ));
 
@@ -2467,8 +2467,8 @@ mod tests {
                 offset0: offset,
                 offset1: Vector3::zero(),
                 size: Vector3::zero(),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
         ));
 
@@ -2579,8 +2579,8 @@ mod tests {
                     offset0: offset,
                     offset1: Vector3::zero(),
                     size,
-                    unk1: 0,
-                    unk2: 0,
+                    point_vs_terrain: 0,
+                    point_vs_not_special: 0,
                 },
             ));
             if immobile {
@@ -2669,8 +2669,8 @@ mod tests {
                     offset0: Vector3::zero(),
                     offset1: Vector3::zero(),
                     size,
-                    unk1: 0,
-                    unk2: 0,
+                    point_vs_terrain: 0,
+                    point_vs_not_special: 0,
                 },
             ));
 
@@ -2854,8 +2854,8 @@ mod tests {
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: authored_size,
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
             PropScale(vec3(-0.888_888_9, 1.333_333_4, 16.0)),
             PropImmobile(true),
@@ -2996,8 +2996,8 @@ mod tests {
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: vec3(2.4, 0.4, 2.4),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
         ));
         let child = world.add_entity((
@@ -3018,8 +3018,8 @@ mod tests {
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: Vector3::zero(),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
             Links {
                 to_links: vec![ToLink {
@@ -3106,8 +3106,8 @@ mod tests {
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: vec3(2.4, 3.2, 0.2),
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
             },
             dark::properties::PropTranslatingDoor {
                 door_type: 1,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8336,8 +8336,30 @@ impl MissionCore {
                         orientation,
                         options,
                     ) {
+                        // Retail's launchProjectile composes two terms: the
+                        // emitted archetype's OWN authored initial velocity,
+                        // rotated into the launcher's frame, plus the caller's
+                        // velocity as an addition. Dropping the first term is
+                        // what flattened an emitted volley into a single
+                        // straight column - the goo pod's globs carry a
+                        // horizontal component that the spinning emitter aims
+                        // somewhere new on every emission.
+                        let archetype_velocity = self
+                            .world
+                            .borrow::<View<PropPhysInitialVelocity>>()
+                            .ok()
+                            .and_then(|velocities| {
+                                velocities.get(created.entity_id).ok().map(|velocity| {
+                                    // Same re-permutation as the GunFlash
+                                    // casing path: the parser's runtime vector
+                                    // back into a +Z-forward launch frame.
+                                    orientation * vec3(velocity.0.z, velocity.0.y, -velocity.0.x)
+                                        / SCALE_FACTOR
+                                })
+                            })
+                            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
                         self.physics
-                            .set_velocity(created.entity_id, initial_velocity);
+                            .set_velocity(created.entity_id, archetype_velocity + initial_velocity);
                     } else {
                         warn!(
                             "{:?} could not resolve authored template {:?}",
@@ -9965,6 +9987,17 @@ impl MissionCore {
                     if let Some(rigid_body_handle) = self.id_to_physics.get(&entity_id) {
                         self.physics.set_rotation(*rigid_body_handle, rotation);
                     };
+                    // Also the authored property, which is where a rotate tweq
+                    // reads the pose it advances from. Without this the spin is
+                    // inert on anything with no rigid body to hold it - the
+                    // Tweq emitters are NoRender and physics-less, so their
+                    // facing never moved and every volley left in one
+                    // direction.
+                    if let Ok(mut positions) = self.world.borrow::<ViewMut<PropPosition>>() {
+                        if let Ok(position) = (&mut positions).get(entity_id) {
+                            position.rotation = rotation;
+                        }
+                    }
                 }
                 Effect::PositionInventory { position, rotation } => {
                     PlayerInventoryEntity::set_position_rotation(
@@ -12610,8 +12643,8 @@ fn create_room_entities(
             PropPhysDimensions {
                 radius0: 0.0,
                 radius1: 1.0,
-                unk1: 0,
-                unk2: 0,
+                point_vs_terrain: 0,
+                point_vs_not_special: 0,
                 offset0: Vector3::zero(),
                 offset1: Vector3::zero(),
                 size: (room.bounding_box.max - room.bounding_box.min),

--- a/shock2vr/src/scripts/goo_projectile.rs
+++ b/shock2vr/src/scripts/goo_projectile.rs
@@ -1,4 +1,4 @@
-use dark::properties::PropTemplateId;
+use dark::properties::{PropPhysDimensions, PropPhysType};
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
@@ -36,13 +36,12 @@ impl Script for GooProjectile {
         let MessagePayload::Collided { with, contact } = msg else {
             return Effect::NoEffect;
         };
-        // Globs from one volley pass through each other. The emitter fires
-        // all four straight up from a single point 100 ms apart, so a fresh
-        // one overlaps the previous one still leaving the muzzle; without
-        // this the volley annihilates itself at the pod and no venom ever
-        // reaches the player. Deliberately narrow - only another glob, not
-        // every projectile in the air.
-        if is_same_archetype(world, entity_id, *with) {
+        // The original's point-vs-not-special rule: two models that both set
+        // `point_vs_not_special` and are both non-special never collide with
+        // each other. The Projectile archetype sets both bits, which is what
+        // stops a stream of emitted globs from detonating on one another
+        // before it has cleared the muzzle.
+        if passes_through(world, entity_id, *with) {
             return Effect::NoEffect;
         }
         // One splat per glob: a single contact can queue several messages
@@ -55,12 +54,22 @@ impl Script for GooProjectile {
     }
 }
 
-/// Whether two entities were created from the same template - i.e. `other` is
-/// another glob from this same volley.
-fn is_same_archetype(world: &World, entity_id: EntityId, other: EntityId) -> bool {
-    let templates = world.borrow::<View<PropTemplateId>>().unwrap();
-    match (templates.get(entity_id), templates.get(other)) {
-        (Ok(mine), Ok(theirs)) => mine.template_id == theirs.template_id,
-        _ => false,
-    }
+/// The original's point-vs-not-special collision filter, for one pair.
+fn passes_through(world: &World, entity_id: EntityId, other: EntityId) -> bool {
+    let dimensions = world.borrow::<View<PropPhysDimensions>>().unwrap();
+    let phys_types = world.borrow::<View<PropPhysType>>().unwrap();
+    let point_vs_not_special = |entity| {
+        dimensions
+            .get(entity)
+            .is_ok_and(|dimensions| dimensions.point_vs_not_special != 0)
+    };
+    let special = |entity| {
+        phys_types
+            .get(entity)
+            .is_ok_and(|phys_type| phys_type.is_special)
+    };
+    point_vs_not_special(entity_id)
+        && point_vs_not_special(other)
+        && !special(entity_id)
+        && !special(other)
 }

--- a/shock2vr/src/scripts/psi_mine.rs
+++ b/shock2vr/src/scripts/psi_mine.rs
@@ -184,8 +184,8 @@ mod tests {
             offset0: vec3(0.0, 0.0, 0.0),
             offset1: vec3(0.0, 0.0, 0.0),
             size: vec3(0.0, 0.0, 0.0),
-            unk1: 1,
-            unk2: 1,
+            point_vs_terrain: 1,
+            point_vs_not_special: 1,
         }
     }
 

--- a/shock2vr/src/systems/tweq.rs
+++ b/shock2vr/src/systems/tweq.rs
@@ -5,9 +5,18 @@ use dark::{
     SCALE_FACTOR,
     properties::{
         PropPosition, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqEmitterConfig,
-        PropTweqEmitterState, PropTweqRotateState, TweqAnimationState, TweqHalt,
+        PropTweqEmitterState, PropTweqRotateConfig, PropTweqRotateState, TweqAnimationState,
+        TweqHalt,
     },
 };
+
+/// The rotate tweq axis the port spins: the original's third axis is heading,
+/// which its up axis maps onto our Y.
+const HEADING_AXIS: usize = 2;
+
+/// Spin rate for a rotating object with no authored rotate config, preserving
+/// the rate the port used before the config was parsed.
+const DEFAULT_SPIN_DEGREES_PER_SECOND: f32 = 20.0;
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, UniqueViewMut, View, ViewMut};
 
 use crate::{
@@ -26,6 +35,7 @@ pub fn run_tweq(
     u_time: UniqueView<Time>,
     v_prop_position: View<PropPosition>,
     v_tweq_rotate_state: View<PropTweqRotateState>,
+    v_tweq_rotate_config: View<PropTweqRotateConfig>,
     mut v_tweq_emit_state: ViewMut<PropTweqEmitterState>,
     mut v_tweq_emit_config: ViewMut<PropTweqEmitterConfig>,
     mut v_tweq_delete_state: ViewMut<PropTweqDeleteState>,
@@ -34,12 +44,22 @@ pub fn run_tweq(
 ) {
     for (id, (tweq, position)) in (&v_tweq_rotate_state, &v_prop_position).iter().with_id() {
         if tweq.animation_state.contains(TweqAnimationState::ON) {
+            // Authored degrees per second for the heading axis when the object
+            // carries a rotate config. The rate matters wherever the spin has
+            // a consequence beyond looks: a Tweq emitter's facing aims what it
+            // launches, so the wrong rate collapses an emitted volley's fan.
+            // Objects with no authored config keep the previous fixed rate.
+            let degrees_per_second = v_tweq_rotate_config
+                .get(id)
+                .map(|config| config.axes[HEADING_AXIS].rate)
+                .unwrap_or(DEFAULT_SPIN_DEGREES_PER_SECOND);
             effects.push(Effect::SetRotation {
                 entity_id: id,
                 // Advance from the current pose; absolute world-time yaw erased
                 // authored pitch/roll (including a sideways ejected casing).
-                rotation: Quaternion::from_angle_y(Deg(u_time.elapsed.as_secs_f32() * 20.0))
-                    * position.rotation,
+                rotation: Quaternion::from_angle_y(Deg(
+                    u_time.elapsed.as_secs_f32() * degrees_per_second
+                )) * position.rotation,
             });
         }
     }

--- a/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
+++ b/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
@@ -92,3 +92,41 @@ test(
     );
   },
 );
+
+test(
+  "an emitted volley fans out as its emitter spins",
+  { skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_annelid" });
+    await game.step({ frames: 30 });
+    const [pod] = await game.entities.byTemplate(-1476);
+    assert.ok(pod);
+    await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+    // Long enough for all four to be away (100 ms apart) and still airborne.
+    await game.step({ frames: 26 });
+
+    const shots = await game.entities.byTemplate(-1557);
+    assert.equal(shots.length, 4);
+    const bodies = await Promise.all(
+      shots.map(async (shot) => (await game.physics.bodies({ entityId: shot.id })).bodies[0]),
+    );
+
+    // Each glob carries the archetype's own authored horizontal velocity,
+    // aimed by the emitter's facing at the moment it left. The emitter spins
+    // at its authored 50 deg/s, so the four headings must differ - taking only
+    // the tweq's straight-up emit velocity would give one shared heading.
+    const headings = bodies.map((body) => {
+      assert.ok(body);
+      return (Math.atan2(body.velocity[2]!, body.velocity[0]!) * 180) / Math.PI;
+    });
+    const spread = Math.max(...headings) - Math.min(...headings);
+    assert.ok(
+      spread > 5,
+      `the volley should fan as the emitter turns, got ${spread.toFixed(1)} deg from ${headings.map((h) => h.toFixed(1)).join(", ")}`,
+    );
+    assert.ok(
+      bodies.every((body) => Math.hypot(body!.velocity[0]!, body!.velocity[2]!) > 0.1),
+      "every glob should carry a horizontal component",
+    );
+  },
+);


### PR DESCRIPTION
Stacked on #1492 (base: `fix/annelid-egg-hatching`). Fixes #1496.

## The bug

A Tweq emitter's volley left in a single straight column. The port launched each emission with **only** the emitter's authored emit velocity. The original composes two terms:

```
velocity  = mat(emitter facing) * projectile's PhysInitialVelocity
velocity *= power
velocity += add_vel                // <- the Tweq's emit velocity, an ADDITION
velocity += launcher's velocity
```

The emitted archetype's **own** initial velocity is the base term, rotated into the emitter's frame; the Tweq's velocity is only added on top. We dropped the base term entirely.

That is what makes an annelid goo pod's volley fan out: `Goo Projectile` (-1557) inherits a purely **horizontal** `PropPhysInitialVelocity([-3.2, 0, 0])` from `Egg Projectiles` (-1556), and the `Egg Goo Emitter` (-1562) spins, so each of the four 100 ms emissions is aimed somewhere new.

## Measured

| | before | after |
|---|---|---|
| glob headings | 90.0°, 90.0°, 90.0°, 90.0° | 86.4°, 79.7°, 72.0°, 69.0° |
| fan spread | 0.0° | **17.5°** (50°/s × 0.3 s) |
| horizontal speed | 0.0 | ~1.5 u/s each |
| splats | stacked on the pod | spread across ~4 units |

## Three things had to be true

1. **Parse `P$CfgTweqRo`** (`PropTweqRotateConfig`). The rotate tweq spun every object at a hardcoded 20°/s; the goo emitter authors **50°/s about its heading axis, wrapping 0–360**. The rate matters wherever a spin has a consequence beyond looks. Laid out as the original's vector-tweq config: 8-byte base, three `(rate, low, high)` triples, `primary_axis` + 3 pad = 48 bytes.
2. **`Effect::SetRotation` now also writes `PropPosition`**, which is where a rotate tweq reads the pose it advances from. It previously only moved the rigid body, so the spin was **inert on anything physics-less** — and Tweq emitters are `NoRender` with no physics, so their facing never moved at all. This was the reason the first two fixes alone still produced a 0° fan.
3. **Name `PropPhysDimensions`' two unknown trailing fields** — `point_vs_terrain` and `point_vs_not_special`, matching the original's `sPhysDimsProp` field order exactly.

## A heuristic replaced by the authored rule

#1492 had `GooProjectile` pass through anything sharing its template, to stop the column detonating on itself. I flagged that as a deviation, and it was.

The original's actual rule is authored data: **two models that both set `point_vs_not_special` and are both non-special never collide with each other** — which is what stops a stream of projectiles destroying itself. The `Projectile` archetype sets both bits. The only other projectile exclusion in the original is projectile-vs-its-own-firer. So this was a missing rule, not a workaround.

## Scope

This is the shared Tweq emit path, so it affects **every** emitted projectile, not just goo. The existing ops4 emitter tests in `systems/tweq.rs` still pass; objects with no authored rotate config keep the previous fixed spin rate.

## Verification

- New e2e: `an emitted volley fans out as its emitter spins` — asserts the four globs' headings differ and each carries a horizontal component. Confirmed **red without the fix** (`got 0.0 deg from 0.0, 0.0, 0.0, 0.0`).
- New unit test for the rotate-config parser.
- `cargo test -p shock2vr` 1696 passed, `-p dark` 177 passed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- All 25 missions load (`missions.e2e.test.ts`), and #1492's egg tests still pass.

## Visual evidence

![goo volley fans out](https://gist.githubusercontent.com/tommy-xr/addb40ae585ca2691a0195eac4e7f092/raw/goo-volley.gif)

<sub>An annelid goo pod's four globs now leave on the emitter's live facing, so the volley fans instead of stacking. Captured headlessly via the debug runtime (`debug_annelid`, `/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

All four airborne and diverging (135 sim frames after the pod is tripped):

![four globs airborne and diverging](https://gist.githubusercontent.com/tommy-xr/addb40ae585ca2691a0195eac4e7f092/raw/goo-volley-airborne.png)

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/addb40ae585ca2691a0195eac4e7f092/raw/goo-before-after.png)

<sub>Same camera, same request sequence, same frame. Before: all four glob headings 90.0° - a single column directly over the pod. After: 87.1° / 78.5° / 72.1° / 68.9°, an 18° fan spilling ~4 units.</sub>


