### PR TITLE
fix(ai): stop gun hybrids miming harmless melee swings

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -575,8 +575,6 @@ pub fn fire_ranged_projectile(
 
         let transform = root_transform.0;
         let position = joint_transform.transform_point(point3(0.0, 0.0, 0.0));
-        let muzzle_transform = transform * Matrix4::from_translation((position + forward).to_vec());
-        let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
         let Some((target_entity, target_position)) = world
             .borrow::<UniqueView<PlayerInfo>>()
             .ok()
@@ -584,6 +582,19 @@ pub fn fire_ranged_projectile(
         else {
             return Effect::NoEffect;
         };
+
+        // The muzzle stands a unit ahead of the firing joint so the shot
+        // clears the shooter's own body. An AI with no melee weapon fires
+        // right down to contact range, where that unit can reach PAST the
+        // target - spawning the shot behind it, aimed back at the shooter,
+        // and a contact-fused grenade at the thrower's own feet. Keep the
+        // muzzle short of the target instead.
+        let joint_position = transform.transform_point(position);
+        let distance_to_target = (target_position - joint_position.to_vec()).magnitude();
+        let muzzle_offset = muzzle_offset_for_distance(distance_to_target);
+        let muzzle_transform =
+            transform * Matrix4::from_translation((position + forward * muzzle_offset).to_vec());
+        let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
         if !has_line_of_fire_from(
             entity_id,
             muzzle_position,
@@ -651,6 +662,22 @@ pub const MONSTER_FOV_HALF_ANGLE: f32 = 60.0;
 /// whether to keep swinging, and a swing may only connect inside it.
 pub const MELEE_ATTACK_RANGE: f32 = 8.0 / SCALE_FACTOR;
 
+/// How far ahead of the firing joint an AI's muzzle sits, so a shot clears
+/// the shooter's own body.
+const MUZZLE_CLEARANCE: f32 = 1.0;
+
+/// The muzzle is pulled back to at least this far short of the target, so a
+/// point-blank shot still spawns between shooter and target rather than
+/// behind it.
+const MUZZLE_TARGET_MARGIN: f32 = 0.25;
+
+/// How far ahead of the firing joint to put the muzzle when the target is
+/// `distance_to_target` away: the full clearance normally, pulled in to stay
+/// short of the target at point-blank range, and never behind the shooter.
+fn muzzle_offset_for_distance(distance_to_target: f32) -> f32 {
+    MUZZLE_CLEARANCE.min((distance_to_target - MUZZLE_TARGET_MARGIN).max(0.0))
+}
+
 ///
 /// Melee Contact
 ///
@@ -697,12 +724,7 @@ pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &Physic
         return Effect::NoEffect;
     }
 
-    let Some((weapon_template_id, _)) =
-        get_first_link_with_template_and_data(world, entity_id, |link| match link {
-            Link::Weapon => Some(()),
-            _ => None,
-        })
-    else {
+    let Some(weapon_template_id) = melee_weapon_template(world, entity_id) else {
         return Effect::NoEffect;
     };
 
@@ -970,6 +992,17 @@ pub fn is_self_destructing(world: &World, entity_id: EntityId) -> bool {
     v_ai.get(entity_id)
         .map(|prop_ai| prop_ai.0.eq_ignore_ascii_case("protocol"))
         .unwrap_or(false)
+}
+
+/// The melee weapon archetype this AI strikes with, if it has one. Melee
+/// damage is the weapon's contact stims, so an AI with no `Weapon` link
+/// cannot land a blow at all.
+pub fn melee_weapon_template(world: &World, entity_id: EntityId) -> Option<i32> {
+    get_first_link_with_template_and_data(world, entity_id, |link| match link {
+        Link::Weapon => Some(()),
+        _ => None,
+    })
+    .map(|(template_id, _)| template_id)
 }
 
 /// Check if an entity has a ranged weapon capability
@@ -2026,5 +2059,39 @@ mod sight_occlusion_tests {
             player_is_visible(&scene),
             "moving the door collider to its open pose must restore sight"
         );
+    }
+}
+
+#[cfg(test)]
+mod muzzle_tests {
+    use super::*;
+
+    /// At ordinary firing range the muzzle keeps its full clearance, so the
+    /// shot still leaves from in front of the shooter's own body.
+    #[test]
+    fn a_distant_target_gets_the_full_muzzle_clearance() {
+        assert_eq!(muzzle_offset_for_distance(10.0), MUZZLE_CLEARANCE);
+    }
+
+    /// A melee-less gun AI fires at contact range. The muzzle must stay
+    /// SHORT of the target - past it, the shot spawns behind the target
+    /// aimed back at the shooter (a contact grenade at its own feet).
+    #[test]
+    fn a_point_blank_target_pulls_the_muzzle_in_short_of_it() {
+        let distance = 0.8;
+        let offset = muzzle_offset_for_distance(distance);
+        assert!(
+            offset < distance,
+            "muzzle {offset} reached past target at {distance}"
+        );
+        assert_eq!(offset, distance - MUZZLE_TARGET_MARGIN);
+    }
+
+    /// Closer than the margin the muzzle collapses onto the joint rather
+    /// than reversing behind the shooter.
+    #[test]
+    fn a_target_inside_the_margin_never_puts_the_muzzle_behind_the_shooter() {
+        assert_eq!(muzzle_offset_for_distance(0.1), 0.0);
+        assert_eq!(muzzle_offset_for_distance(0.0), 0.0);
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     physics::PhysicsWorld,
     scripts::ai::ai_util::{
         chase_target, chase_target_distance, has_line_of_fire, has_ranged_weapon,
-        is_self_destructing,
+        is_self_destructing, melee_weapon_template,
     },
 };
 
@@ -61,7 +61,29 @@ pub fn attack_behavior_for_distance(
     let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
     let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
-    let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
+
+    // Melee damage is the swing weapon's contact stims, so an AI with no
+    // Weapon link cannot land a blow at all. The shotgun and grenade
+    // hybrids are authored that way - an AIProjectile link and nothing to
+    // swing - while a creature meant to do both, the monkeys, carries both
+    // links. (A weapon whose archetype stims for no damage still swings;
+    // this asks only whether there is a weapon at all.)
+    let can_melee = melee_weapon_template(world, entity_id).is_some();
+
+    // ...but only a creature that can shoot INSTEAD gives up its swing. A
+    // creature with neither link - a swarm, which hurts the player through
+    // a proximity stim rather than a blow - keeps closing and attacking, or
+    // it would shove silently with a walk cycle playing.
+    let gives_up_melee = !can_melee && has_ranged_weapon(world, entity_id);
+
+    // A gun AI with nothing to swing keeps shooting all the way in to
+    // contact rather than standing off, so being cornered by one hurts:
+    // retail hybrids fire point-blank instead of closing to swing.
+    let ranged_min_attack_distance = if gives_up_melee {
+        0.0
+    } else {
+        15.0 / SCALE_FACTOR
+    };
 
     // A protocol droid has no weapon to swing: closing the distance starts
     // its self-destruct instead of a melee attack.
@@ -82,9 +104,137 @@ pub fn attack_behavior_for_distance(
         && has_line_of_fire(entity_id, world, physics, target)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
-    } else if distance < melee_attack_distance {
+    } else if distance < melee_attack_distance && !gives_up_melee {
         Some(Box::new(RefCell::new(MeleeAttackBehavior)))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Quaternion, Rotation3, vec3};
+    use dark::properties::{Link, Links, PropHitPoints, PropPosition, ToLink};
+
+    use crate::mission::PlayerInfo;
+
+    /// An AI at the origin with the given weapon links, and the player
+    /// `distance` units down +Z. The physics world is empty, so the line of
+    /// fire is always clear.
+    fn world_with_armed_ai(links: Vec<Link>, distance: f32) -> (World, EntityId) {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropHitPoints { hit_points: 12 },
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::from_angle_y(cgmath::Deg(0.0)),
+                cell: 0,
+            },
+            Links {
+                to_links: links
+                    .into_iter()
+                    .map(|link| ToLink {
+                        to_template_id: -1,
+                        to_entity_id: None,
+                        link,
+                    })
+                    .collect(),
+            },
+        ));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, distance),
+            rotation: Quaternion::from_angle_y(cgmath::Deg(0.0)),
+            entity_id: EntityId::dead(),
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: EntityId::dead(),
+        });
+        (world, entity_id)
+    }
+
+    fn behavior_name(links: Vec<Link>, distance: f32) -> Option<String> {
+        let (world, entity_id) = world_with_armed_ai(links, distance);
+        let physics = PhysicsWorld::new();
+        attack_behavior_for_distance(&world, &physics, entity_id)
+            .map(|behavior| behavior.borrow().name().to_owned())
+    }
+
+    fn ai_projectile() -> Link {
+        Link::AIProjectile(dark::properties::AIProjectileOptions {
+            targeting_method: dark::properties::AITargetMethod::StraightLine,
+            delay: 0.0,
+            should_lead_target: false,
+            ammo: 0,
+            accuracy: 0,
+            select_time: 0.0,
+            joint: 0,
+            vhot: 0,
+        })
+    }
+
+    /// A hybrid with a pipe swings, and its swing is what carries the
+    /// contact stims that damage the player.
+    #[test]
+    fn a_melee_armed_ai_at_contact_range_attacks_in_melee() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon], 1.0).as_deref(),
+            Some("MeleeAttack")
+        );
+    }
+
+    /// A shotgun hybrid has no `Weapon` link to resolve a blow with, so it
+    /// must not mime a harmless swing - it shoots at contact range instead.
+    #[test]
+    fn a_gun_ai_with_no_melee_weapon_shoots_at_contact_range() {
+        assert_eq!(
+            behavior_name(vec![ai_projectile()], 1.0).as_deref(),
+            Some("RangedAttack")
+        );
+    }
+
+    /// A monkey authors both links: at contact range the melee attack still
+    /// wins, so adding the close-range fire path doesn't disarm its claw.
+    #[test]
+    fn a_dual_armed_ai_still_melees_at_contact_range() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon, ai_projectile()], 1.0).as_deref(),
+            Some("MeleeAttack")
+        );
+    }
+
+    /// The stand-off distance is unchanged for everything that can melee.
+    #[test]
+    fn a_dual_armed_ai_shoots_from_stand_off_range() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon, ai_projectile()], 8.0).as_deref(),
+            Some("RangedAttack")
+        );
+    }
+
+    /// Out past its maximum range, a gun AI chases rather than firing.
+    #[test]
+    fn a_gun_ai_out_of_range_has_no_attack() {
+        assert_eq!(behavior_name(vec![ai_projectile()], 20.0), None);
+    }
+
+    /// Only a creature that can shoot instead gives up its swing. A swarm
+    /// carries neither link - it hurts the player through a proximity stim -
+    /// so it must keep attacking rather than shoving with a walk cycle.
+    #[test]
+    fn an_ai_with_no_weapon_at_all_still_attacks_at_contact_range() {
+        assert_eq!(behavior_name(vec![], 1.0).as_deref(), Some("MeleeAttack"));
+    }
+
+    /// A protocol droid deliberately has no `Weapon` link - closing the
+    /// distance lights its fuse, and the melee gate must not intercept that.
+    #[test]
+    fn a_protocol_droid_still_self_destructs_at_contact_range() {
+        let (mut world, entity_id) = world_with_armed_ai(vec![], 1.0);
+        world.add_component(entity_id, dark::properties::PropAI("protocol".to_owned()));
+        let physics = PhysicsWorld::new();
+        let name = attack_behavior_for_distance(&world, &physics, entity_id)
+            .map(|behavior| behavior.borrow().name().to_owned());
+        assert_eq!(name.as_deref(), Some("SelfDestruct"));
     }
 }


