### PR TITLE
fix(scripts): implement DelayGrenade so thrown grenades detonate

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -575,8 +575,6 @@ pub fn fire_ranged_projectile(
 
         let transform = root_transform.0;
         let position = joint_transform.transform_point(point3(0.0, 0.0, 0.0));
-        let muzzle_transform = transform * Matrix4::from_translation((position + forward).to_vec());
-        let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
         let Some((target_entity, target_position)) = world
             .borrow::<UniqueView<PlayerInfo>>()
             .ok()
@@ -584,6 +582,19 @@ pub fn fire_ranged_projectile(
         else {
             return Effect::NoEffect;
         };
+
+        // The muzzle stands a unit ahead of the firing joint so the shot
+        // clears the shooter's own body. An AI with no melee weapon fires
+        // right down to contact range, where that unit can reach PAST the
+        // target - spawning the shot behind it, aimed back at the shooter,
+        // and a contact-fused grenade at the thrower's own feet. Keep the
+        // muzzle short of the target instead.
+        let joint_position = transform.transform_point(position);
+        let distance_to_target = (target_position - joint_position.to_vec()).magnitude();
+        let muzzle_offset = muzzle_offset_for_distance(distance_to_target);
+        let muzzle_transform =
+            transform * Matrix4::from_translation((position + forward * muzzle_offset).to_vec());
+        let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
         if !has_line_of_fire_from(
             entity_id,
             muzzle_position,
@@ -651,6 +662,22 @@ pub const MONSTER_FOV_HALF_ANGLE: f32 = 60.0;
 /// whether to keep swinging, and a swing may only connect inside it.
 pub const MELEE_ATTACK_RANGE: f32 = 8.0 / SCALE_FACTOR;
 
+/// How far ahead of the firing joint an AI's muzzle sits, so a shot clears
+/// the shooter's own body.
+const MUZZLE_CLEARANCE: f32 = 1.0;
+
+/// The muzzle is pulled back to at least this far short of the target, so a
+/// point-blank shot still spawns between shooter and target rather than
+/// behind it.
+const MUZZLE_TARGET_MARGIN: f32 = 0.25;
+
+/// How far ahead of the firing joint to put the muzzle when the target is
+/// `distance_to_target` away: the full clearance normally, pulled in to stay
+/// short of the target at point-blank range, and never behind the shooter.
+fn muzzle_offset_for_distance(distance_to_target: f32) -> f32 {
+    MUZZLE_CLEARANCE.min((distance_to_target - MUZZLE_TARGET_MARGIN).max(0.0))
+}
+
 ///
 /// Melee Contact
 ///
@@ -697,12 +724,7 @@ pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &Physic
         return Effect::NoEffect;
     }
 
-    let Some((weapon_template_id, _)) =
-        get_first_link_with_template_and_data(world, entity_id, |link| match link {
-            Link::Weapon => Some(()),
-            _ => None,
-        })
-    else {
+    let Some(weapon_template_id) = melee_weapon_template(world, entity_id) else {
         return Effect::NoEffect;
     };
 
@@ -970,6 +992,17 @@ pub fn is_self_destructing(world: &World, entity_id: EntityId) -> bool {
     v_ai.get(entity_id)
         .map(|prop_ai| prop_ai.0.eq_ignore_ascii_case("protocol"))
         .unwrap_or(false)
+}
+
+/// The melee weapon archetype this AI strikes with, if it has one. Melee
+/// damage is the weapon's contact stims, so an AI with no `Weapon` link
+/// cannot land a blow at all.
+pub fn melee_weapon_template(world: &World, entity_id: EntityId) -> Option<i32> {
+    get_first_link_with_template_and_data(world, entity_id, |link| match link {
+        Link::Weapon => Some(()),
+        _ => None,
+    })
+    .map(|(template_id, _)| template_id)
 }
 
 /// Check if an entity has a ranged weapon capability
@@ -2026,5 +2059,39 @@ mod sight_occlusion_tests {
             player_is_visible(&scene),
             "moving the door collider to its open pose must restore sight"
         );
+    }
+}
+
+#[cfg(test)]
+mod muzzle_tests {
+    use super::*;
+
+    /// At ordinary firing range the muzzle keeps its full clearance, so the
+    /// shot still leaves from in front of the shooter's own body.
+    #[test]
+    fn a_distant_target_gets_the_full_muzzle_clearance() {
+        assert_eq!(muzzle_offset_for_distance(10.0), MUZZLE_CLEARANCE);
+    }
+
+    /// A melee-less gun AI fires at contact range. The muzzle must stay
+    /// SHORT of the target - past it, the shot spawns behind the target
+    /// aimed back at the shooter (a contact grenade at its own feet).
+    #[test]
+    fn a_point_blank_target_pulls_the_muzzle_in_short_of_it() {
+        let distance = 0.8;
+        let offset = muzzle_offset_for_distance(distance);
+        assert!(
+            offset < distance,
+            "muzzle {offset} reached past target at {distance}"
+        );
+        assert_eq!(offset, distance - MUZZLE_TARGET_MARGIN);
+    }
+
+    /// Closer than the margin the muzzle collapses onto the joint rather
+    /// than reversing behind the shooter.
+    #[test]
+    fn a_target_inside_the_margin_never_puts_the_muzzle_behind_the_shooter() {
+        assert_eq!(muzzle_offset_for_distance(0.1), 0.0);
+        assert_eq!(muzzle_offset_for_distance(0.0), 0.0);
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     physics::PhysicsWorld,
     scripts::ai::ai_util::{
         chase_target, chase_target_distance, has_line_of_fire, has_ranged_weapon,
-        is_self_destructing,
+        is_self_destructing, melee_weapon_template,
     },
 };
 
@@ -61,7 +61,29 @@ pub fn attack_behavior_for_distance(
     let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
     let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
-    let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
+
+    // Melee damage is the swing weapon's contact stims, so an AI with no
+    // Weapon link cannot land a blow at all. The shotgun and grenade
+    // hybrids are authored that way - an AIProjectile link and nothing to
+    // swing - while a creature meant to do both, the monkeys, carries both
+    // links. (A weapon whose archetype stims for no damage still swings;
+    // this asks only whether there is a weapon at all.)
+    let can_melee = melee_weapon_template(world, entity_id).is_some();
+
+    // ...but only a creature that can shoot INSTEAD gives up its swing. A
+    // creature with neither link - a swarm, which hurts the player through
+    // a proximity stim rather than a blow - keeps closing and attacking, or
+    // it would shove silently with a walk cycle playing.
+    let gives_up_melee = !can_melee && has_ranged_weapon(world, entity_id);
+
+    // A gun AI with nothing to swing keeps shooting all the way in to
+    // contact rather than standing off, so being cornered by one hurts:
+    // retail hybrids fire point-blank instead of closing to swing.
+    let ranged_min_attack_distance = if gives_up_melee {
+        0.0
+    } else {
+        15.0 / SCALE_FACTOR
+    };
 
     // A protocol droid has no weapon to swing: closing the distance starts
     // its self-destruct instead of a melee attack.
@@ -82,9 +104,137 @@ pub fn attack_behavior_for_distance(
         && has_line_of_fire(entity_id, world, physics, target)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
-    } else if distance < melee_attack_distance {
+    } else if distance < melee_attack_distance && !gives_up_melee {
         Some(Box::new(RefCell::new(MeleeAttackBehavior)))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Quaternion, Rotation3, vec3};
+    use dark::properties::{Link, Links, PropHitPoints, PropPosition, ToLink};
+
+    use crate::mission::PlayerInfo;
+
+    /// An AI at the origin with the given weapon links, and the player
+    /// `distance` units down +Z. The physics world is empty, so the line of
+    /// fire is always clear.
+    fn world_with_armed_ai(links: Vec<Link>, distance: f32) -> (World, EntityId) {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropHitPoints { hit_points: 12 },
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::from_angle_y(cgmath::Deg(0.0)),
+                cell: 0,
+            },
+            Links {
+                to_links: links
+                    .into_iter()
+                    .map(|link| ToLink {
+                        to_template_id: -1,
+                        to_entity_id: None,
+                        link,
+                    })
+                    .collect(),
+            },
+        ));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, distance),
+            rotation: Quaternion::from_angle_y(cgmath::Deg(0.0)),
+            entity_id: EntityId::dead(),
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: EntityId::dead(),
+        });
+        (world, entity_id)
+    }
+
+    fn behavior_name(links: Vec<Link>, distance: f32) -> Option<String> {
+        let (world, entity_id) = world_with_armed_ai(links, distance);
+        let physics = PhysicsWorld::new();
+        attack_behavior_for_distance(&world, &physics, entity_id)
+            .map(|behavior| behavior.borrow().name().to_owned())
+    }
+
+    fn ai_projectile() -> Link {
+        Link::AIProjectile(dark::properties::AIProjectileOptions {
+            targeting_method: dark::properties::AITargetMethod::StraightLine,
+            delay: 0.0,
+            should_lead_target: false,
+            ammo: 0,
+            accuracy: 0,
+            select_time: 0.0,
+            joint: 0,
+            vhot: 0,
+        })
+    }
+
+    /// A hybrid with a pipe swings, and its swing is what carries the
+    /// contact stims that damage the player.
+    #[test]
+    fn a_melee_armed_ai_at_contact_range_attacks_in_melee() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon], 1.0).as_deref(),
+            Some("MeleeAttack")
+        );
+    }
+
+    /// A shotgun hybrid has no `Weapon` link to resolve a blow with, so it
+    /// must not mime a harmless swing - it shoots at contact range instead.
+    #[test]
+    fn a_gun_ai_with_no_melee_weapon_shoots_at_contact_range() {
+        assert_eq!(
+            behavior_name(vec![ai_projectile()], 1.0).as_deref(),
+            Some("RangedAttack")
+        );
+    }
+
+    /// A monkey authors both links: at contact range the melee attack still
+    /// wins, so adding the close-range fire path doesn't disarm its claw.
+    #[test]
+    fn a_dual_armed_ai_still_melees_at_contact_range() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon, ai_projectile()], 1.0).as_deref(),
+            Some("MeleeAttack")
+        );
+    }
+
+    /// The stand-off distance is unchanged for everything that can melee.
+    #[test]
+    fn a_dual_armed_ai_shoots_from_stand_off_range() {
+        assert_eq!(
+            behavior_name(vec![Link::Weapon, ai_projectile()], 8.0).as_deref(),
+            Some("RangedAttack")
+        );
+    }
+
+    /// Out past its maximum range, a gun AI chases rather than firing.
+    #[test]
+    fn a_gun_ai_out_of_range_has_no_attack() {
+        assert_eq!(behavior_name(vec![ai_projectile()], 20.0), None);
+    }
+
+    /// Only a creature that can shoot instead gives up its swing. A swarm
+    /// carries neither link - it hurts the player through a proximity stim -
+    /// so it must keep attacking rather than shoving with a walk cycle.
+    #[test]
+    fn an_ai_with_no_weapon_at_all_still_attacks_at_contact_range() {
+        assert_eq!(behavior_name(vec![], 1.0).as_deref(), Some("MeleeAttack"));
+    }
+
+    /// A protocol droid deliberately has no `Weapon` link - closing the
+    /// distance lights its fuse, and the melee gate must not intercept that.
+    #[test]
+    fn a_protocol_droid_still_self_destructs_at_contact_range() {
+        let (mut world, entity_id) = world_with_armed_ai(vec![], 1.0);
+        world.add_component(entity_id, dark::properties::PropAI("protocol".to_owned()));
+        let physics = PhysicsWorld::new();
+        let name = attack_behavior_for_distance(&world, &physics, entity_id)
+            .map(|behavior| behavior.borrow().name().to_owned());
+        assert_eq!(name.as_deref(), Some("SelfDestruct"));
     }
 }

