### PR TITLE
refactor(ui): share one list composition across every frontend list

### DIFF
--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -180,31 +180,23 @@ fn scene_count() -> usize {
     super::debug_scene_names().count()
 }
 
-fn scene_rows_per_page(rects: PanelRects) -> usize {
-    list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, SCENE_ROW_H)
+/// The launcher list's geometry - paging, the gutter rocker and the
+/// slot-to-entry mapping - shared with every other frontend list.
+fn scene_list(rects: PanelRects) -> list_scroll::ListGeometry {
+    list_scroll::ListGeometry {
+        pane: rects.list_rect(),
+        bottom_limit: FIELD_TOP_Y,
+        row_h: SCENE_ROW_H,
+        text_inset: SCENE_TEXT_INSET,
+    }
 }
 
-fn scene_max_scroll(rects: PanelRects, len: usize) -> usize {
-    list_scroll::max_scroll(len, scene_rows_per_page(rects))
-}
-
-/// The list indices on screen at `scene_scroll`, clamped to the page.
 fn scene_visible_rows(
     rects: PanelRects,
     len: usize,
     scene_scroll: usize,
 ) -> std::ops::Range<usize> {
-    list_scroll::visible_rows(len, scene_rows_per_page(rects), scene_scroll)
-}
-
-/// The launcher's scroll rocker, in the gutter down the pane's right edge -
-/// the very same one the parameter page scrolls with.
-fn scene_rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(
-        rects.list_rect(),
-        FIELD_TOP_Y,
-        scene_max_scroll(rects, len) > 0,
-    )
+    scene_list(rects).visible_rows(len, scene_scroll)
 }
 
 /// The canvas rect of the tab header for `tab`: the header rect split evenly
@@ -223,33 +215,16 @@ fn tab_rect(rects: PanelRects, tab: SceneTab) -> Rect {
     Rect::new(header.x + index as f32 * width, header.y, width, header.h)
 }
 
-/// The canvas rect of the launcher's `slot`-th visible row. The rows stop
-/// short of the scroll gutter whenever it is in use, so a row and the rocker
-/// can never claim the same point.
+/// The canvas rect of the launcher's `slot`-th visible row. Production code
+/// reaches rows through `scene_list(..).hit(..)`; the tests still name them.
+#[cfg(test)]
 fn scene_row_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let list = rects.list_rect();
-    let gutter = if scene_max_scroll(rects, len) > 0 {
-        list_scroll::GUTTER_W
-    } else {
-        0.0
-    };
-    Rect::new(
-        list.x,
-        list.y + slot as f32 * SCENE_ROW_H,
-        (list.w - gutter).max(0.0),
-        SCENE_ROW_H,
-    )
+    scene_list(rects).row_rect(len, slot)
 }
 
 /// The rect a row's name is drawn in: the row, inset on both edges.
 fn scene_text_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let row = scene_row_rect(rects, len, slot);
-    Rect::new(
-        row.x + SCENE_TEXT_INSET,
-        row.y,
-        (row.w - 2.0 * SCENE_TEXT_INSET).max(0.0),
-        row.h,
-    )
+    scene_list(rects).text_rect(len, slot)
 }
 
 /// What is at a canvas point, on whichever page is showing. Shared by the
@@ -278,23 +253,14 @@ fn hit(state: ScreenState, point: Vector2<f32>) -> Option<DeveloperAction> {
             if state.rects.done_rect().contains(point) {
                 return Some(DeveloperAction::CloseScenes);
             }
-            let rows = scene_visible_rows(state.rects, state.list_len, state.scene_scroll);
-            if let Some(rocker) = scene_rocker(state.rects, state.list_len) {
-                if let Some(half) = list_scroll::hit(
-                    &rocker,
-                    rows.start,
-                    scene_max_scroll(state.rects, state.list_len),
-                    point,
-                ) {
-                    return Some(DeveloperAction::ScrollScenes(half));
-                }
-            }
             // Rows carry the index of the entry scrolled into that slot, never
             // the slot itself: a positional index would launch whatever entry
-            // *used* to be in the row the moment the list scrolls.
-            (0..rows.len())
-                .find(|slot| scene_row_rect(state.rects, state.list_len, *slot).contains(point))
-                .map(|slot| DeveloperAction::SelectScene(rows.start + slot))
+            // *used* to be in the row the moment the list scrolls. That rule,
+            // and the inert-rocker-end one, live in `list_scroll`.
+            match scene_list(state.rects).hit(state.list_len, state.scene_scroll, point)? {
+                list_scroll::ListHit::Row(index) => Some(DeveloperAction::SelectScene(index)),
+                list_scroll::ListHit::Scroll(half) => Some(DeveloperAction::ScrollScenes(half)),
+            }
         }
     }
 }