### PR DESCRIPTION
## Problem

Shotgun hybrids swing at the player in melee and nothing happens.

AI melee damage resolves through the attacker's `Weapon` link contact stims (`ai_util::melee_contact_attack`). The shipped data authors the hybrids asymmetrically:

| Template | Links | `PropAI` |
| --- | --- | --- |
| `-397 OG-Pipe` | `Weapon -> -365 Lead Pipe` | `melee` |
| `-175 OG-Shotgun` | `AIProjectile -> -676` only | `ranged` |
| `-176 OG-Grenade` | `AIProjectile -> -1600` only | `ranged` |
| `-1431 Blue Monkey` | **both** `Weapon -> -2017` and `AIProjectile -> -2210` | - |

So the missing melee weapon on the gun hybrids is deliberate authored data - the monkeys show how a creature meant to do both is expressed - and it is reinforced by the combat properties: `OG-Pipe` carries `P$HTHCombat`/`P$HTHMotion`, `OG-Shotgun` carries `P$AIRCRange`/`P$AIRCProp` instead.

But `attack_behavior_for_distance` sent *anything* inside melee range into `MeleeAttackBehavior`, while ranged was already gated on `has_ranged_weapon`. The gun hybrids therefore entered melee, played the swing, and `melee_contact_attack` bailed at the weapon lookup every time.

