### PR TITLE
fix(dark): parse LD$Corpse by defaulting its missing records

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1232,12 +1232,6 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
     // Links
     let links = vec![
         define_link("L$AIRangedW", |_| Link::AIRangedWeapon),
-        // TODO: Why is the data not available for some of these links?
-        define_link("L$Corpse", |_| {
-            Link::Corpse(CorpseOptions {
-                propagate_scale: false,
-            })
-        }),
         define_link("L$LandingPo", |_| Link::LandingPoint),
         define_link("L$Replicato", |_| Link::Replicator),
         define_link("L$SpawnPoin", |_| Link::SpawnPoint),
@@ -1257,7 +1251,11 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
 
     // Links with data
     let links_with_data = vec![
-        // define_link_with_data("L$Corpse", "LD$Corpse", CorpseOptions::read, Link::Corpse),
+        // Sparse in the shipped data (the gamesys authors 9 records for 71
+        // links; shodan has 44 links and none), and an unauthored
+        // `propagate_scale` is false - exactly what the hardcoded stand-in
+        // this replaces assumed for every link.
+        define_link_with_optional_data("L$Corpse", "LD$Corpse", CorpseOptions::read, Link::Corpse),
         define_link_with_data(
             "L$AIWatchOb",
             "LD$AIWatchO",
@@ -2427,6 +2425,13 @@ pub trait LinkDefinitionWithData: Send + Sync {
     fn link_data_chunk_name(&self) -> String;
     fn link_data_framing(&self) -> LinkDataFraming;
 
+    /// Whether a link of this flavor with no LD$ record of its own keeps the
+    /// link with a zero-filled record, instead of being dropped. Opt-in: it is
+    /// only correct where the reader parses all-zeroes as "unspecified", which
+    /// is per-flavor - a zeroed `LD$PhysAtta` offset means "welded to the
+    /// parent's origin", not "no offset authored".
+    fn defaults_missing_records(&self) -> bool;
+
     fn convert(&self, data: Vec<u8>, prop_len: u32, link: ToTemplateLinkInfo) -> ToTemplateLink;
 }
 
@@ -2434,6 +2439,7 @@ struct LinkDefinitionWithDataStruct<TData> {
     link_name: String,
     link_data_name: String,
     framing: LinkDataFraming,
+    defaults_missing_records: bool,
     converter: Converter<TData, Link>,
     reader: Reader<Box<dyn ReadAndSeek>, TData>,
 }
@@ -2452,6 +2458,10 @@ impl<TData> LinkDefinitionWithData for LinkDefinitionWithDataStruct<TData> {
 
     fn link_data_framing(&self) -> LinkDataFraming {
         self.framing
+    }
+
+    fn defaults_missing_records(&self) -> bool {
+        self.defaults_missing_records
     }
 
     fn convert(
@@ -2597,6 +2607,27 @@ pub fn define_link_with_data<TData: 'static + fmt::Debug + Send + Sync + Clone>(
         link_name: link_name.to_string(),
         link_data_name: link_data_name.to_string(),
         framing: LinkDataFraming::HeaderDeclared,
+        defaults_missing_records: false,
+        reader,
+        converter,
+    })
+}
+
+/// Like `define_link_with_data`, but for a flavor whose LD$ chunk is sparse and
+/// whose reader parses all-zeroes as "unspecified": a link with no record of
+/// its own keeps the link with a zero-filled record instead of being dropped.
+/// Check the reader before using this - see `defaults_missing_records`.
+pub fn define_link_with_optional_data<TData: 'static + fmt::Debug + Send + Sync + Clone>(
+    link_name: &str,
+    link_data_name: &str,
+    reader: Reader<Box<dyn ReadAndSeek>, TData>,
+    converter: Converter<TData, Link>,
+) -> Box<dyn LinkDefinitionWithData> {
+    Box::new(LinkDefinitionWithDataStruct {
+        link_name: link_name.to_string(),
+        link_data_name: link_data_name.to_string(),
+        framing: LinkDataFraming::HeaderDeclared,
+        defaults_missing_records: true,
         reader,
         converter,
     })
@@ -2614,6 +2645,7 @@ pub fn define_link_with_versioned_data<TData: 'static + fmt::Debug + Send + Sync
         link_name: link_name.to_string(),
         link_data_name: link_data_name.to_string(),
         framing: LinkDataFraming::VersionHeader,
+        defaults_missing_records: false,
         reader,
         converter,
     })