@@ -502,12 +468,12 @@ impl DeveloperScene {
                         });
                 }
 
-                if let Some(rocker) = scene_rocker(self.panel_rects, len) {
+                if let Some(rocker) = scene_list(self.panel_rects).rocker(len) {
                     list_scroll::draw(
                         &mut canvas,
                         &rocker,
                         rows.start,
-                        scene_max_scroll(self.panel_rects, len),
+                        scene_list(self.panel_rects).max_scroll(len),
                         match hovered {
                             Some(DeveloperAction::ScrollScenes(half)) => Some(half),
                             _ => None,
@@ -562,7 +528,7 @@ impl DeveloperScene {
             }
             DeveloperAction::SelectScene(index) => self.selected_scene = Some(index),
             DeveloperAction::ScrollScenes(half) => {
-                let max = scene_max_scroll(self.panel_rects, self.tab_list_len());
+                let max = scene_list(self.panel_rects).max_scroll(self.tab_list_len());
                 list_scroll::apply(half, &mut self.scene_scroll, max)
             }
             DeveloperAction::LaunchScene => {
@@ -1119,7 +1085,7 @@ mod tests {
     fn the_launcher_hit_test_follows_its_scroll() {
         let rects = PanelRects::default();
         let len = scene_count();
-        let max = scene_max_scroll(rects, len);
+        let max = scene_list(rects).max_scroll(len);
         assert!(max > 0, "the shipped scene list must scroll to test this");
         for scroll in 1..=max {
             let slot0 = scene_row_rect(rects, len, 0);
@@ -1135,8 +1101,10 @@ mod tests {
     fn the_launchers_rocker_scrolls_and_stops_at_both_ends() {
         let rects = PanelRects::default();
         let len = scene_count();
-        let rocker = scene_rocker(rects, len).expect("the shipped scene list scrolls");
-        let max = scene_max_scroll(rects, len);
+        let rocker = scene_list(rects)
+            .rocker(len)
+            .expect("the shipped scene list scrolls");
+        let max = scene_list(rects).max_scroll(len);
 
         // At the top the up half is inert; at the bottom, the down half is.
         assert_eq!(hit(scenes_state(0, true, len), rocker.up.center()), None);

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -225,17 +225,30 @@ fn row_rects(rects: PanelRects, index: usize) -> RowRects {
     }
 }
 
+/// This page's list geometry - the paging and the gutter rocker every other
+/// frontend list uses, at the parameter rows' own pitch. The rows themselves
+/// are built by [`row_rects`] rather than the shared `row_rect`, because a
+/// parameter row is not one target but four columns (label, `<`, value, `>`).
+fn list(rects: PanelRects) -> list_scroll::ListGeometry {
+    list_scroll::ListGeometry {
+        pane: rects.list,
+        bottom_limit: FIELD_TOP_Y,
+        row_h: ROW_PITCH,
+        text_inset: TEXT_INSET,
+    }
+}
+
 /// How many rows fit in the pane above the backdrop's painted field - the
 /// size of one page of the list, however long the registry is.
 fn rows_per_page(rects: PanelRects) -> usize {
-    list_scroll::rows_per_page(rects.list, FIELD_TOP_Y, ROW_PITCH)
+    list(rects).rows_per_page()
 }
 
 /// The furthest the list can scroll: the first-row index that puts the tail
 /// of the registry against the bottom of the pane. Zero when everything fits
 /// at once, which is also what hides the scroll rocker.
 fn max_scroll(rects: PanelRects) -> usize {
-    list_scroll::max_scroll(dev_params::PARAMS.len(), rows_per_page(rects))
+    list(rects).max_scroll(dev_params::PARAMS.len())
 }
 
 /// The registry indices on screen at `scroll`, with `scroll` clamped to what
@@ -246,7 +259,7 @@ fn max_scroll(rects: PanelRects) -> usize {
 /// *step* another's - the failure a positional row index invites the moment
 /// the list scrolls.
 fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
-    list_scroll::visible_rows(dev_params::PARAMS.len(), rows_per_page(rects), scroll)
+    list(rects).visible_rows(dev_params::PARAMS.len(), scroll)
 }
 
 /// The scroll rocker's two halves - up and down arrows - in a gutter down the
@@ -259,7 +272,7 @@ fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
 /// anyway - a scrollbar's place is beside what it scrolls, not across the
 /// screen from it.
 fn rocker(rects: PanelRects) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(rects.list, FIELD_TOP_Y, max_scroll(rects) > 0)
+    list(rects).rocker(dev_params::PARAMS.len())
 }
 
 #[cfg(test)]

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -135,10 +135,106 @@ pub fn hit(
 }
 
 /// Move `scroll` by one row, stopping at either end.
+///
+/// The offset is clamped into range *before* it moves, so an offset left over
+/// from a longer list (or a taller pane) does not need several dead `Up`
+/// clicks to unstick: the display already clamps via [`visible_rows`], and
+/// this keeps the stored offset agreeing with what is drawn.
 pub fn apply(half: ScrollHalf, scroll: &mut usize, max_scroll: usize) {
+    *scroll = (*scroll).min(max_scroll);
     match half {
         ScrollHalf::Up => *scroll = scroll.saturating_sub(1),
         ScrollHalf::Down => *scroll = (*scroll + 1).min(max_scroll),
+    }
+}
+
+/// What a point on a list pane landed on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ListHit {
+    /// The item index scrolled into the row under the point - never the row's
+    /// own slot, which would act on whatever *used* to sit there.
+    Row(usize),
+    Scroll(ScrollHalf),
+}
+
+/// One list pane's geometry: everything a screen needs to turn "a pane, a row
+/// height and a number of items" into rows, a rocker and a hit test.
+///
+/// The primitives above are shared; this is the *composition* of them, which
+/// was written out once per screen until three lists had their own copy. A
+/// screen now states its pane and its pitch and gets the same paging, the same
+/// gutter, and the same slot-to-index mapping as every other list.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ListGeometry {
+    /// The pane the rows live in, from the backdrop's authored layout.
+    pub pane: Rect,
+    /// The y the rows must stop at - where the backdrop starts painting
+    /// something they have to clear.
+    pub bottom_limit: f32,
+    /// Distance between row tops, and each row's height.
+    pub row_h: f32,
+    /// Horizontal inset of a row's text from the row.
+    pub text_inset: f32,
+}
+
+impl ListGeometry {
+    pub fn rows_per_page(&self) -> usize {
+        rows_per_page(self.pane, self.bottom_limit, self.row_h)
+    }
+
+    pub fn max_scroll(&self, len: usize) -> usize {
+        max_scroll(len, self.rows_per_page())
+    }
+
+    pub fn visible_rows(&self, len: usize, scroll: usize) -> Range<usize> {
+        visible_rows(len, self.rows_per_page(), scroll)
+    }
+
+    pub fn rocker(&self, len: usize) -> Option<Rocker> {
+        rocker(self.pane, self.bottom_limit, self.max_scroll(len) > 0)
+    }
+
+    /// The `slot`-th visible row. Rows stop short of the scroll gutter exactly
+    /// when [`Self::rocker`] is `Some` - the same expression decides both, so a
+    /// row and the rocker can never claim the same point.
+    pub fn row_rect(&self, len: usize, slot: usize) -> Rect {
+        let gutter = if self.max_scroll(len) > 0 {
+            GUTTER_W
+        } else {
+            0.0
+        };
+        Rect::new(
+            self.pane.x,
+            self.pane.y + slot as f32 * self.row_h,
+            (self.pane.w - gutter).max(0.0),
+            self.row_h,
+        )
+    }
+
+    /// The rect a row's text is drawn in: the row, inset on both edges.
+    pub fn text_rect(&self, len: usize, slot: usize) -> Rect {
+        let row = self.row_rect(len, slot);
+        Rect::new(
+            row.x + self.text_inset,
+            row.y,
+            (row.w - 2.0 * self.text_inset).max(0.0),
+            row.h,
+        )
+    }
+
+    /// What is at a canvas point: a row's item index, a live rocker half, or
+    /// nothing. The rocker is tested first, and a half that cannot move is
+    /// inert rather than falling through to the row beneath it.
+    pub fn hit(&self, len: usize, scroll: usize, point: Vector2<f32>) -> Option<ListHit> {
+        let rows = self.visible_rows(len, scroll);
+        if let Some(rocker) = self.rocker(len) {
+            if let Some(half) = hit(&rocker, rows.start, self.max_scroll(len), point) {
+                return Some(ListHit::Scroll(half));
+            }
+        }
+        (0..rows.len())
+            .find(|slot| self.row_rect(len, *slot).contains(point))
+            .map(|slot| ListHit::Row(rows.start + slot))
     }
 }
 
@@ -241,6 +337,74 @@ mod tests {
         assert_eq!(art_for(&UP_ART, false, false), "BUP_DOWN.PCX");
         assert_eq!(art_for(&UP_ART, false, true), "BUP_DOWN.PCX");
         assert_eq!(art_for(&DOWN_ART, false, true), "BDN_DOWN.PCX");
+    }
+
+    const GEOMETRY: ListGeometry = ListGeometry {
+        pane: LIST,
+        bottom_limit: FIELD_TOP_Y,
+        row_h: 19.0,
+        text_inset: 8.0,
+    };
+
+    /// The composition every list shares: rows page, the gutter appears with
+    /// the rocker, and a row reports the item scrolled into it.
+    #[test]
+    fn the_geometry_maps_slots_to_the_scrolled_item() {
+        let short = GEOMETRY.rows_per_page() - 1;
+        let long = GEOMETRY.rows_per_page() + 5;
+
+        // A list that fits: no rocker, and rows span the full pane.
+        assert!(GEOMETRY.rocker(short).is_none());
+        assert_eq!(GEOMETRY.row_rect(short, 0).w, LIST.w);
+        assert_eq!(
+            GEOMETRY.hit(short, 0, GEOMETRY.row_rect(short, 0).center()),
+            Some(ListHit::Row(0))
+        );
+
+        // A list that does not: the rows make room for the gutter...
+        assert!(GEOMETRY.rocker(long).is_some());
+        assert_eq!(GEOMETRY.row_rect(long, 0).w, LIST.w - GUTTER_W);
+        // ...the top row follows the offset...
+        assert_eq!(
+            GEOMETRY.hit(long, 3, GEOMETRY.row_rect(long, 0).center()),
+            Some(ListHit::Row(3))
+        );
+        // ...an over-scroll clamps rather than walking off the end...
+        assert_eq!(
+            GEOMETRY.hit(long, 99, GEOMETRY.row_rect(long, 0).center()),
+            Some(ListHit::Row(GEOMETRY.max_scroll(long)))
+        );
+        // ...and the rocker takes its own gutter, with inert ends.
+        let rocker = GEOMETRY.rocker(long).unwrap();
+        assert_eq!(
+            GEOMETRY.hit(long, 0, rocker.down.center()),
+            Some(ListHit::Scroll(ScrollHalf::Down))
+        );
+        assert_eq!(GEOMETRY.hit(long, 0, rocker.up.center()), None);
+    }
+
+    /// Every row of a full page clears the painted field, not just the pane.
+    #[test]
+    fn a_full_page_of_rows_stays_above_the_field() {
+        let len = GEOMETRY.rows_per_page() + 5;
+        for slot in 0..GEOMETRY.rows_per_page() {
+            let row = GEOMETRY.row_rect(len, slot);
+            assert!(row.y >= LIST.y, "{row:?}");
+            assert!(row.y + row.h <= FIELD_TOP_Y, "slot {slot}: {row:?}");
+        }
+    }
+
+    /// An offset stranded past the end (a shorter list, a shallower pane)
+    /// must not need dead clicks to unstick.
+    #[test]
+    fn an_over_scroll_is_clamped_before_it_moves() {
+        let mut scroll = 40;
+        apply(ScrollHalf::Up, &mut scroll, 5);
+        assert_eq!(scroll, 4, "one Up from a stranded offset must move a row");
+
+        let mut scroll = 40;
+        apply(ScrollHalf::Down, &mut scroll, 5);
+        assert_eq!(scroll, 5);
     }
 
     #[test]


### PR DESCRIPTION
Groundwork split out of #1224 so the cheats page that follows does not add a *third* copy of the same list code.

## Problem

`ui/list_scroll` shared the list **primitives** (`rows_per_page`, `max_scroll`, `visible_rows`, `rocker`, `hit`, `apply`, the arrow art) but not their **composition**. Every screen wrote that composition out itself, so the debug-scene launcher's `scene_*` helpers and `dev_params_panel`'s were near-copies differing only in row pitch. "The frontend lists scroll the same way" was a convention maintained by hand, not a fact.

## Change

`list_scroll::ListGeometry` owns the composition: a screen states its pane, its bottom limit, its row pitch and its text inset, and gets the paging, the gutter rocker, the row/text rects and the hit test from one place. Two rules that were previously duplicated are now single-sourced:

- a row **clears the scroll gutter exactly when the rocker exists** (the same expression decides both, so a row and the rocker can never claim the same point);
- a row reports the **item index scrolled into it**, never its own slot — a positional index acts on whatever *used* to sit there the moment the list scrolls.

`list_scroll::apply` also clamps a stranded offset before it moves. An offset left over from a longer list (or a taller pane) previously needed several dead `Up` clicks to unstick, because the *display* clamps via `visible_rows` but the stored offset did not.

No behavior change otherwise; no player-visible change, so no visuals.

## Verification

- `cargo test -p shock2vr --lib`: **1699 pass, 0 fail** — including the launcher's existing hit-test/rocker/row-containment tests, which exercise the new path unchanged.
- Three new `list_scroll` tests cover the extracted composition directly: slot-to-item mapping across scroll offsets, a full page of rows staying above the painted field, and the over-scroll clamp (this one fails without the `apply` fix).
- `cargo check -p shock2vr` clean. The 3 `-D warnings` failures under `--all-targets` (`wielded_weapon.rs`) are present on `main` unchanged.