**Measured before:** player parked adjacent to a shotgun hybrid for 30 s - `MeleeAttack` held for 27 s, melee clips actively cycling (`ogpmelat1`, `ogpmelat2a2`), combat barks playing, **player HP 30 -> 30**. Same procedure against a pipe hybrid: 10 damage per swing, player dead in ~18 s.

## Change

1. **Gate melee on actually having a `Weapon` link** - but only a creature that can shoot *instead* gives up its swing. A creature with neither link (a swarm, which hurts the player through a proximity stim rather than a blow) keeps attacking, or it would shove silently with a walk cycle playing.
2. **Let a melee-less gun AI fire below the ranged stand-off minimum**, so being cornered by a shotgun hybrid hurts instead of being the safest place to stand. Retail hybrids fire point-blank rather than closing to swing.
3. **Clamp the muzzle offset.** (2) reaches a range the firing path had never run at: the muzzle sits a unit ahead of the firing joint, which at contact range spawns the shot *past* the target - `projectile_transform_aimed_at_player` then aims it back at the shooter, and the line-of-fire gate cannot catch it because the backwards ray hits the player collider and resolves to the target. Worst case was the grenade hybrid dropping a contact-fused grenade on its own feet. The muzzle now stays short of the target.

## Verification

**Unit** (10 new tests, all confirmed as negative tests - each fails on the code without its fix):
- melee-armed / gun-only / dual-armed at contact range, dual-armed at stand-off, gun out of range
- a weapon-less AI (the swarm case) still attacks at contact range
- a protocol droid still self-destructs (it deliberately has no `Weapon` link, and must not be intercepted by the melee gate)
- muzzle clamp: full clearance at range, pulled in short of a point-blank target, never reversed behind the shooter