--- a/shock2vr/src/scripts/delay_grenade.rs
+++ b/shock2vr/src/scripts/delay_grenade.rs
@@ -1,0 +1,212 @@
+//! Script `DelayGrenade`: the grenade lobbed by the grenade hybrid
+//! (`OG-Grenade`, -176) through its `AIProjectile -> Grunt Grenade` (-1600)
+//! link.
+//!
+//! Unlike the bullet-style monster projectiles, the grenade is authored
+//! `BOUNCE | FULL_COLLISION_SOUND` - it does NOT inherit `SLAY_ON_IMPACT` from
+//! its parent `Monster Projectiles` (-672) - so nothing in the generic
+//! collision path ends it. It goes off when something bumps into it, after a
+//! short arming delay so it cannot detonate on the thrower as it leaves the
+//! hand.
+//!
+//! The blast is authored data, not code: slaying the grenade spawns its
+//! `Corpse -> HE Explosion` (-3933), whose stim source is resolved like any
+//! other explosion.
+
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, World};
+use std::time::Duration;
+
+use crate::{physics::PhysicsWorld, time::Time};
+
+use super::{Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError};
+
+/// How long after the throw the grenade starts reacting to contact, so it
+/// cannot go off against the thrower's own body on the frame it spawns. A
+/// point-blank throw reaches the player around 100 ms, so this stays well
+/// under that: a grenade that arrives before arming simply lands and waits to
+/// be bumped, which is the same script behaviour a heartbeat later.
+const ARM_DELAY: Duration = Duration::from_millis(50);
+
+/// How long a grenade that nothing ever bumps lasts before it quietly
+/// expires. Only entity contacts raise `Collided` - world geometry carries no
+/// entity id - so a grenade that lands on the floor and is never walked into
+/// would otherwise live forever, and one thrown off a ledge falls out of the
+/// level still live. Not an authored value: it exists so misses cannot
+/// accumulate.
+const LIFETIME: Duration = Duration::from_secs(30);
+
+const SCRIPT_STATE_KEY: &str = "shock2vr.delay_grenade";
+
+#[derive(Serialize, Deserialize)]
+struct DelayGrenadeState {
+    age_secs: f32,
+}
+
+pub struct DelayGrenade {
+    age: Duration,
+}
+
+impl DelayGrenade {
+    pub fn new() -> DelayGrenade {
+        DelayGrenade {
+            age: Duration::ZERO,
+        }
+    }
+}
+
+impl Script for DelayGrenade {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        self.age += time.elapsed;
+
+        if self.age >= LIFETIME {
+            // Expiry is not a detonation: an untripped grenade goes away
+            // rather than blasting an empty room long after the fight.
+            Effect::DestroyEntity { entity_id }
+        } else {
+            Effect::NoEffect
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Collided { .. } if self.age >= ARM_DELAY => {
+                Effect::SlayEntity { entity_id }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SCRIPT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &DelayGrenadeState {
+                age_secs: self.age.as_secs_f32(),
+            },
+            SCRIPT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: DelayGrenadeState = state.decode(1, SCRIPT_STATE_KEY)?;
+        self.age = Duration::from_secs_f32(restored.age_secs.max(0.0));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn tick(script: &mut DelayGrenade, grenade: EntityId, elapsed: Duration) -> Effect {
+        script.update(
+            grenade,
+            &World::new(),
+            &PhysicsWorld::new(),
+            &Time {
+                elapsed,
+                ..Time::default()
+            },
+        )
+    }
+
+    fn collide(script: &mut DelayGrenade, grenade: EntityId) -> Effect {
+        script.handle_message(
+            grenade,
+            &World::new(),
+            &PhysicsWorld::new(),
+            &MessagePayload::Collided {
+                with: EntityId::dead(),
+                contact: None,
+            },
+        )
+    }
+
+    /// The point of the script: a grenade that bumps something goes off, so
+    /// the authored `Corpse -> HE Explosion` gets a chance to spawn.
+    #[test]
+    fn an_armed_grenade_detonates_when_something_bumps_it() {
+        let mut world = World::new();
+        let grenade = world.add_entity(());
+        let mut script = DelayGrenade::new();
+        tick(&mut script, grenade, ARM_DELAY);
+        assert!(matches!(
+            collide(&mut script, grenade),
+            Effect::SlayEntity { entity_id } if entity_id == grenade
+        ));
+    }
+
+    /// The delay in the name: a contact on the throw frame must not blow the
+    /// grenade up against the thrower.
+    #[test]
+    fn a_grenade_still_in_the_hand_does_not_detonate() {
+        let mut world = World::new();
+        let grenade = world.add_entity(());
+        let mut script = DelayGrenade::new();
+        assert!(matches!(collide(&mut script, grenade), Effect::NoEffect));
+        tick(&mut script, grenade, ARM_DELAY / 2);
+        assert!(matches!(collide(&mut script, grenade), Effect::NoEffect));
+    }
+
+    /// A grenade nothing ever touches goes away instead of drifting through
+    /// the level - and goes away quietly, without a blast.
+    #[test]
+    fn an_untripped_grenade_expires_without_detonating() {
+        let mut world = World::new();
+        let grenade = world.add_entity(());
+        let mut script = DelayGrenade::new();
+        assert!(matches!(
+            tick(&mut script, grenade, LIFETIME - ARM_DELAY),
+            Effect::NoEffect
+        ));
+        assert!(matches!(
+            tick(&mut script, grenade, ARM_DELAY),
+            Effect::DestroyEntity { entity_id } if entity_id == grenade
+        ));
+    }
+
+    /// The fuse survives a save/load, so a grenade in flight when the game is
+    /// saved neither re-arms from scratch nor expires early.
+    #[test]
+    fn the_fuse_survives_a_save_and_restore() {
+        let mut script = DelayGrenade::new();
+        let grenade = World::new().add_entity(());
+        tick(&mut script, grenade, ARM_DELAY);
+        let state = script.save_state().expect("save");
+        let mut restored = DelayGrenade::new();
+        let remap = HashMap::new();
+        restored
+            .restore_state(
+                &state,
+                &ScriptRestoreContext {
+                    entity_id_map: &remap,
+                },
+            )
+            .expect("restore");
+        assert!(matches!(
+            collide(&mut restored, grenade),
+            Effect::SlayEntity { entity_id } if entity_id == grenade
+        ));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -23,6 +23,7 @@ mod core_room;
 mod create_sound;
 mod cs9;
 mod dead_power_cell;
+mod delay_grenade;
 mod destroy_all_by_name;
 mod die_shodan_die;
 mod energy_station;
@@ -124,6 +125,7 @@ use self::chemical::ChemicalScript;
 use self::choose_mission::ChooseMissionScript;
 use self::choose_service::ChooseServiceScript;
 use self::comestible::Comestible;
+use self::delay_grenade::DelayGrenade;
 /// Preloaded elevator floor labels (from MISC.STR) + current mission, added as
 /// a world unique at mission load so the (`AssetCache`-less) `ElevatorGui` can
 /// read them at draw time.
@@ -1137,7 +1139,7 @@ impl ScriptWorld {
             "twostatebutton" => Box::new(BaseButton::new()),
 
             // weapons:
-            "delaygrenade" => Box::new(UnimplementedScript::new(&script_name)),
+            "delaygrenade" => Box::new(DelayGrenade::new()),
             "annelidmodify" => Box::new(UnimplementedScript::new(&script_name)),
             "empmodify" => Box::new(NoopScript::new()),
             "lasermodify" => Box::new(NoopScript::new()),


### PR DESCRIPTION
Fixes #1501. Stacked on #1500 (independent code, but that PR is what lets a grenade hybrid engage at contact range at all).

## Problem

Grenade hybrids (`OG-Grenade`, -176) damaged nobody, at any range.

The throw path was never at fault. Instrumented per-frame in `rec1.mis`, the AI plays its throw clips (`oggshot2`, `oggshot3`) and emits a correctly arced `Grunt Grenade` (-1600) about every 3 s:

```
f0  pos [22.35, 2.85, -86.86]  vel [1.41,  7.06, -6.35]  speed 9.60   player [22.57, 3.94, -87.84]
f6  pos [22.46, 3.47, -87.34]  vel [-0.49, 3.89,  2.21]  speed 4.50   <-- bounces off, reverses
```

Then nothing, forever. The projectile is authored `BOUNCE | FULL_COLLISION_SOUND`, deliberately **not** inheriting `SLAY_ON_IMPACT` from its parent `Monster Projectiles` (-672), so the generic collision path never ends it. Ending it is `DelayGrenade`'s job - and that mapped to `UnimplementedScript`:

```rust
// shock2vr/src/scripts/mod.rs:1140
"delaygrenade" => Box::new(UnimplementedScript::new(&script_name)),
```

No slay -> no `Corpse -> HE Explosion` (-3933) -> no damage. Nothing removed them either: over ~2000 stepped frames there was not a single entity removal, five grenades were alive at once, sliding forever and sinking through the floor.

## Change

Implement `DelayGrenade`, per its documented behaviour - *dies when bumped-in to, but with delayed activation*. It arms on a short timer, then a contact slays it and the authored corpse explosion does the rest. No new damage plumbing: the blast is data.

The fuse is script state (`script_state_key`/`save_state`/`restore_state`), so a grenade in flight when the game is saved neither re-arms from scratch nor expires early.

Two judgment calls, both called out in the code:

- **Arm delay 50 ms.** Enough to clear the throw frame, well under the ~100 ms a point-blank throw takes to reach the player, so a direct hit still detonates. A grenade arriving before arming just lands and waits to be bumped - the same script behaviour a heartbeat later.
- **30 s expiry, ours and not authored.** Only entity contacts raise `Collided` (world geometry carries no entity id, `physics_events.rs:43`), so a grenade landing on the floor waits to be walked into rather than going off on landing. Without an expiry a miss lives forever - which is exactly what the bug report observed. Expiry destroys rather than detonates: no blast in an empty room long after the fight.

## Verification

**Unit** (4 new): arms then detonates on contact; does not detonate still in the hand; expires quietly without a blast; fuse survives save/restore.

**In-game** (headless debug runtime, `rec1.mis` - the only mission placing an `OG-Grenade`):

| | Before | After |
| --- | --- | --- |
| Close range (~1.5), 3 throws | player HP 30 -> 30 | player HP **30 -> 6** |
| Medium range (~9), 5 throws | player HP 30 -> 30 | player HP **30 -> 0 (death)**, 6-8 dmg/blast |
| `HE Explosion` (-3933) | never appeared | **8/8 throws**, at the grenade's last position |
| Grenades alive at once | 5 after 33 s, none ever removed | **max 1**; 8 removed by detonation, 1 by expiry |
| Forced miss | drifts forever | destroyed at dt = 30.00 s, **no** explosion |

`cargo test -p shock2vr --lib`: 1710 passed. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean. Existing `close-range-projectile` e2e (muzzle clearance / close-range damage) passes, along with `ai-alertness`, `ally-line-of-fire` and `chase-last-seen`.

No screenshots: the visible result is the shipped `HE Explosion` FX, unchanged by this PR - the fix is that it now gets spawned at all.

## Worth a maintainer's call

**Point-blank, the hybrid kills itself in 3 throws** (6 HP self-damage per blast against its own 15 HP). This is not an arming failure - the grenade clears the thrower and detonates on the *player*; the thrower is simply inside its own authored blast radius, and took zero self-damage on all four medium-range throws. Whether retail hybrids are meant to be this suicidal at contact range is a data/balance question the harness can't settle, so I've left the authored radius alone rather than inventing a self-damage exemption.

## Not covered

The "lies on the floor until something walks into it" path could not be exercised in-game: a missed grenade falls *through* the floor (it reached y = -4098 before expiring) rather than resting on it. That tunneling is pre-existing and noted in #1501 - the bodies are authored `mass: 1.0` but come out at 1.13e-5, so the runtime is deriving mass from the 0.03 radius somewhere instead of taking the authored value. Out of scope here; the expiry at least reaps them.
