### PR TITLE
fix(render): stop baking debug cubes at every vhot

### DIFF
--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use cgmath::{Matrix4, Vector2, Vector3, Vector4, vec4};
-use cgmath::{Point3, point3, prelude::*, vec3};
+use cgmath::{Point3, point3, prelude::*};
 use collision::Aabb3;
 use engine::{
     assets::asset_cache::AssetCache,
@@ -127,7 +127,7 @@ pub fn to_scene_objects(
     let skeleton = obj_skeleton(mesh);
     let is_skinned = skeleton.bone_count() > 1;
 
-    let mut mesh_objects = vertices
+    let mesh_objects = vertices
         .into_iter()
         .filter_map(|(slot, verts)| {
             if verts.is_empty() {
@@ -233,21 +233,9 @@ pub fn to_scene_objects(
         })
         .collect::<Vec<SceneObject>>();
 
-    let vhots = &mesh.vhots;
-    let mut vhot_objs = vhots
-        .iter()
-        .map(|vhot| {
-            let geometry = engine::scene::cube::create();
-            let material = RefCell::new(engine::scene::color_material::create(vec3(0.0, 0.0, 1.0)));
-            let mut scene_obj = SceneObject::create(material, Rc::new(Box::new(geometry)));
-            scene_obj.set_local_transform(
-                Matrix4::from_translation(vhot.point.to_vec()) * Matrix4::from_scale(0.025),
-            );
-            scene_obj
-        })
-        .collect::<Vec<SceneObject>>();
-
-    mesh_objects.append(&mut vhot_objs);
+    // Vhots are attachment points (muzzle, light, particle origins), not
+    // geometry - they are read off `mesh.vhots` by whoever attaches to them.
+    // The viewer tools draw their own markers (`--debug-articulation`).
     (mesh_objects, skeleton)
 }
 
@@ -1217,6 +1205,7 @@ fn convert_skinned_vertices_to_static_vertices(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::vec3;
     use std::io::Cursor;
 
     /// S_HIVOLT.BIN contains two coplanar, opposite-wound faces with inverse U

--- a/tools/dark_viewer/src/scenes/render_helpers.rs
+++ b/tools/dark_viewer/src/scenes/render_helpers.rs
@@ -39,8 +39,6 @@ pub fn articulation_overlay(model: &Model) -> Vec<SceneObject> {
         })
         .collect::<Vec<SceneObject>>();
 
-    // These coincide with the small blue cubes the LGMD loader itself bakes in
-    // at every vhot (`ss2_bin_obj_loader::to_scene_objects`) - see issue #1208.
     objects.extend(model.vhots().iter().map(|vhot| {
         let at = Matrix4::from_translation(vhot.point.to_vec());
         marker(VHOT_COLOR, at, VHOT_MARKER_SIZE)


### PR DESCRIPTION
`to_scene_objects` appended a small blue `color_material` cube per vhot of every
LGMD model, ungated — so the cubes rendered **in-game** on weapons, props and
doors (plus a draw call each), not just in the viewer tools.

Vhots are attachment points (muzzle, light, particle origins) read off
`mesh.vhots` by whoever attaches to them; nothing needed them as geometry. The
viewer tools already draw their own markers (`--debug-articulation`), so the
coincidence note at that code is gone too.

## Verification

`debug_interactions`, identical free-camera pose before/after:

| | entity-attributed scene objects | unculled (the vhot cubes) |
|---|---|---|
| before | 81 | 5 (Psi Amp, Assault Rifle ×2, Shotgun, Pistol) |
| after | 76 | 0 |

- `cargo test -p dark -p shock2vr` — green (1696 + 179 + 11 passed)
- `RUSTFLAGS="-D warnings" cargo check -p dark -p shock2vr -p desktop_runtime -p debug_runtime -p dark_viewer` — clean
- `SHOCK2_E2E=1 missions.e2e.test.ts` — 23/23 missions load, 0 failures

Fixes #1208

## Visuals

![Assault rifle orbit, no vhot debug cubes](https://gist.githubusercontent.com/tommy-xr/ff65d664895984b607ebe92ccae1a15b/raw/rifle_orbit.gif)

<sub>Camera orbit around the rack's Assault Rifle in `debug_interactions`, captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). No blue vhot cubes from any angle.</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/ff65d664895984b607ebe92ccae1a15b/raw/beforeafter.png)

<sub>Same free-camera pose on the Assault Rifle: before shows a blue debug cube on the receiver, after has it removed.</sub>