**In-game** (headless debug runtime, `medsci1.mis` / `rec1.mis`):

| Case | Before | After |
| --- | --- | --- |
| Shotgun hybrid, player adjacent 30 s | `MeleeAttack` 27 s, HP 30 -> 30 | `RangedAttack` throughout, **HP 30 -> 10** |
| Grenade hybrid, player adjacent 30 s | - | AI HP flat 15/15, no self-damage |
| Pipe hybrid (regression) | 10 dmg/swing, kill in ~18 s | unchanged, 10 dmg/swing, kill in 13 s |
| Blue Monkey, dual-armed (regression) | melee at contact | unchanged, melee at contact |

`cargo test -p shock2vr --lib`: 1706 passed. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean.

No screenshots: the change is AI behavior selection and damage resolution, with no new or altered visual.

## Follow-ups filed, not in scope here

- #1493 - show combat frustration when an attack is unavailable (blocked line of fire, lost target). Retail reaches this fix's outcome from the other side: hand-to-hand is entered on distance, finds nothing attackable, and a lockout hands the fight back to ranged. Modelling that faithfully needs a per-AI two-timer state machine; modelling it loosely would reintroduce the harmless-swing beat this PR removes.
- #1495 - `FIRE` and `MELEE_CONTACT_START` arriving in one tick drops the melee hit (the flags are a union; the two attack arms are chained with `else if`).
- #1499 - ranged AI still flips between `RangedAttack` and `Chase` at point-blank. The muzzle clamp measurably improved this (multi-second ranged stretches instead of flipping every poll) but did not eliminate it.

## Not covered

No mission places a live `Swarm` (-183) - only `SwarmerEgg` pods, which did not hatch in 20 s of stepping - so the neither-weapon case rests on its unit test rather than an in-game check.