--- a/dark/src/ss2_entity_info.rs
+++ b/dark/src/ss2_entity_info.rs
@@ -386,7 +386,7 @@ fn read_all_data_links<R1: io::Read + io::Seek>(
         let data_chunk_name = link.link_data_chunk_name();
 
         let link_infos = read_link(&chunk_name, ref_reader, toc);
-        let link_data = read_link_data(
+        let (link_data, record_size) = read_link_data(
             &data_chunk_name,
             ref_reader,
             toc,
@@ -401,8 +401,13 @@ fn read_all_data_links<R1: io::Read + io::Seek>(
                 flavor: link_info.flavor,
             };
 
-            if let Some(data) = link_data.get(&link_info.id) {
-                let component_link = link.convert(data.clone(), data.len() as u32, to_link);
+            let default_size = link
+                .defaults_missing_records()
+                .then_some(record_size)
+                .flatten();
+            if let Some(data) = link_record(&link_data, default_size, link_info.id) {
+                let len = data.len() as u32;
+                let component_link = link.convert(data, len, to_link);
 
                 ent_to_links
                     .entry(link_info.src)
@@ -421,8 +426,9 @@ pub fn read_link_data<T: io::Read + io::Seek>(
     toc: &ChunkFileTableOfContents,
     count: u32,
     framing: LinkDataFraming,
-) -> HashMap<i32, Vec<u8>> {
+) -> (HashMap<i32, Vec<u8>>, Option<usize>) {
     let mut data = HashMap::new();
+    let mut record_size = None;
 
     if count > 0 {
         if let Some(chunk_pos) = toc.get_chunk(link_data_chunk_name.to_owned()) {
@@ -448,11 +454,12 @@ pub fn read_link_data<T: io::Read + io::Seek>(
                             "{}: chunk length {} does not hold {} uniform records; skipping",
                             link_data_chunk_name, chunk_pos.length, count
                         );
-                        return data;
+                        return (data, None);
                     }
                     record_size - 4
                 }
             };
+            record_size = Some(data_len as usize);
             while reader.stream_position().unwrap() < end_pos {
                 let id = read_i32(reader);
                 let bytes = read_bytes(reader, data_len as usize);
@@ -461,7 +468,28 @@ pub fn read_link_data<T: io::Read + io::Seek>(
         }
     }
 
-    data
+    (data, record_size)
+}
+
+/// The data record for one link of a link-with-data flavor. LD$ chunks are
+/// sparse: the gamesys authors 9 LD$Corpse records for 71 L$Corpse links, so a
+/// link with no record of its own takes a zero-filled default and survives,
+/// rather than being dropped along with the link.
+///
+/// `default_size` carries that record shape, and is `None` both for a flavor
+/// that has not opted in (see `LinkDefinitionWithData::defaults_missing_records`
+/// - zeroes are not "unspecified" for every reader) and when the LD$ chunk is
+/// absent or malformed, leaving no shape to default to. Either way the link is
+/// dropped, as it was before defaulting existed.
+fn link_record(
+    link_data: &HashMap<i32, Vec<u8>>,
+    default_size: Option<usize>,
+    link_id: i32,
+) -> Option<Vec<u8>> {
+    match link_data.get(&link_id) {
+        Some(data) => Some(data.clone()),
+        None => default_size.map(|size| vec![0u8; size]),
+    }
 }
 
 fn read_all_links<R: io::Read + io::Seek>(
@@ -595,4 +623,34 @@ fn read_unparsed_link_data_chunk<R: io::Read + io::Seek>(
     }
 
     entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// LD$ chunks are sparse - the shipped gamesys has 71 L$Corpse links but
+    /// only 9 LD$Corpse records. A link with no record of its own must survive
+    /// with a zero-filled default record, not be dropped.
+    #[test]
+    fn a_link_without_a_data_record_takes_the_zeroed_default() {
+        let mut authored = HashMap::new();
+        authored.insert(7, vec![1u8, 0, 0, 0]);
+
+        assert_eq!(link_record(&authored, Some(4), 7), Some(vec![1, 0, 0, 0]));
+        assert_eq!(link_record(&authored, Some(4), 8), Some(vec![0, 0, 0, 0]));
+    }
+
+    /// A flavor that has not opted in (`default_size` None) keeps the old
+    /// behavior: its authored records still parse, the rest stay dropped. A
+    /// zeroed record is not "unspecified" for every reader - a zeroed
+    /// `LD$PhysAtta` offset welds the child to its parent's origin.
+    #[test]
+    fn a_flavor_that_did_not_opt_in_still_drops_its_unauthored_links() {
+        let mut authored = HashMap::new();
+        authored.insert(7, vec![1u8, 0, 0, 0]);
+
+        assert_eq!(link_record(&authored, None, 7), Some(vec![1, 0, 0, 0]));
+        assert_eq!(link_record(&authored, None, 8), None);
+    }
 }

--- a/tools/shock2-sdk/test/link-data-defaults.e2e.test.ts
+++ b/tools/shock2-sdk/test/link-data-defaults.e2e.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// LD$ link-data chunks are sparse, and a link with no record of its own only
+// takes a zero-filled default where its reader parses zeroes as "unspecified"
+// (`LinkDefinitionWithData::defaults_missing_records`).
+//
+// earth.mis is the counter-example that makes that opt-in necessary: its
+// LD$PhysAtta chunk declares a 12-byte record and holds NONE, for six
+// L$PhysAttach links. A zeroed PhysAttach offset does not mean "no offset
+// authored" - it means "sit exactly on the parent's origin", so defaulting
+// those records welds the intro tram's whole collision shell (roof, sides,
+// front, back) onto the tramcar's origin within a couple of seconds.
+//
+// Opt-in (this file only):
+//   tsc && SHOCK2_E2E=1 node --test dist/test/link-data-defaults.e2e.test.js
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "earth tram panels keep their authored placement, not the tramcar's origin",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+
+    const panelsAt = async () => {
+      const { entities } = await game.entities.list({ filter: "Large Tram" });
+      const panels = entities.filter((e) => e.name !== "Large Tramcar");
+      const car = entities.find((e) => e.name === "Large Tramcar");
+      assert.ok(car, "expected a Large Tramcar in earth.mis");
+      assert.equal(panels.length, 6, `expected 6 tram panels, got ${panels.length}`);
+      return { panels, car };
+    };
+
+    const { panels: before, car } = await panelsAt();
+
+    // The panels are authored away from the car's own origin; if they were
+    // already coincident this test could not tell the two apart.
+    const authored = before[0].position;
+    assert.ok(
+      Math.hypot(...authored.map((v, i) => v - car.position[i])) > 0.1,
+      "panels and tramcar start coincident - test cannot distinguish the regression",
+    );
+
+    await game.step({ frames: 120 });
+
+    const { panels: after } = await panelsAt();
+    for (const panel of after) {
+      const start = before.find((p) => p.id === panel.id);
+      assert.ok(start, `panel ${panel.id} disappeared`);
+      assert.deepEqual(
+        panel.position,
+        start.position,
+        `${panel.name} moved off its authored placement to the tramcar origin`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
Clears the `// TODO: Why is the data not available for some of these links?` on `L$Corpse` in `dark/src/properties/mod.rs`.

## The cause

`LD$` chunks are sparse. The gamesys authors **9** `LD$Corpse` records for **71** `L$Corpse` links, and `shodan.mis` has 44 links with none at all. `read_all_data_links` drops any link with no record of its own, so enabling the `L$Corpse` link-with-data definition would have lost 62 of 71 links — hence the commented-out definition and a stand-in that hardcoded `propagate_scale: false` for every link.

A link with no authored record can now keep the link with a zero-filled record, and `L$Corpse` opts in: **71 links preserved, 9 carrying real `propagate_scale`** (8 true, 1 false) instead of `false` for all.

## Why the default is opt-in, not blanket

Zeroes are only "unspecified" to *some* readers. `earth.mis` is the counter-example: its `LD$PhysAtta` chunk declares a 12-byte record and holds **none** for six `L$PhysAttach` links, and a zeroed offset means "sit exactly on the parent's origin". Defaulting them welds the intro tram's whole collision shell onto the tramcar:

```
at load:   Large Tram RHS/Roof/LS Front/LS Back/Front/Back  [10.8,   2.3,    -10.52]
after 120: all six                                          [10.152, 2.0868, -10.431]   (= Large Tramcar)
```

So `LinkDefinitionWithData::defaults_missing_records` is per-flavor and off by default. **Flavors that have not opted in keep today's behavior exactly** — only `L$Corpse` changes.

`propagate_scale` is still unread (`mission_core` binds `_corpse_options`), so this is parsing fidelity, not a behavior change.

## Verification

- `cargo dq entities medsci1.mis --filter L$Corpse` → **178 entities**, same as before the change. With the drop restored it collapses to **9**.
- New `tools/shock2-sdk/test/link-data-defaults.e2e.test.ts` pins the earth tram panels to their authored placement — verified to **fail** when `PhysAttach` is opted in (`Large Tram RHS moved off its authored placement to the tramcar origin`).
- Unit tests on `link_record` cover both the opted-in default and the not-opted-in drop; verified to fail without the change.
- `SHOCK2_E2E=1` missions + new test: **24/24 pass, 0 fail**.
- `cargo test -p dark -p shock2vr` green (1696 + 179 + 11).
- `RUSTFLAGS="-D warnings" cargo check -p dark -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Deliberately not in scope

The other sparse flavors are still dropped — `LD$Particle` (112/113, every mission), `LD$PhysAtta` (0/6, earth), `LD$TPath` (172/173, shodan) — each for a different reason, plus two latent framing problems. Measured table and analysis in #1504.

Note the earth tram panels are dropped **today** as well, so the shell stays behind when the tram moves; this PR doesn't fix that, it only stops making it worse. That's the substance of #1504.