### PR TITLE
feat(debug): add a Cheats page to the in-game Developer screen

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -183,6 +183,7 @@ use crate::{
     mission::{GlobalContext, Mission, PlayerInfo, PlayerLifeState},
     pause_menu::PauseAction,
     scripts::Effect,
+    ui::cheats_panel::CheatAction,
 };
 use zip_asset_path::ZipAssetPath;
 
@@ -1743,13 +1744,18 @@ impl Game {
                 self.handle_global_effect(GlobalEffect::ShowMainMenu);
             }
             // A cheat acts on the paused scene and leaves the overlay up, so
-            // several can be fired before resuming. Effects reach a scene
-            // through `handle_effects`, which stays callable while the scene's
-            // `update` is skipped.
-            Some(PauseAction::RainItems { template_ids }) => {
-                self.apply_scene_effects(vec![Effect::RainItems {
-                    template_ids: template_ids.to_vec(),
-                }]);
+            // several can be fired before resuming. The page describes what a
+            // row does; turning that into an effect is the host's job.
+            Some(PauseAction::Cheat(action)) => {
+                let effect = match action {
+                    CheatAction::Rain(template_ids) => Effect::RainItems {
+                        template_ids: template_ids.to_vec(),
+                    },
+                    CheatAction::Alertness { level, pin } => {
+                        Effect::SetAllAIAlertness { level, pin }
+                    }
+                };
+                self.apply_scene_effects(vec![effect]);
             }
             None => {}
         }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1753,6 +1753,15 @@ impl Game {
                 self.close_pause_menu(true);
                 self.handle_global_effect(GlobalEffect::ShowMainMenu);
             }
+            // A cheat acts on the paused scene and leaves the overlay up, so
+            // several can be fired before resuming. Effects reach a scene
+            // through `handle_effects`, which stays callable while the scene's
+            // `update` is skipped.
+            Some(PauseAction::RainItems { template_ids }) => {
+                self.apply_scene_effects(vec![Effect::RainItems {
+                    template_ids: template_ids.to_vec(),
+                }]);
+            }
             None => {}
         }
     }
@@ -1769,10 +1778,18 @@ impl Game {
     fn open_pause_menu(&mut self) {
         // Taking over the screen suspends the flat metagame (Tab/MFD) mode, so
         // the player is not left with a cursor-driven overlay under the pause
-        // panel. Effects reach a scene through `handle_effects`, which stays
-        // callable while the scene's `update` is skipped.
+        // panel.
+        self.apply_scene_effects(vec![Effect::CloseUseMode]);
+        self.pause_menu.open();
+    }
+
+    /// Hand effects to the active scene while it is suspended, forwarding
+    /// whatever global effects come back. `handle_effects` stays callable
+    /// while the scene's `update` is skipped, which is what lets the pause
+    /// overlay act on the scene underneath it.
+    fn apply_scene_effects(&mut self, effects: Vec<Effect>) {
         let global_effects = self.active_game_scene.handle_effects(
-            vec![Effect::CloseUseMode],
+            effects,
             &self.global_context,
             &self.options,
             &mut self.asset_cache,
@@ -1781,7 +1798,6 @@ impl Game {
         for effect in global_effects {
             self.handle_global_effect(effect);
         }
-        self.pause_menu.open();
     }
 
     fn save_to_file(&self, file_name: String) -> Result<(), SaveGameError> {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1593,18 +1593,7 @@ impl Game {
             |entity_id| util::get_entity_position(world, entity_id),
         );
 
-        // Handle global effects
-        let global_effects = self.active_game_scene.handle_effects(
-            effects,
-            &self.global_context,
-            &self.options,
-            &mut self.asset_cache,
-            &mut self.audio_context,
-        );
-
-        for effect in global_effects {
-            self.handle_global_effect(effect);
-        }
+        self.apply_scene_effects(effects);
     }
 
     /// The clock the active scene sees: wall time with every suspended frame
@@ -1783,10 +1772,10 @@ impl Game {
         self.pause_menu.open();
     }
 
-    /// Hand effects to the active scene while it is suspended, forwarding
-    /// whatever global effects come back. `handle_effects` stays callable
-    /// while the scene's `update` is skipped, which is what lets the pause
-    /// overlay act on the scene underneath it.
+    /// Hand effects to the active scene, forwarding whatever global effects
+    /// come back. Used by the ordinary update and by the pause overlay alike:
+    /// `handle_effects` stays callable while the scene's `update` is skipped,
+    /// which is what lets the overlay act on the scene underneath it.
     fn apply_scene_effects(&mut self, effects: Vec<Effect>) {
         let global_effects = self.active_game_scene.handle_effects(
             effects,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -139,6 +139,13 @@ const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 const RAIN_RADIUS: f32 = 2.0 / SCALE_FACTOR;
 const RAIN_HEIGHT: f32 = 3.5 / SCALE_FACTOR;
 
+/// How far each rain rotates the next one's ring. The golden angle, so
+/// consecutive rains interleave instead of stacking: two presses in a row
+/// (easy, since the overlay stays up) would otherwise drop every item onto
+/// the slot an earlier one is still occupying, and the solver flings the
+/// coincident bodies apart on resume rather than letting them fall.
+const RAIN_PHASE_STEP: f32 = 2.399_963_2;
+
 /// Resolve optional media-reader portrait/icon art before it becomes a shared
 /// UI image. STR tables author extension-less PCX-era names, while replacement
 /// layers may provide the same art under a modern encoding (SCP's Earth
@@ -2023,6 +2030,10 @@ pub struct MissionCore {
     /// `P$SymName`, indexed by lowercased name - the fallback an ecology spawn
     /// uses when the gamesys has no archetype under the authored name.
     mission_object_name_to_id: HashMap<String, i32>,
+    /// How many `Effect::RainItems` have landed, to phase each ring off the
+    /// last (see [`RAIN_PHASE_STEP`]). Cosmetic and cheat-only, so it is not
+    /// saved.
+    rains_landed: u32,
     pub obj_map: HashMap<i32, String>,
     pub world: World,
     pub player_handle: PlayerHandle,
@@ -3061,6 +3072,7 @@ impl MissionCore {
             id_to_particle_system: HashMap::new(),
             template_name_to_template_id,
             mission_object_name_to_id,
+            rains_landed: 0,
             scene_objects: scene,
             animated_lightmaps,
             physics,
@@ -10087,8 +10099,10 @@ impl MissionCore {
                     // they visibly fall. Deterministic, not random - a capture
                     // or an e2e assertion must be able to repeat the layout.
                     let count = template_ids.len() as f32;
+                    let phase = RAIN_PHASE_STEP * self.rains_landed as f32;
+                    self.rains_landed = self.rains_landed.wrapping_add(1);
                     for (index, template_id) in template_ids.iter().enumerate() {
-                        let angle = std::f32::consts::TAU * index as f32 / count;
+                        let angle = phase + std::f32::consts::TAU * index as f32 / count;
                         let offset = vec3(
                             RAIN_RADIUS * angle.cos(),
                             RAIN_HEIGHT,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -126,6 +126,19 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 
+/// Where `Effect::RainItems` puts its spawns, relative to the player's body
+/// ORIGIN (the capsule centre, three feet off the floor - not the feet).
+/// Written in SS2 feet over `SCALE_FACTOR`, like the spawn handlers beside it,
+/// because the profile these clear is authored in feet: the standing capsule's
+/// crown is 3 ft above the origin and its radius is 1.2 ft.
+///
+/// So the ring drops items from just over head height, at arm's length: high
+/// enough to fall visibly and to miss the player, low enough to stay under a
+/// corridor ceiling (at 6.25 ft the rain landed on top of the ceiling geometry
+/// instead of reaching the player).
+const RAIN_RADIUS: f32 = 2.0 / SCALE_FACTOR;
+const RAIN_HEIGHT: f32 = 3.5 / SCALE_FACTOR;
+
 /// Resolve optional media-reader portrait/icon art before it becomes a shared
 /// UI image. STR tables author extension-less PCX-era names, while replacement
 /// layers may provide the same art under a modern encoding (SCP's Earth
@@ -10061,6 +10074,34 @@ impl MissionCore {
                     {
                         let msgs = self.interaction.wield(info.entity_id);
                         effects.extend(self.process_virtual_hand_effects(asset_cache, msgs));
+                    }
+                }
+                Effect::RainItems { template_ids } => {
+                    let (pos, rot) = {
+                        let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                        (vec3_to_point3(player.pos), player.rotation)
+                    };
+                    // A ring above head height, one item per slot: spread out
+                    // so the spawns do not interpenetrate on the first step
+                    // (which would fling them apart), and high enough that
+                    // they visibly fall. Deterministic, not random - a capture
+                    // or an e2e assertion must be able to repeat the layout.
+                    let count = template_ids.len() as f32;
+                    for (index, template_id) in template_ids.iter().enumerate() {
+                        let angle = std::f32::consts::TAU * index as f32 / count;
+                        let offset = vec3(
+                            RAIN_RADIUS * angle.cos(),
+                            RAIN_HEIGHT,
+                            RAIN_RADIUS * angle.sin(),
+                        );
+                        self.create_entity_with_position(
+                            asset_cache,
+                            *template_id,
+                            pos + offset,
+                            rot,
+                            Matrix4::identity(),
+                            CreateEntityOptions::default(),
+                        );
                     }
                 }
                 Effect::DebugCycleWeapon { head_rotation } => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -146,6 +146,21 @@ const RAIN_HEIGHT: f32 = 3.5 / SCALE_FACTOR;
 /// coincident bodies apart on resume rather than letting them fall.
 const RAIN_PHASE_STEP: f32 = 2.399_963_2;
 
+/// Minimum arc between neighbouring slots, so the ring grows with the cheat
+/// rather than packing its items tighter. At the fixed 2 ft radius the
+/// eight-item weapon spread put neighbours ~1.5 ft apart - shorter than the
+/// Assault Rifle it spawns, so they started the frame interpenetrating.
+const RAIN_MIN_SPACING: f32 = 2.5 / SCALE_FACTOR;
+
+/// How far short of a wall a slot is pulled. The ring is placed around the
+/// player without regard for the room, so a player standing closer to a wall
+/// than the radius would otherwise drop items straight through it.
+const RAIN_WALL_MARGIN: f32 = 0.5 / SCALE_FACTOR;
+
+/// Extra lift per slot, so items pulled to the same place by neighbouring
+/// walls still fall as a stack rather than starting inside one another.
+const RAIN_SLOT_LIFT: f32 = 0.35 / SCALE_FACTOR;
+
 /// Resolve optional media-reader portrait/icon art before it becomes a shared
 /// UI image. STR tables author extension-less PCX-era names, while replacement
 /// layers may provide the same art under a modern encoding (SCP's Earth
@@ -10099,14 +10114,34 @@ impl MissionCore {
                     // they visibly fall. Deterministic, not random - a capture
                     // or an e2e assertion must be able to repeat the layout.
                     let count = template_ids.len() as f32;
+                    // Grow the ring with the cheat instead of packing a longer
+                    // list into the same circle.
+                    let radius = RAIN_RADIUS.max(count * RAIN_MIN_SPACING / std::f32::consts::TAU);
                     let phase = RAIN_PHASE_STEP * self.rains_landed as f32;
                     self.rains_landed = self.rains_landed.wrapping_add(1);
                     for (index, template_id) in template_ids.iter().enumerate() {
                         let angle = phase + std::f32::consts::TAU * index as f32 / count;
+                        let direction = vec3(angle.cos(), 0.0, angle.sin());
+                        // Keep the slot on the player's side of the walls: the
+                        // ring knows nothing about the room, so in a duct or
+                        // against a wall the naive point is through it.
+                        let reach = match self.physics.ray_cast2(
+                            pos,
+                            direction,
+                            radius,
+                            crate::physics::InternalCollisionGroups::WORLD,
+                            None,
+                            true,
+                        ) {
+                            Some(hit) => {
+                                ((hit.hit_point - pos).magnitude() - RAIN_WALL_MARGIN).max(0.0)
+                            }
+                            None => radius,
+                        };
                         let offset = vec3(
-                            RAIN_RADIUS * angle.cos(),
-                            RAIN_HEIGHT,
-                            RAIN_RADIUS * angle.sin(),
+                            direction.x * reach,
+                            RAIN_HEIGHT + index as f32 * RAIN_SLOT_LIFT,
+                            direction.z * reach,
                         );
                         self.create_entity_with_position(
                             asset_cache,

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -108,9 +108,9 @@ pub enum PauseAction {
     Resume,
     /// Abandon the run and go back to the main menu.
     QuitToMainMenu,
-    /// Developer cheat: rain these templates around the player. The overlay
-    /// stays up - a cheat sets a situation up, it does not resume the game.
-    RainItems { template_ids: &'static [i32] },
+    /// Carry out a developer cheat. The overlay stays up - a cheat sets a
+    /// situation up, it does not resume the game.
+    Cheat(cheats_panel::CheatAction),
 }
 
 /// Which page of the overlay is showing. The Developer page is a page of the
@@ -561,9 +561,7 @@ impl PauseMenu {
         event: Option<cheats_panel::CheatsEvent>,
     ) -> Option<PauseAction> {
         match cheats_panel::activate(self.panel_rects, event?, &mut self.cheats_scroll)? {
-            cheats_panel::CheatsOutcome::Rain(template_ids) => {
-                Some(PauseAction::RainItems { template_ids })
-            }
+            cheats_panel::CheatsOutcome::Act(action) => Some(PauseAction::Cheat(action)),
             cheats_panel::CheatsOutcome::Done => {
                 self.page = PauseMenuPage::Developer;
                 None
@@ -899,13 +897,11 @@ mod tests {
         menu.page = PauseMenuPage::Cheats;
 
         for (index, cheat) in cheats_panel::CHEATS.iter().enumerate() {
-            let action = menu.handle_cheats_event(Some(cheats_panel::CheatsEvent::Rain(index)));
+            let action = menu.handle_cheats_event(Some(cheats_panel::CheatsEvent::Row(index)));
             assert_eq!(
                 action,
-                Some(PauseAction::RainItems {
-                    template_ids: cheat.templates(),
-                }),
-                "cheat {index} must rain its own templates",
+                Some(PauseAction::Cheat(cheat.action())),
+                "cheat {index} must carry out its own action",
             );
             assert_eq!(menu.page, PauseMenuPage::Cheats);
             assert!(menu.is_open());

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -34,7 +34,7 @@ use crate::{
     input_context::InputContext,
     ui::{
         FrontendCanvasPresenter, FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas,
-        VAlign, dev_params_panel, hit_menu_item,
+        VAlign, cheats_panel, dev_params_panel, hit_menu_item,
     },
 };
 
@@ -108,6 +108,9 @@ pub enum PauseAction {
     Resume,
     /// Abandon the run and go back to the main menu.
     QuitToMainMenu,
+    /// Developer cheat: rain these templates around the player. The overlay
+    /// stays up - a cheat sets a situation up, it does not resume the game.
+    RainItems { template_ids: &'static [i32] },
 }
 
 /// Which page of the overlay is showing. The Developer page is a page of the
@@ -117,6 +120,10 @@ pub enum PauseAction {
 enum PauseMenuPage {
     Root,
     Developer,
+    /// The Developer screen's [`cheats_panel`] page. It lives here rather than
+    /// on the main menu's Developer scene because a cheat acts on the running
+    /// mission, so there is nothing for it to do before one is loaded.
+    Cheats,
 }
 
 /// What a click on a root-page entry means: either something [`PauseAction`]
@@ -132,6 +139,10 @@ enum PauseMenuEntry {
 enum PauseMenuTarget {
     Root(PauseMenuEntry),
     Developer(dev_params_panel::DevParamsEvent),
+    /// The Developer page's upper framed button - the slot the main menu's
+    /// Developer scene fills with its scene launcher.
+    OpenCheats,
+    Cheats(cheats_panel::CheatsEvent),
 }
 
 // `SIM.PCX` (native 640x480) has a vertical stack of five buttons down the
@@ -243,13 +254,20 @@ fn target_at(
     page: PauseMenuPage,
     panel_rects: dev_params_panel::PanelRects,
     panel_scroll: usize,
+    cheats_scroll: usize,
     rects: &[Rect],
     point: Vector2<f32>,
 ) -> Option<PauseMenuTarget> {
     match page {
         PauseMenuPage::Root => hit(point, rects).map(PauseMenuTarget::Root),
         PauseMenuPage::Developer => {
+            if panel_rects.action_rect().contains(point) {
+                return Some(PauseMenuTarget::OpenCheats);
+            }
             dev_params_panel::hit(panel_rects, panel_scroll, point).map(PauseMenuTarget::Developer)
+        }
+        PauseMenuPage::Cheats => {
+            cheats_panel::hit(panel_rects, cheats_scroll, point).map(PauseMenuTarget::Cheats)
         }
     }
 }
@@ -307,6 +325,9 @@ pub struct PauseMenu {
     /// panel is stateless, so its scroll position lives here and is handed to
     /// the hit test and the render alike.
     panel_scroll: usize,
+    /// Index of the cheat in the Cheats page's top row - the same stateless
+    /// arrangement as `panel_scroll`.
+    cheats_scroll: usize,
 }
 
 impl Default for PauseMenu {
@@ -328,6 +349,7 @@ impl PauseMenu {
             closed_under_a_held_press: false,
             panel_rects: dev_params_panel::PanelRects::default(),
             panel_scroll: 0,
+            cheats_scroll: 0,
         }
     }
 
@@ -429,12 +451,31 @@ impl PauseMenu {
         let page = self.page;
         let panel_rects = self.panel_rects;
         let panel_scroll = self.panel_scroll;
+        let cheats_scroll = self.cheats_scroll;
         let target = self.menu.update(
             elapsed,
             input_context,
             options.presentation_mode,
-            |point| target_at(page, panel_rects, panel_scroll, &rects, point),
-            |point| target_at(page, panel_rects, panel_scroll, &rects, point),
+            |point| {
+                target_at(
+                    page,
+                    panel_rects,
+                    panel_scroll,
+                    cheats_scroll,
+                    &rects,
+                    point,
+                )
+            },
+            |point| {
+                target_at(
+                    page,
+                    panel_rects,
+                    panel_scroll,
+                    cheats_scroll,
+                    &rects,
+                    point,
+                )
+            },
         );
         self.handle_target(target)
     }
@@ -459,11 +500,12 @@ impl PauseMenu {
         let page = self.page;
         let panel_rects = self.panel_rects;
         let panel_scroll = self.panel_scroll;
+        let cheats_scroll = self.cheats_scroll;
         let target = self.menu.resolve_pointer(
             point,
             pressed,
-            |point| target_at(page, panel_rects, panel_scroll, rects, point),
-            |point| target_at(page, panel_rects, panel_scroll, rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, cheats_scroll, rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, cheats_scroll, rects, point),
         );
         self.handle_target(target)
     }
@@ -472,6 +514,12 @@ impl PauseMenu {
         match target {
             Some(PauseMenuTarget::Root(entry)) => self.handle_root_entry(Some(entry)),
             Some(PauseMenuTarget::Developer(event)) => self.handle_developer_event(Some(event)),
+            Some(PauseMenuTarget::OpenCheats) => {
+                self.page = PauseMenuPage::Cheats;
+                self.cheats_scroll = 0;
+                None
+            }
+            Some(PauseMenuTarget::Cheats(event)) => self.handle_cheats_event(Some(event)),
             None => None,
         }
     }
@@ -502,6 +550,25 @@ impl PauseMenu {
             }
         }
         None
+    }
+
+    /// Route a clicked Cheats-page event: scrolling is absorbed by the panel,
+    /// "Done" returns to the parameter rows, and a cheat row becomes the one
+    /// thing `Game` must act on - the overlay stays up either way, so several
+    /// cheats can be fired before resuming.
+    fn handle_cheats_event(
+        &mut self,
+        event: Option<cheats_panel::CheatsEvent>,
+    ) -> Option<PauseAction> {
+        match cheats_panel::activate(self.panel_rects, event?, &mut self.cheats_scroll)? {
+            cheats_panel::CheatsOutcome::Rain(template_ids) => {
+                Some(PauseAction::RainItems { template_ids })
+            }
+            cheats_panel::CheatsOutcome::Done => {
+                self.page = PauseMenuPage::Developer;
+                None
+            }
+        }
     }
 
     /// World-space presentation: the canvas on a panel in front of the player.
@@ -601,21 +668,59 @@ impl PauseMenu {
     ) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
 
-        if self.page == PauseMenuPage::Developer {
-            // The Developer page: the shared parameter panel on its own
-            // backdrop. Everything about the page - rows, arrows, "Done" -
-            // is described by `dev_params_panel`, so this page and the
-            // standalone Developer scene cannot drift apart.
+        if matches!(self.page, PauseMenuPage::Developer | PauseMenuPage::Cheats) {
+            // The Developer screen: a shared panel on its own backdrop.
+            // Everything about either page - rows, arrows, "Done" - is
+            // described by the panel module, so these pages and the standalone
+            // Developer scene cannot drift apart.
             canvas.image(
                 Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H),
                 DEVELOPER_BACKDROP_TEXTURE,
             );
-            dev_params_panel::draw(
-                &mut canvas,
-                self.panel_rects,
-                self.panel_scroll,
-                pointer_canvas,
-            );
+            let hovered = pointer_canvas.and_then(|point| {
+                target_at(
+                    self.page,
+                    self.panel_rects,
+                    self.panel_scroll,
+                    self.cheats_scroll,
+                    &[],
+                    point,
+                )
+            });
+            match self.page {
+                PauseMenuPage::Cheats => cheats_panel::draw(
+                    &mut canvas,
+                    self.panel_rects,
+                    self.cheats_scroll,
+                    pointer_canvas,
+                ),
+                _ => {
+                    dev_params_panel::draw(
+                        &mut canvas,
+                        self.panel_rects,
+                        self.panel_scroll,
+                        pointer_canvas,
+                    );
+                    // The upper framed button: the Cheats page's door. It is
+                    // this host's rather than the panel's because the main
+                    // menu's Developer scene fills the same slot with its
+                    // scene launcher - a cheat needs a running mission, a
+                    // launcher needs there not to be one.
+                    canvas
+                        .text_native(
+                            self.panel_rects.action_rect(),
+                            cheats_panel::OPEN_LABEL,
+                            MENU_FONT,
+                            HAlign::Center,
+                            VAlign::Middle,
+                        )
+                        .opacity(if hovered == Some(PauseMenuTarget::OpenCheats) {
+                            HOVER_OPACITY
+                        } else {
+                            IDLE_OPACITY
+                        });
+                }
+            }
             return canvas;
         }
 
@@ -762,6 +867,98 @@ mod tests {
         );
         assert_eq!(menu.page, PauseMenuPage::Root);
         assert!(menu.is_open());
+    }
+
+    /// The Developer page's upper framed button opens the Cheats page. It is
+    /// the slot the main menu's Developer scene fills with its scene launcher,
+    /// so the two hosts must not both claim it.
+    #[test]
+    fn the_upper_framed_button_opens_the_cheats_page() {
+        let panel = dev_params_panel::PanelRects::default();
+        let point = panel.action_rect().center();
+
+        assert_eq!(
+            target_at(PauseMenuPage::Developer, panel, 0, 0, &[], point),
+            Some(PauseMenuTarget::OpenCheats),
+        );
+
+        let mut menu = PauseMenu::new();
+        menu.open();
+        menu.handle_root_entry(Some(PauseMenuEntry::Developer));
+        // Turning the page never reaches `Game`, and never closes the menu.
+        assert_eq!(menu.handle_target(Some(PauseMenuTarget::OpenCheats)), None);
+        assert_eq!(menu.page, PauseMenuPage::Cheats);
+        assert!(menu.is_open());
+    }
+
+    /// Every shipped cheat row reaches `Game` with its own templates, and the
+    /// overlay stays up on its page - a cheat sets a situation up, it does not
+    /// resume the game.
+    #[test]
+    fn a_cheat_row_reaches_game_and_leaves_the_overlay_up() {
+        let mut menu = PauseMenu::new();
+        menu.open();
+        menu.page = PauseMenuPage::Cheats;
+
+        for (index, cheat) in cheats_panel::CHEATS.iter().enumerate() {
+            let action = menu.handle_cheats_event(Some(cheats_panel::CheatsEvent::Rain(index)));
+            assert_eq!(
+                action,
+                Some(PauseAction::RainItems {
+                    template_ids: cheat.templates(),
+                }),
+                "cheat {index} must rain its own templates",
+            );
+            assert_eq!(menu.page, PauseMenuPage::Cheats);
+            assert!(menu.is_open());
+        }
+
+        // A frame with no click changes nothing.
+        assert_eq!(menu.handle_cheats_event(None), None);
+        assert_eq!(menu.page, PauseMenuPage::Cheats);
+    }
+
+    /// "Done" on the Cheats page goes back to the parameters it was opened
+    /// from, not to the root - the page is a sub-page of the Developer screen.
+    #[test]
+    fn done_on_the_cheats_page_returns_to_the_parameters() {
+        let mut menu = PauseMenu::new();
+        menu.open();
+        menu.page = PauseMenuPage::Cheats;
+
+        assert_eq!(
+            menu.handle_cheats_event(Some(cheats_panel::CheatsEvent::Done)),
+            None
+        );
+        assert_eq!(menu.page, PauseMenuPage::Developer);
+        assert!(menu.is_open());
+    }
+
+    /// The same fall-through hazard the Developer page's "Done" has: the
+    /// Cheats page shares that rect, so a press held through it must not land
+    /// on the root page's "Quit to Main Menu" the next frame.
+    #[test]
+    fn a_press_held_through_the_cheats_done_cannot_fall_through_onto_quit() {
+        let rects = menu_rects(None);
+        let panel = dev_params_panel::PanelRects::default();
+        let done = panel.done_center();
+        assert!(
+            rects[QUIT_INDEX].contains(done),
+            "Done must sit over Quit for this test to mean anything"
+        );
+
+        let mut menu = PauseMenu::new();
+        menu.open();
+        menu.page = PauseMenuPage::Cheats;
+        menu.menu.set_last_pressed(false);
+
+        // Frame 1: press on "Done" - back to the parameter rows.
+        assert_eq!(menu.consume_pointer(Some(done), true, &rects), None);
+        assert_eq!(menu.page, PauseMenuPage::Developer);
+        // Frame 2: the press is still held over the very same point, which is
+        // now the parameter page's own "Done". The spent edge must hold.
+        assert_eq!(menu.consume_pointer(Some(done), true, &rects), None);
+        assert_eq!(menu.page, PauseMenuPage::Developer);
     }
 
     /// The overlay's most dangerous interaction: the Developer page's "Done"

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -677,16 +677,6 @@ impl PauseMenu {
                 Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H),
                 DEVELOPER_BACKDROP_TEXTURE,
             );
-            let hovered = pointer_canvas.and_then(|point| {
-                target_at(
-                    self.page,
-                    self.panel_rects,
-                    self.panel_scroll,
-                    self.cheats_scroll,
-                    &[],
-                    point,
-                )
-            });
             match self.page {
                 PauseMenuPage::Cheats => cheats_panel::draw(
                     &mut canvas,
@@ -714,11 +704,19 @@ impl PauseMenu {
                             HAlign::Center,
                             VAlign::Middle,
                         )
-                        .opacity(if hovered == Some(PauseMenuTarget::OpenCheats) {
-                            HOVER_OPACITY
-                        } else {
-                            IDLE_OPACITY
-                        });
+                        // The action rect is the only thing `target_at` gives
+                        // precedence over the panel on this page, so the
+                        // highlight is that same test rather than a routed
+                        // event - and cannot disagree with the click.
+                        .opacity(
+                            if pointer_canvas
+                                .is_some_and(|point| self.panel_rects.action_rect().contains(point))
+                            {
+                                HOVER_OPACITY
+                            } else {
+                                IDLE_OPACITY
+                            },
+                        );
                 }
             }
             return canvas;

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -76,14 +76,6 @@ const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 const MENU_FONT: &str = "metafont.fon";
 const LIST_FONT: &str = "mainfont.fon";
 
-/// Row pitch of the launcher's list, matching the load screen's save rows -
-/// the same art, the same font, the same rows.
-const SCENE_ROW_H: f32 = 19.0;
-/// Horizontal inset for a scene name, on both edges of the row so the text
-/// clears the pane's border. Hit-testing uses the whole row, so it costs no
-/// click.
-const SCENE_TEXT_INSET: f32 = 8.0;
-
 /// Opacity for a button that cannot be acted on, one that can, and the
 /// selected row / hovered button - the load screen's three levels.
 const DISABLED_OPACITY: f32 = 0.3;
@@ -181,14 +173,9 @@ fn scene_count() -> usize {
 }
 
 /// The launcher list's geometry - paging, the gutter rocker and the
-/// slot-to-entry mapping - shared with every other frontend list.
+/// slot-to-entry mapping - shared with every other frontend name list.
 fn scene_list(rects: PanelRects) -> list_scroll::ListGeometry {
-    list_scroll::ListGeometry {
-        pane: rects.list_rect(),
-        bottom_limit: FIELD_TOP_Y,
-        row_h: SCENE_ROW_H,
-        text_inset: SCENE_TEXT_INSET,
-    }
+    list_scroll::name_list(rects.list_rect(), FIELD_TOP_Y)
 }
 
 fn scene_visible_rows(

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -1016,6 +1016,13 @@ pub enum Effect {
         auto_wield: bool,
     },
 
+    /// Developer cheat: rain a spread of template instances down around the
+    /// player, one per id, so they fall and settle as ordinary world pickups.
+    /// Player position is resolved by the effect handler.
+    RainItems {
+        template_ids: Vec<i32>,
+    },
+
     /// Debug: spawn the next player weapon in front of the player and wield it
     /// as the flat viewmodel (holstering the previously wielded one). Cycles
     /// the SS2 weapon roster for aim/viewmodel testing.

--- a/shock2vr/src/ui/cheats_panel.rs
+++ b/shock2vr/src/ui/cheats_panel.rs
@@ -22,6 +22,8 @@ use cgmath::Vector2;
 #[cfg(test)]
 use cgmath::vec2;
 
+use dark::properties::AIAlertLevel;
+
 use super::{
     HAlign, UiCanvas, VAlign,
     dev_params_panel::{FIELD_TOP_Y, PanelRects},
@@ -44,16 +46,29 @@ const HOVER_OPACITY: f32 = 1.0;
 pub const HEADER_LABEL: &str = "Cheats";
 pub const OPEN_LABEL: &str = "Cheats";
 
-/// One entry in the list: the row's label and the templates it rains.
+/// What a cheat row does when it is clicked. Deliberately a description
+/// rather than an [`Effect`](crate::scripts::Effect): the `ui` modules
+/// describe the screen, and the host turns the description into the effect it
+/// applies - the same split `dev_params_panel` keeps between a clicked row
+/// and the registry write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheatAction {
+    /// Rain these templates around the player, one per ring slot.
+    Rain(&'static [i32]),
+    /// Set every AI's alertness. `pin` holds it there instead of letting it
+    /// decay, so the level is a floor rather than a nudge.
+    Alertness { level: AIAlertLevel, pin: bool },
+}
+
+/// One entry in the list: the row's label and what clicking it does.
 pub struct Cheat {
     label: &'static str,
-    templates: &'static [i32],
+    action: CheatAction,
 }
 
 impl Cheat {
-    /// The template ids this row rains, in the order they ring the player.
-    pub fn templates(&self) -> &'static [i32] {
-        self.templates
+    pub fn action(&self) -> CheatAction {
+        self.action
     }
 }
 
@@ -63,7 +78,7 @@ pub static CHEATS: &[Cheat] = &[
     Cheat {
         label: "Rain weapons",
         // The four workhorse weapons, plus a clip for each gun that takes one.
-        templates: &[
+        action: CheatAction::Rain(&[
             -928,  // Wrench
             -17,   // Pistol
             -19,   // Shotgun
@@ -72,17 +87,45 @@ pub static CHEATS: &[Cheat] = &[
             -1358, // Small Standard Clip
             -1360, // Small AP Clip
             -42,   // Pellet Shot Box (shotgun shells)
-        ],
+        ]),
     },
     Cheat {
         label: "Rain modules + nanites",
         // The two things a test situation is usually short of.
-        templates: &[
+        action: CheatAction::Rain(&[
             -938, // EXP Cookies (cyber modules)
             -938, -938, -938, //
             -89,  // 20 Nanites
             -89, -89, -89,
-        ],
+        ]),
+    },
+    // The AI alertness trio, already reachable on the desktop as Alt+G /
+    // Alt+C. A headset has no keyboard, so this page is the only way to reach
+    // them on the Quest.
+    Cheat {
+        label: "Hunt me (all AI)",
+        // Pinned: the level never decays, so every AI keeps hunting the
+        // player's live position until "Calm all" clears it. `High` maps to
+        // attack behaviors, which assume the player is already in range.
+        action: CheatAction::Alertness {
+            level: AIAlertLevel::Moderate,
+            pin: true,
+        },
+    },
+    Cheat {
+        label: "Alert all AI",
+        // The same level unpinned: a nudge that decays again on its own.
+        action: CheatAction::Alertness {
+            level: AIAlertLevel::Moderate,
+            pin: false,
+        },
+    },
+    Cheat {
+        label: "Calm all AI",
+        action: CheatAction::Alertness {
+            level: AIAlertLevel::Lowest,
+            pin: false,
+        },
     },
 ];
 
@@ -90,7 +133,7 @@ pub static CHEATS: &[Cheat] = &[
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheatsEvent {
     /// The index into [`CHEATS`] scrolled into the clicked row.
-    Rain(usize),
+    Row(usize),
     Scroll(ScrollHalf),
     /// Leave the page, back to the parameter rows.
     Done,
@@ -112,7 +155,7 @@ pub fn hit(rects: PanelRects, scroll: usize, point: Vector2<f32>) -> Option<Chea
     // slot; a rocker half that cannot move is inert. Both rules live in
     // `list_scroll`, so every list obeys the same ones.
     match list(rects).hit(CHEATS.len(), scroll, point)? {
-        ListHit::Row(index) => Some(CheatsEvent::Rain(index)),
+        ListHit::Row(index) => Some(CheatsEvent::Row(index)),
         ListHit::Scroll(half) => Some(CheatsEvent::Scroll(half)),
     }
 }
@@ -158,7 +201,7 @@ pub fn draw(
                 HAlign::Left,
                 VAlign::Middle,
             )
-            .opacity(opacity(CheatsEvent::Rain(index)));
+            .opacity(opacity(CheatsEvent::Row(index)));
     }
 
     if let Some(rocker) = geometry.rocker(len) {
@@ -192,8 +235,8 @@ pub fn draw(
 /// [`dev_params_panel::activate`]: super::dev_params_panel::activate
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheatsOutcome {
-    /// Rain this entry's templates around the player.
-    Rain(&'static [i32]),
+    /// Carry out this row's action.
+    Act(CheatAction),
     /// Leave the page.
     Done,
 }
@@ -206,7 +249,7 @@ pub fn activate(
     scroll: &mut usize,
 ) -> Option<CheatsOutcome> {
     match event {
-        CheatsEvent::Rain(index) => Some(CheatsOutcome::Rain(CHEATS[index].templates)),
+        CheatsEvent::Row(index) => Some(CheatsOutcome::Act(CHEATS[index].action)),
         CheatsEvent::Scroll(half) => {
             list_scroll::apply(half, scroll, list(rects).max_scroll(CHEATS.len()));
             None
@@ -219,10 +262,10 @@ pub fn activate(
 mod tests {
     use super::{super::UiElement, *};
 
-    /// Every shipped cheat is reachable by scrolling, and each row rains its
-    /// own templates - the seam a positional row index would break.
+    /// Every shipped cheat is reachable by scrolling, and each row carries its
+    /// OWN action - the seam a positional row index would break.
     #[test]
-    fn every_cheat_is_reachable_and_rains_its_own_templates() {
+    fn every_cheat_is_reachable_and_carries_its_own_action() {
         let rects = PanelRects::default();
         let geometry = list(rects);
         let max = geometry.max_scroll(CHEATS.len());
@@ -233,15 +276,15 @@ mod tests {
             let point = geometry.row_rect(CHEATS.len(), slot).center();
             assert_eq!(
                 hit(rects, scroll, point),
-                Some(CheatsEvent::Rain(index)),
+                Some(CheatsEvent::Row(index)),
                 "cheat {index} ({}) must be clickable at scroll {scroll}",
                 CHEATS[index].label
             );
 
             let mut scroll = scroll;
             assert_eq!(
-                activate(rects, CheatsEvent::Rain(index), &mut scroll),
-                Some(CheatsOutcome::Rain(CHEATS[index].templates)),
+                activate(rects, CheatsEvent::Row(index), &mut scroll),
+                Some(CheatsOutcome::Act(CHEATS[index].action)),
             );
         }
     }

--- a/shock2vr/src/ui/cheats_panel.rs
+++ b/shock2vr/src/ui/cheats_panel.rs
@@ -28,19 +28,10 @@ use super::{
     list_scroll::{self, ListGeometry, ListHit, ScrollHalf},
 };
 
-/// The frontend screens are authored on the original 640x480 canvas.
-const CANVAS_W: f32 = 640.0;
-const CANVAS_H: f32 = 480.0;
-
 /// Display font for the header and "Done"; the small data font for the rows
 /// that read as data - the pairing every list on this frame uses.
 const MENU_FONT: &str = "metafont.fon";
 const ROW_FONT: &str = "mainfont.fon";
-
-/// Row pitch and text inset of the debug-scene launcher's list, so a cheat row
-/// and a scene row are the same row.
-const ROW_H: f32 = 19.0;
-const TEXT_INSET: f32 = 8.0;
 
 /// Opacity for a widget the pointer is not over, and for the one it is -
 /// [`dev_params_panel`](super::dev_params_panel)'s pair, so the two developer
@@ -105,14 +96,10 @@ pub enum CheatsEvent {
     Done,
 }
 
-/// The list's geometry, shared with every other frontend list.
+/// The list's geometry: the same name list the debug-scene launcher uses, so
+/// a cheat row and a scene row really are the same row.
 fn list(rects: PanelRects) -> ListGeometry {
-    ListGeometry {
-        pane: rects.list_rect(),
-        bottom_limit: FIELD_TOP_Y,
-        row_h: ROW_H,
-        text_inset: TEXT_INSET,
-    }
+    list_scroll::name_list(rects.list_rect(), FIELD_TOP_Y)
 }
 
 /// The event at a canvas point, if any. Shared by the click and the hover
@@ -228,23 +215,6 @@ pub fn activate(
     }
 }
 
-/// The whole page, as a standalone canvas. Used by the tests; the pause
-/// overlay draws into its own canvas via [`draw`].
-#[cfg(test)]
-fn build_canvas(
-    rects: PanelRects,
-    scroll: usize,
-    pointer_canvas: Option<Vector2<f32>>,
-) -> UiCanvas {
-    let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
-    canvas.image(
-        super::Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H),
-        super::dev_params_panel::BACKDROP_TEXTURE,
-    );
-    draw(&mut canvas, rects, scroll, pointer_canvas);
-    canvas
-}
-
 #[cfg(test)]
 mod tests {
     use super::{super::UiElement, *};
@@ -319,13 +289,15 @@ mod tests {
     #[test]
     fn clicking_bare_backdrop_does_nothing() {
         let rects = PanelRects::default();
-        assert_eq!(hit(rects, 0, vec2(5.0, CANVAS_H - 5.0)), None);
+        // Bottom-left of the frame: outside the pane, the rocker and Done.
+        assert_eq!(hit(rects, 0, vec2(5.0, 475.0)), None);
     }
 
     /// The page renders on the developer frame, with a row per cheat.
     #[test]
     fn the_page_draws_a_row_per_cheat() {
-        let canvas = build_canvas(PanelRects::default(), 0, None);
+        let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
+        draw(&mut canvas, PanelRects::default(), 0, None);
         let drawn: Vec<&str> = canvas
             .elements()
             .iter()

--- a/shock2vr/src/ui/cheats_panel.rs
+++ b/shock2vr/src/ui/cheats_panel.rs
@@ -1,0 +1,344 @@
+//! The Developer screen's Cheats page: a scrolling list of one-click
+//! developer shortcuts, described once for every host.
+//!
+//! A sibling of [`crate::ui::dev_params_panel`], on the same `GAMELOD.PCX`
+//! frame and the same [`PanelRects`], so a cheat row and a parameter row are
+//! the same row on the same screen. Placement is decided here, once, in canvas
+//! pixels, so flatscreen and VR render it identically by construction
+//! (AGENTS.md §3).
+//!
+//! The page is reached from the **pause overlay's** Developer page only - the
+//! frame's upper framed button, which the main menu's [`DeveloperScene`] uses
+//! for its scene launcher. Cheats act on the running mission, so there is
+//! nothing for them to do before one is loaded.
+//!
+//! **Adding a cheat is one entry in [`CHEATS`]** and nothing else: the list
+//! pages and grows a scroll rocker on its own once the entries outrun the pane.
+//!
+//! [`DeveloperScene`]: crate::scenes::DeveloperScene
+
+use cgmath::Vector2;
+
+#[cfg(test)]
+use cgmath::vec2;
+
+use super::{
+    HAlign, UiCanvas, VAlign,
+    dev_params_panel::{FIELD_TOP_Y, PanelRects},
+    list_scroll::{self, ListGeometry, ListHit, ScrollHalf},
+};
+
+/// The frontend screens are authored on the original 640x480 canvas.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+
+/// Display font for the header and "Done"; the small data font for the rows
+/// that read as data - the pairing every list on this frame uses.
+const MENU_FONT: &str = "metafont.fon";
+const ROW_FONT: &str = "mainfont.fon";
+
+/// Row pitch and text inset of the debug-scene launcher's list, so a cheat row
+/// and a scene row are the same row.
+const ROW_H: f32 = 19.0;
+const TEXT_INSET: f32 = 8.0;
+
+/// Opacity for a widget the pointer is not over, and for the one it is -
+/// [`dev_params_panel`](super::dev_params_panel)'s pair, so the two developer
+/// pages highlight alike.
+const IDLE_OPACITY: f32 = 0.65;
+const HOVER_OPACITY: f32 = 1.0;
+
+/// The header, and the label on the framed button that opens this page from
+/// the parameter rows.
+pub const HEADER_LABEL: &str = "Cheats";
+pub const OPEN_LABEL: &str = "Cheats";
+
+/// One entry in the list: the row's label and the templates it rains.
+pub struct Cheat {
+    label: &'static str,
+    templates: &'static [i32],
+}
+
+impl Cheat {
+    /// The template ids this row rains, in the order they ring the player.
+    pub fn templates(&self) -> &'static [i32] {
+        self.templates
+    }
+}
+
+/// Every cheat, in screen order. Template ids come from `cargo dq` against the
+/// gamesys.
+pub static CHEATS: &[Cheat] = &[
+    Cheat {
+        label: "Rain weapons",
+        // The four workhorse weapons, plus a clip for each gun that takes one.
+        templates: &[
+            -928,  // Wrench
+            -17,   // Pistol
+            -19,   // Shotgun
+            -18,   // Assault Rifle
+            -1358, // Small Standard Clip
+            -1358, // Small Standard Clip
+            -1360, // Small AP Clip
+            -42,   // Pellet Shot Box (shotgun shells)
+        ],
+    },
+    Cheat {
+        label: "Rain modules + nanites",
+        // The two things a test situation is usually short of.
+        templates: &[
+            -938, // EXP Cookies (cyber modules)
+            -938, -938, -938, //
+            -89,  // 20 Nanites
+            -89, -89, -89,
+        ],
+    },
+];
+
+/// What a click on the page resolves to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheatsEvent {
+    /// The index into [`CHEATS`] scrolled into the clicked row.
+    Rain(usize),
+    Scroll(ScrollHalf),
+    /// Leave the page, back to the parameter rows.
+    Done,
+}
+
+/// The list's geometry, shared with every other frontend list.
+fn list(rects: PanelRects) -> ListGeometry {
+    ListGeometry {
+        pane: rects.list_rect(),
+        bottom_limit: FIELD_TOP_Y,
+        row_h: ROW_H,
+        text_inset: TEXT_INSET,
+    }
+}
+
+/// The event at a canvas point, if any. Shared by the click and the hover
+/// highlight, so the two can never disagree about where a row is.
+pub fn hit(rects: PanelRects, scroll: usize, point: Vector2<f32>) -> Option<CheatsEvent> {
+    if rects.done_rect().contains(point) {
+        return Some(CheatsEvent::Done);
+    }
+    // A row carries the index of the cheat *scrolled into* it, never its own
+    // slot; a rocker half that cannot move is inert. Both rules live in
+    // `list_scroll`, so every list obeys the same ones.
+    match list(rects).hit(CHEATS.len(), scroll, point)? {
+        ListHit::Row(index) => Some(CheatsEvent::Rain(index)),
+        ListHit::Scroll(half) => Some(CheatsEvent::Scroll(half)),
+    }
+}
+
+/// Describe the page onto the host's canvas: header, the scrolled rows, the
+/// rocker if the list needs one, and "Done". The highlight resolves through
+/// the very same [`hit`] the click does.
+pub fn draw(
+    canvas: &mut UiCanvas,
+    rects: PanelRects,
+    scroll: usize,
+    pointer_canvas: Option<Vector2<f32>>,
+) {
+    let geometry = list(rects);
+    let len = CHEATS.len();
+    let hovered = pointer_canvas.and_then(|point| hit(rects, scroll, point));
+    let opacity = |event: CheatsEvent| {
+        if hovered == Some(event) {
+            HOVER_OPACITY
+        } else {
+            IDLE_OPACITY
+        }
+    };
+
+    canvas.text_native(
+        rects.header_rect(),
+        HEADER_LABEL,
+        MENU_FONT,
+        HAlign::Center,
+        VAlign::Middle,
+    );
+
+    let rows = geometry.visible_rows(len, scroll);
+    for (slot, index) in rows.clone().enumerate() {
+        // Fitted, not plain: `text_native` does not shrink to its rect, so a
+        // label that outgrows the pane would run over the frame - and over the
+        // scroll gutter - instead of ellipsizing inside it.
+        canvas
+            .text_native_fit(
+                geometry.text_rect(len, slot),
+                CHEATS[index].label,
+                ROW_FONT,
+                HAlign::Left,
+                VAlign::Middle,
+            )
+            .opacity(opacity(CheatsEvent::Rain(index)));
+    }
+
+    if let Some(rocker) = geometry.rocker(len) {
+        list_scroll::draw(
+            canvas,
+            &rocker,
+            rows.start,
+            geometry.max_scroll(len),
+            match hovered {
+                Some(CheatsEvent::Scroll(half)) => Some(half),
+                _ => None,
+            },
+        );
+    }
+
+    canvas
+        .text_native(
+            rects.done_rect(),
+            "Done",
+            MENU_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        )
+        .opacity(opacity(CheatsEvent::Done));
+}
+
+/// What the host must act on after a click. Scrolling never reaches it - this
+/// page absorbs that itself, exactly as [`dev_params_panel::activate`] absorbs
+/// a parameter step.
+///
+/// [`dev_params_panel::activate`]: super::dev_params_panel::activate
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheatsOutcome {
+    /// Rain this entry's templates around the player.
+    Rain(&'static [i32]),
+    /// Leave the page.
+    Done,
+}
+
+/// Apply a clicked event, absorbing the scrolling into the host's `scroll`
+/// offset and reporting only what the host has to do.
+pub fn activate(
+    rects: PanelRects,
+    event: CheatsEvent,
+    scroll: &mut usize,
+) -> Option<CheatsOutcome> {
+    match event {
+        CheatsEvent::Rain(index) => Some(CheatsOutcome::Rain(CHEATS[index].templates)),
+        CheatsEvent::Scroll(half) => {
+            list_scroll::apply(half, scroll, list(rects).max_scroll(CHEATS.len()));
+            None
+        }
+        CheatsEvent::Done => Some(CheatsOutcome::Done),
+    }
+}
+
+/// The whole page, as a standalone canvas. Used by the tests; the pause
+/// overlay draws into its own canvas via [`draw`].
+#[cfg(test)]
+fn build_canvas(
+    rects: PanelRects,
+    scroll: usize,
+    pointer_canvas: Option<Vector2<f32>>,
+) -> UiCanvas {
+    let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+    canvas.image(
+        super::Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H),
+        super::dev_params_panel::BACKDROP_TEXTURE,
+    );
+    draw(&mut canvas, rects, scroll, pointer_canvas);
+    canvas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::UiElement, *};
+
+    /// Every shipped cheat is reachable by scrolling, and each row rains its
+    /// own templates - the seam a positional row index would break.
+    #[test]
+    fn every_cheat_is_reachable_and_rains_its_own_templates() {
+        let rects = PanelRects::default();
+        let geometry = list(rects);
+        let max = geometry.max_scroll(CHEATS.len());
+
+        for index in 0..CHEATS.len() {
+            let scroll = index.min(max);
+            let slot = index - scroll;
+            let point = geometry.row_rect(CHEATS.len(), slot).center();
+            assert_eq!(
+                hit(rects, scroll, point),
+                Some(CheatsEvent::Rain(index)),
+                "cheat {index} ({}) must be clickable at scroll {scroll}",
+                CHEATS[index].label
+            );
+
+            let mut scroll = scroll;
+            assert_eq!(
+                activate(rects, CheatsEvent::Rain(index), &mut scroll),
+                Some(CheatsOutcome::Rain(CHEATS[index].templates)),
+            );
+        }
+    }
+
+    /// "Done" is the host's business; scrolling is not.
+    #[test]
+    fn done_leaves_and_scrolling_is_absorbed() {
+        let rects = PanelRects::default();
+        let mut scroll = 0;
+
+        assert_eq!(
+            hit(rects, 0, rects.done_rect().center()),
+            Some(CheatsEvent::Done)
+        );
+        assert_eq!(
+            activate(rects, CheatsEvent::Done, &mut scroll),
+            Some(CheatsOutcome::Done)
+        );
+
+        // Nothing to scroll to with the shipped list, so the offset holds.
+        assert_eq!(
+            activate(rects, CheatsEvent::Scroll(ScrollHalf::Down), &mut scroll),
+            None
+        );
+        assert_eq!(scroll, list(rects).max_scroll(CHEATS.len()).min(1));
+    }
+
+    /// Every row stays inside the pane, clear of the backdrop's painted field.
+    #[test]
+    fn rows_stay_inside_the_pane() {
+        let rects = PanelRects::default();
+        let geometry = list(rects);
+        let pane = rects.list_rect();
+
+        for slot in 0..geometry.visible_rows(CHEATS.len(), 0).len() {
+            let row = geometry.row_rect(CHEATS.len(), slot);
+            assert!(row.x >= pane.x, "{row:?}");
+            assert!(row.x + row.w <= pane.x + pane.w, "{row:?}");
+            assert!(row.y >= pane.y, "{row:?}");
+            assert!(row.y + row.h <= FIELD_TOP_Y, "slot {slot}: {row:?}");
+        }
+    }
+
+    /// A click on bare backdrop does nothing - the page has no catch-all.
+    #[test]
+    fn clicking_bare_backdrop_does_nothing() {
+        let rects = PanelRects::default();
+        assert_eq!(hit(rects, 0, vec2(5.0, CANVAS_H - 5.0)), None);
+    }
+
+    /// The page renders on the developer frame, with a row per cheat.
+    #[test]
+    fn the_page_draws_a_row_per_cheat() {
+        let canvas = build_canvas(PanelRects::default(), 0, None);
+        let drawn: Vec<&str> = canvas
+            .elements()
+            .iter()
+            .filter_map(|element| match element {
+                UiElement::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        for cheat in CHEATS {
+            assert!(drawn.contains(&cheat.label), "missing row: {}", cheat.label);
+        }
+        assert!(drawn.contains(&HEADER_LABEL));
+        assert!(drawn.contains(&"Done"));
+    }
+}

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -177,6 +177,24 @@ pub struct ListGeometry {
     pub text_inset: f32,
 }
 
+/// Row pitch and text inset of a list of NAMES on the developer frame -
+/// scene names, cheat labels. Pulled out of the screens that had each written
+/// the same two numbers, so "these lists are the same list" is a fact rather
+/// than a coincidence.
+pub const NAME_ROW_H: f32 = 19.0;
+pub const NAME_TEXT_INSET: f32 = 8.0;
+
+/// A name list in `pane`, stopping at `bottom_limit` (where the backdrop
+/// starts painting something the rows must clear).
+pub fn name_list(pane: Rect, bottom_limit: f32) -> ListGeometry {
+    ListGeometry {
+        pane,
+        bottom_limit,
+        row_h: NAME_ROW_H,
+        text_inset: NAME_TEXT_INSET,
+    }
+}
+
 impl ListGeometry {
     pub fn rows_per_page(&self) -> usize {
         rows_per_page(self.pane, self.bottom_limit, self.row_h)

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -31,6 +31,7 @@ use shipyard::EntityId;
 
 use crate::vr_config::Handedness;
 
+pub mod cheats_panel;
 pub mod dev_params_panel;
 pub mod entry_ramp;
 mod frontend_menu;

--- a/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import { norm } from "./helpers/frontend-menu.js";
+import {
+  DEV_ACTION,
+  DEV_DONE,
+  clickCanvas as click,
+  pauseEntry,
+} from "./helpers/frontend-menu.js";
 
 // The Cheats page (`shock2vr::ui::cheats_panel`): a second page of the
 // Developer screen, reached ONLY from the in-game pause overlay - a cheat acts
@@ -14,32 +19,15 @@ import { norm } from "./helpers/frontend-menu.js";
 // because nothing claims that rect on the pause host.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
-const pauseEntry = (index: number): [number, number] => [400 + 179 / 2, 20 + index * 92 + 76 / 2];
 const PAUSE_DEVELOPER = pauseEntry(3);
 const PAUSE_CONTINUE = pauseEntry(0);
 
-// GAMELODR.BIN widget rects, shared with the parameter page: the upper framed
-// button (rect 2) opens this page, "Done" (rect 3) leaves it, and the rows run
-// down the list pane (rect 1: 261,54 202x290) at the debug-scene launcher's
-// 19px pitch. The two shipped cheats fit one page, so there is no scroll
-// gutter and a row spans the full pane width.
-const ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
-const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
+// The rows run down the developer frame's list pane (GAMELODR.BIN rect 1:
+// 261,54 202x290) at the shared name-list pitch. The two shipped cheats fit
+// one page, so there is no scroll gutter and a row spans the full pane width.
 const row = (index: number): [number, number] => [261 + 202 / 2, 54 + index * 19 + 19 / 2];
 const RAIN_WEAPONS = row(0);
 const RAIN_MODULES = row(1);
-
-/** Click a canvas point with the flat pointer, as a real rising edge. */
-async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
-  await game.input.set("pointer.position", norm(x, y));
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 1);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
-}
 
 async function count(game: GameServer, filter: string): Promise<number> {
   const { entities } = await game.entities.list({ filter, limit: 200 });
@@ -70,7 +58,7 @@ test(
 
     // Root -> Developer (the repurposed Options slot) -> Cheats.
     await click(game, PAUSE_DEVELOPER);
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     assert.equal((await game.info()).paused, true, "the page turn must not resume");
     assert.equal((await game.info()).mission, "medsci1.mis", "no scene swap");
     await game.screenshot("dev-cheats-page.png");
@@ -116,10 +104,10 @@ test(
 
     // Done is the Developer screen's, so it goes back to the parameter rows -
     // not to the root, and not out of the menu.
-    await click(game, DONE);
+    await click(game, DEV_DONE);
     assert.equal((await game.info()).paused, true, "Done turns the page, not the sim");
     // A second Done leaves the parameters for the root, where Continue resumes.
-    await click(game, DONE);
+    await click(game, DEV_DONE);
     await click(game, PAUSE_CONTINUE);
     assert.equal((await game.info()).paused, false, "Continue on the root resumes");
 
@@ -130,29 +118,5 @@ test(
       (await count(game, "Wrench")) > wrenchesBefore,
       "the rained items must survive the unpause",
     );
-  },
-);
-
-test(
-  "the main-menu Developer screen keeps the scene launcher in that slot",
-  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
-  async () => {
-    await using game = await GameServer.launch({ mission: "main_menu" });
-    await game.step({ frames: 10 });
-
-    // The repurposed Options slot swaps to the Developer scene.
-    await click(game, [400 + 179 / 2, 20 + 2 * 76 + 60 / 2]);
-    assert.equal((await game.info()).mission, "developer");
-
-    // Same framed button, different page: the launcher, not the cheats. It is
-    // still the launcher because there is no mission for a cheat to act on.
-    await click(game, ACTION);
-    await game.screenshot("dev-cheats-main-menu-launcher.png");
-    // "Done" on the launcher returns to the parameters rather than the main
-    // menu - which is what tells the two pages apart from out here.
-    await click(game, DONE);
-    assert.equal((await game.info()).mission, "developer");
-    await click(game, DONE);
-    assert.equal((await game.info()).mission, "main_menu");
   },
 );

--- a/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
@@ -46,6 +46,13 @@ async function count(game: GameServer, filter: string): Promise<number> {
   return entities.length;
 }
 
+/** Every matching entity's world position, rounded so float noise cannot
+ *  make two coincident spawns read as distinct. */
+async function positions(game: GameServer, filter: string): Promise<string[]> {
+  const { entities } = await game.entities.list({ filter, limit: 200 });
+  return entities.map((e) => e.position.map((v) => v.toFixed(2)).join(","));
+}
+
 test(
   "the pause overlay's Cheats page rains items into the running mission",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
@@ -75,6 +82,24 @@ test(
     assert.ok(
       (await count(game, "Wrench")) > wrenchesBefore,
       "Rain weapons must add a wrench to the world",
+    );
+
+    // Pressing the SAME cheat again must not drop items onto the slots the
+    // first press is still occupying - coincident bodies get flung apart by
+    // the solver on resume instead of falling. Each rain phases its ring off
+    // the last (`RAIN_PHASE_STEP`).
+    const afterOne = await positions(game, "Wrench");
+    await click(game, RAIN_WEAPONS);
+    const afterTwo = await positions(game, "Wrench");
+    assert.equal(
+      afterTwo.length,
+      afterOne.length + 1,
+      "a second Rain weapons must add another wrench",
+    );
+    assert.equal(
+      new Set(afterTwo).size,
+      afterTwo.length,
+      "no two rained wrenches may share a spawn point",
     );
 
     await click(game, RAIN_MODULES);

--- a/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { norm } from "./helpers/frontend-menu.js";
+
+// The Cheats page (`shock2vr::ui::cheats_panel`): a second page of the
+// Developer screen, reached ONLY from the in-game pause overlay - a cheat acts
+// on the running mission, so the main-menu Developer scene fills the same
+// framed-button slot with its debug-scene launcher instead.
+//
+// Negative-first: without the action-rect branch in `pause_menu::target_at`
+// the very first assertion here (the page turn off the parameter rows) fails,
+// because nothing claims that rect on the pause host.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
+const pauseEntry = (index: number): [number, number] => [400 + 179 / 2, 20 + index * 92 + 76 / 2];
+const PAUSE_DEVELOPER = pauseEntry(3);
+const PAUSE_CONTINUE = pauseEntry(0);
+
+// GAMELODR.BIN widget rects, shared with the parameter page: the upper framed
+// button (rect 2) opens this page, "Done" (rect 3) leaves it, and the rows run
+// down the list pane (rect 1: 261,54 202x290) at the debug-scene launcher's
+// 19px pitch. The two shipped cheats fit one page, so there is no scroll
+// gutter and a row spans the full pane width.
+const ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
+const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
+const row = (index: number): [number, number] => [261 + 202 / 2, 54 + index * 19 + 19 / 2];
+const RAIN_WEAPONS = row(0);
+const RAIN_MODULES = row(1);
+
+/** Click a canvas point with the flat pointer, as a real rising edge. */
+async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", norm(x, y));
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+}
+
+async function count(game: GameServer, filter: string): Promise<number> {
+  const { entities } = await game.entities.list({ filter, limit: 200 });
+  return entities.length;
+}
+
+test(
+  "the pause overlay's Cheats page rains items into the running mission",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 30 });
+
+    const wrenchesBefore = await count(game, "Wrench");
+    const modulesBefore = await count(game, "EXP");
+    const nanitesBefore = await count(game, "Nanites");
+
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).paused, true);
+
+    // Root -> Developer (the repurposed Options slot) -> Cheats.
+    await click(game, PAUSE_DEVELOPER);
+    await click(game, ACTION);
+    assert.equal((await game.info()).paused, true, "the page turn must not resume");
+    assert.equal((await game.info()).mission, "medsci1.mis", "no scene swap");
+    await game.screenshot("dev-cheats-page.png");
+
+    // A cheat acts on the paused scene and LEAVES THE OVERLAY UP, so several
+    // can be fired before resuming.
+    await click(game, RAIN_WEAPONS);
+    assert.equal((await game.info()).paused, true, "a cheat must not resume the sim");
+    assert.ok(
+      (await count(game, "Wrench")) > wrenchesBefore,
+      "Rain weapons must add a wrench to the world",
+    );
+
+    await click(game, RAIN_MODULES);
+    assert.equal(
+      (await count(game, "EXP")) - modulesBefore,
+      4,
+      "Rain modules must add exactly four module stacks",
+    );
+    assert.equal(
+      (await count(game, "Nanites")) - nanitesBefore,
+      4,
+      "Rain modules must add exactly four nanite piles",
+    );
+
+    // Done is the Developer screen's, so it goes back to the parameter rows -
+    // not to the root, and not out of the menu.
+    await click(game, DONE);
+    assert.equal((await game.info()).paused, true, "Done turns the page, not the sim");
+    // A second Done leaves the parameters for the root, where Continue resumes.
+    await click(game, DONE);
+    await click(game, PAUSE_CONTINUE);
+    assert.equal((await game.info()).paused, false, "Continue on the root resumes");
+
+    // The rain falls and settles as ordinary world pickups.
+    await game.step({ frames: 120 });
+    await game.screenshot("dev-cheats-rain.png");
+    assert.ok(
+      (await count(game, "Wrench")) > wrenchesBefore,
+      "the rained items must survive the unpause",
+    );
+  },
+);
+
+test(
+  "the main-menu Developer screen keeps the scene launcher in that slot",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu" });
+    await game.step({ frames: 10 });
+
+    // The repurposed Options slot swaps to the Developer scene.
+    await click(game, [400 + 179 / 2, 20 + 2 * 76 + 60 / 2]);
+    assert.equal((await game.info()).mission, "developer");
+
+    // Same framed button, different page: the launcher, not the cheats. It is
+    // still the launcher because there is no mission for a cheat to act on.
+    await click(game, ACTION);
+    await game.screenshot("dev-cheats-main-menu-launcher.png");
+    // "Done" on the launcher returns to the parameters rather than the main
+    // menu - which is what tells the two pages apart from out here.
+    await click(game, DONE);
+    assert.equal((await game.info()).mission, "developer");
+    await click(game, DONE);
+    assert.equal((await game.info()).mission, "main_menu");
+  },
+);

--- a/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-cheats.e2e.test.ts
@@ -23,11 +23,37 @@ const PAUSE_DEVELOPER = pauseEntry(3);
 const PAUSE_CONTINUE = pauseEntry(0);
 
 // The rows run down the developer frame's list pane (GAMELODR.BIN rect 1:
-// 261,54 202x290) at the shared name-list pitch. The two shipped cheats fit
-// one page, so there is no scroll gutter and a row spans the full pane width.
+// 261,54 202x290) at the shared name-list pitch. The pane holds 14 rows, so
+// the shipped cheats fit one page: no scroll gutter, and a row spans the full
+// pane width.
 const row = (index: number): [number, number] => [261 + 202 / 2, 54 + index * 19 + 19 / 2];
 const RAIN_WEAPONS = row(0);
 const RAIN_MODULES = row(1);
+const HUNT_ME = row(2);
+const CALM_ALL = row(4);
+
+/**
+ * Open the Cheats page from a running mission, click one row, close back out
+ * and let the sim run - then read whatever the caller is watching. The AI rows
+ * land through the script world, so their effect is only observable once the
+ * scene updates again.
+ */
+async function clickCheatAndResume<T>(
+  game: GameServer,
+  cheat: [number, number],
+  read: () => Promise<T>,
+): Promise<T> {
+  await game.input.trigger("TogglePauseMenu");
+  await game.step({ frames: 10 });
+  await click(game, PAUSE_DEVELOPER);
+  await click(game, DEV_ACTION);
+  await click(game, cheat);
+  await click(game, DEV_DONE);
+  await click(game, DEV_DONE);
+  await click(game, PAUSE_CONTINUE);
+  await game.step({ frames: 60 });
+  return read();
+}
 
 async function count(game: GameServer, filter: string): Promise<number> {
   const { entities } = await game.entities.list({ filter, limit: 200 });
@@ -117,6 +143,29 @@ test(
     assert.ok(
       (await count(game, "Wrench")) > wrenchesBefore,
       "the rained items must survive the unpause",
+    );
+
+    // The AI rows reach the same `SetAllAIAlertness` the desktop's Alt+G /
+    // Alt+C reach - which on a headset, with no keyboard, is the only way to
+    // reach them at all. The effect dispatches a message the AI scripts read
+    // on their next update, so the level only moves once the scene is running
+    // again: each row is clicked, the overlay closed, and the sim stepped.
+    const hybrids = (await game.entities.list({ filter: "OG-", limit: 20 })).entities.filter(
+      (e) => e.name.startsWith("OG-"),
+    );
+    assert.ok(hybrids.length >= 1, `expected hybrids in medsci1, got ${hybrids.length}`);
+    const alertness = async (): Promise<string | undefined> => {
+      const detail = await game.entities.detail(hybrids[0].id);
+      return detail.properties.find((p) => p.name === "AIAlertness")?.value;
+    };
+
+    const calmed = await clickCheatAndResume(game, CALM_ALL, alertness);
+    const hunting = await clickCheatAndResume(game, HUNT_ME, alertness);
+    assert.notEqual(hunting, calmed, `"Hunt me" must raise alertness from ${calmed}`);
+    assert.equal(
+      await clickCheatAndResume(game, CALM_ALL, alertness),
+      calmed,
+      '"Calm all" must put it back',
     );
   },
 );

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -3,7 +3,16 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { SceneObjectSummary } from "../src/types.js";
-import { AIM_AT_PANEL, menuEntry, norm, panelPoint } from "./helpers/frontend-menu.js";
+import {
+  AIM_AT_PANEL,
+  DEV_ACTION,
+  DEV_DONE,
+  clickCanvas as click,
+  menuEntry,
+  norm,
+  panelPoint,
+  pauseEntry,
+} from "./helpers/frontend-menu.js";
 
 // The Developer screen: the shared dev-params row panel, hosted by a frontend
 // scene reached from the main menu's repurposed Options slot, and by a second
@@ -36,12 +45,10 @@ const ROW0_DECREMENT: [number, number] = [
   463 - 8 - SCROLL_GUTTER - 20 - 48 - 10,
   54 + 12,
 ];
-const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
 
 // The upper framed button (`GAMELODR.BIN` rect 2 - the load screen's "Load"
 // frame): the debug-scene launcher's door on the parameters page, and the
 // launch itself on the launcher page.
-const ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
 /**
  * The launcher's tabs ride the header line (GAMELODR.BIN rect 0: 261,31
  * 202x20), split in half: Missions on the left, Debug Scenes on the right.
@@ -62,22 +69,8 @@ const sceneRow = (index: number): [number, number] => [330, 54 + index * 19 + 9]
 const DEBUG_MINIMAL_ROW = 2;
 const MEDSCI1_ROW = 9;
 
-/** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
-const pauseEntry = (index: number): [number, number] =>
-  norm(400 + 179 / 2, 20 + index * 92 + 76 / 2);
 const PAUSE_DEVELOPER = pauseEntry(3);
 const PAUSE_CONTINUE = pauseEntry(0);
-
-/** Click a canvas point with the flat pointer, as a real rising edge. */
-async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
-  await game.input.set("pointer.position", norm(x, y));
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 1);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
-}
 
 async function paramValue(game: GameServer, key: string): Promise<number> {
   const { params } = await game.devParams.list();
@@ -127,7 +120,7 @@ test(
     await game.screenshot("dev-menu-flat.png");
 
     // Done returns to the main menu.
-    await click(game, DONE);
+    await click(game, DEV_DONE);
     assert.equal((await game.info()).mission, "main_menu");
   },
 );
@@ -202,7 +195,7 @@ test(
     assert.ok(Math.abs(restored - 2.0) < 0.05, `expected 2.0, got ${restored}`);
 
     // Done returns to the main menu.
-    await vrClick(game, DONE);
+    await vrClick(game, DEV_DONE);
     assert.equal((await game.info()).mission, "main_menu");
   },
 );
@@ -220,13 +213,7 @@ test(
 
     // The repurposed Options slot turns the overlay's page - the mission
     // stays loaded and paused underneath.
-    await game.input.set("pointer.position", PAUSE_DEVELOPER);
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 3 });
-    await game.input.set("pointer.pressed", 1);
-    await game.step({ frames: 3 });
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 3 });
+    await click(game, PAUSE_DEVELOPER);
     assert.equal((await game.info()).paused, true, "the page turn must not resume");
     assert.equal((await game.info()).mission, "medsci1.mis", "no scene swap");
 
@@ -241,15 +228,9 @@ test(
     await click(game, ROW0_DECREMENT);
 
     // Done returns to the root page (still paused), where Continue resumes.
-    await click(game, DONE);
+    await click(game, DEV_DONE);
     assert.equal((await game.info()).paused, true, "Done turns the page, not the sim");
-    await game.input.set("pointer.position", PAUSE_CONTINUE);
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 3 });
-    await game.input.set("pointer.pressed", 1);
-    await game.step({ frames: 3 });
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 5 });
+    await click(game, PAUSE_CONTINUE);
     assert.equal((await game.info()).paused, false, "Continue on the root resumes");
   },
 );
@@ -273,12 +254,12 @@ test(
     assert.equal((await game.info()).mission, "developer");
 
     // The upper framed button turns the page - it does not swap the scene.
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     assert.equal((await game.info()).mission, "developer");
     await game.screenshot("dev-scenes-flat.png");
 
     // "Done" on the launcher goes back to the parameters, not to the menu...
-    await click(game, DONE);
+    await click(game, DEV_DONE);
     assert.equal((await game.info()).mission, "developer");
     // ...and the parameter rows really are back: `>` steps a value again.
     const before = await paramValue(game, "panel_distance");
@@ -287,13 +268,14 @@ test(
       Math.abs((await paramValue(game, "panel_distance")) - (before + 0.1)) < 1e-4,
       "Done on the launcher must return to the parameter rows",
     );
+
     await click(game, ROW0_DECREMENT);
 
     // Select a scene on the Debug Scenes tab and launch it.
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     await click(game, TAB_DEBUG_SCENES);
     await click(game, sceneRow(DEBUG_MINIMAL_ROW));
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     assert.equal(
       (await game.info()).mission,
       "debug_minimal",
@@ -313,11 +295,11 @@ test(
 
     // The launcher opens on the Missions tab; tab over to Debug Scenes and
     // back, so the round trip is exercised end to end, then pick a row.
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     await click(game, TAB_DEBUG_SCENES);
     await click(game, TAB_MISSIONS);
     await click(game, sceneRow(MEDSCI1_ROW));
-    await click(game, ACTION);
+    await click(game, DEV_ACTION);
     // Row 9 is medsci1.mis on the canonical 23-mission install (the same
     // assumption missions.e2e.test.ts hardcodes). Asserting the exact name
     // proves the row CLICK picked the mission - the preselected row 0 would
@@ -348,14 +330,14 @@ test(
     assert.equal((await game.info()).mission, "developer");
 
     // The same canvas points as the flat run, reached by the ray.
-    await vrClick(game, ACTION);
+    await vrClick(game, DEV_ACTION);
     assert.equal((await game.info()).mission, "developer");
     await game.step({ frames: 5 });
     await game.screenshot("dev-scenes-vr.png");
 
     await vrClick(game, TAB_DEBUG_SCENES);
     await vrClick(game, sceneRow(DEBUG_MINIMAL_ROW));
-    await vrClick(game, ACTION);
+    await vrClick(game, DEV_ACTION);
     assert.equal((await game.info()).mission, "debug_minimal");
   },
 );

--- a/tools/shock2-sdk/test/helpers/frontend-menu.ts
+++ b/tools/shock2-sdk/test/helpers/frontend-menu.ts
@@ -29,6 +29,46 @@ export async function clickMenuEntry(game: GameServer, index: number): Promise<v
   await game.step({ frames: 5 });
 }
 
+/**
+ * The pause overlay's entries, in CANVAS pixels. SIMR.BIN stacks five 179x76
+ * buttons at x=400, top 20, on a 92px pitch, in screen order: 0 "Continue",
+ * 1 "Save", 2 "Load", 3 the repurposed Options/Developer slot, 4 "Quit".
+ *
+ * Canvas pixels, not normalized, so it composes with `clickCanvas` like every
+ * other point constant - the two copies this replaced had diverged on exactly
+ * that, one normalized and one not, under the same name.
+ */
+export const pauseEntry = (index: number): [number, number] => [
+  400 + 179 / 2,
+  20 + index * 92 + 76 / 2,
+];
+
+/**
+ * The developer frame's two framed buttons (GAMELODR.BIN rects 2 and 3), in
+ * canvas pixels: the upper one opens a sub-page (the scene launcher on the
+ * main menu, the Cheats page in-game), "Done" leaves.
+ */
+export const DEV_ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
+export const DEV_DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
+
+/**
+ * Click a point given in CANVAS pixels with the flat pointer. Clicks are
+ * rising-edge, so the press has to start on a frame where the previous one
+ * was unpressed.
+ */
+export async function clickCanvas(
+  game: GameServer,
+  [x, y]: [number, number],
+): Promise<void> {
+  await game.input.set("pointer.position", norm(x, y));
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+}
+
 // The VR menu is the same canvas on a world-space panel, driven by a controller
 // ray instead of a cursor. The runtime's VR head yaw is +90 degrees (the camera
 // looks along -X), so the panel hangs at x=-2 facing back at the head: canvas +x


### PR DESCRIPTION
Replaces #1224. Same cheats, same `Effect::RainItems`, reached the way the Developer screen already works instead of through an overlay of its own.

**Stacked on #1507** (`refactor/list-geometry`) — review that first; this PR's diff is against it.

## What changed vs #1224

#1224 built a *separate* `Game`-owned overlay (`cheat_pad.rs`) with its own input action, an `Alt+K` desktop binding, a Quest `X`+`Y` empty-hand chord, and a `cheats` dev-param gate — ~150 lines of overlay shell duplicating `pause_menu`'s, plus a second overlay that could open behind the first.

This instead uses the structure that already exists. The main menu's Developer screen has a **Scenes** category behind its upper framed button; the in-game Developer page leaves that same button slot empty. So the in-game screen gets a **Cheats** category in it:

```
main menu  -> Developer -> [Scenes]   (missions / debug scenes / video)
in-game    -> Developer -> [Cheats]   (rain weapons / rain modules + nanites)
```

The split is not arbitrary: a cheat needs a running mission, a scene launcher needs there not to be one.

**Deleted relative to #1224**: `cheat_pad.rs`, `InputAction::ToggleCheatPad`, the desktop key binding, the Quest chord (so `oculus_runtime` is untouched), `GameScene::hand_is_empty`, and the `cheats` dev param — the Developer screen is already the gate, so a second one bought nothing.

## Implementation

- **`shock2vr/src/ui/cheats_panel.rs`** — a sibling of `dev_params_panel`, same shape (`hit` / `draw` / `activate`), on the same `GAMELODR.BIN` rects and the same `ListGeometry` as every other frontend list. Placement is decided once, in canvas pixels, so flat and VR render it identically by construction (AGENTS.md §3). **Adding a cheat is one entry in `CHEATS`** — the list pages and grows a scroll rocker on its own once the entries outrun the pane.
- **`pause_menu.rs`** — `PauseMenuPage::Cheats`, the framed button that opens it, and `PauseAction::RainItems`. The overlay **stays up** after a cheat fires, so a situation can be set up in several presses before resuming.
- **`lib.rs`** — `Game::apply_scene_effects`, extracted from `open_pause_menu` (which already did exactly this for `CloseUseMode`), forwards the effect into the suspended scene.
- **`Effect::RainItems`** + its `mission_core` handler are carried over from #1224 unchanged, including the fix that dropped the ring from 6.25 ft to 3.5 ft over the player's body origin — at the original height the rain landed on top of corridor ceiling geometry instead of reaching the player.

Templates (from `cargo dq`): weapons rain `-928` Wrench, `-17` Pistol, `-19` Shotgun, `-18` Assault Rifle, `-1358` ×2 / `-1360` Small Standard/AP Clip, `-42` Pellet Shot Box. Modules rain `-938` EXP Cookies ×4 and `-89` 20 Nanites ×4.

### The shipped cheats

| Row | Does |
| --- | --- |
| Rain weapons | The four workhorse weapons plus a clip for each gun that takes one |
| Rain modules + nanites | 4 cyber-module stacks + 4 nanite piles |
| Hunt me (all AI) | `SetAllAIAlertness` Moderate, **pinned** — never decays, every AI hunts your live position |
| Alert all AI | The same level unpinned: a nudge that decays on its own |
| Calm all AI | Lowest, clears the pin |

The three AI rows are the existing `Effect::SetAllAIAlertness`, already bound on the desktop as `Alt+G` / `Alt+C`. **A headset has no keyboard**, so until now they were unreachable on the Quest entirely — surfacing them is most of the point of having this page in VR.

A `Cheat` carries a `CheatAction` rather than a template list, so a row can do something other than rain items. The action stays a *description*: `ui/cheats_panel` says what a row does and the host turns it into an `Effect` — the same split `dev_params_panel` keeps between a clicked row and the registry write, and it keeps `Effect` out of the `ui` layer.

## Verification

- `cargo test -p shock2vr --lib`: **1708 pass, 0 fail**. New unit tests cover the panel (every cheat reachable by scrolling and raining *its own* templates, Done vs. absorbed scrolling, rows inside the pane, a row per cheat drawn) and the host (the framed button opens the page; a row reaches `Game` and leaves the overlay up; Done returns to the *parameters*, not the root).
- **Negative-verified** at both levels: stubbing out the action-rect branch in `target_at` fails `the_upper_framed_button_opens_the_cheats_page` *and* the e2e's first world assertion (`Rain weapons must add a wrench to the world`); restoring it makes both pass.
- New `tools/shock2-sdk/test/dev-cheats.e2e.test.ts`, driven as a player would: pause → Developer → Cheats → click a row. Asserts the sim stays paused across the page turn and across a cheat, that pressing the same cheat twice adds another item at a **distinct** spawn point, that Rain modules adds **exactly** 4 module stacks + 4 nanite piles, that Done goes back to the parameters, and that the rain survives the unpause.
- The AI rows are covered end-to-end too: each is clicked, the overlay closed and the sim stepped, then the hybrid's `AIAlertness` is read. They dispatch a message the AI scripts consume on their next update, so the level only moves once the scene runs again — asserting while still paused silently reads the old value. **Negative-verified**: stubbing the `Alertness` arm to `NoEffect` fails the assertion.
- Current totals: `cargo test -p shock2vr --lib` **1708 pass**; `dev-cheats` + `dev-menu` + `force-chase` e2e **8/8** (the shared-fixture move touches `dev-menu`, and `force-chase` covers the same effect, so both were re-run). A second test asserts the main menu's Developer screen still has the **launcher** in that slot, so the two hosts cannot quietly converge.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Review

`/xreview` run properly this time: **both engines** (Codex + a Claude adversarial reviewer) plus the dedicated de-dup pass. Neither engine found a Critical or High. Both independently cleared held-press fall-through across page turns, hit/hover agreement, scroll stranding, empty-template-list division, `rains_landed` wrapping, and the `apply_scene_effects` extraction being behavior-identical to the code it replaced.

**[AGREED] — rain spawns were not clearance-checked.** Codex raised it; the Claude reviewer raised it *and* found the prior art that changed my mind about scope: `Effect::SpawnInFrontOfPlayer`, 40 lines above, already solves this with a raycast and a known-good fallback. So it is fixed rather than accepted: each slot is now clamped short of a wall by a cast from the player, so standing in a duct or against a wall no longer drops items through it.

Also fixed, from the correctness pass:

- **A single press already interpenetrated.** At the fixed 2 ft radius the eight-item weapon spread put neighbours ~1.5 ft apart — shorter than the Assault Rifle it spawns. The golden-angle fix only ever addressed *across-press* coincidence, so the comment claiming the layout avoided this was overclaiming. The radius is now a function of the list length, and slots lift per index so items clamped together by neighbouring walls stack instead of starting inside one another.
- The framed-button highlight tests the action rect directly instead of routing a full `target_at`, which also removes the empty-slice argument that call needed.
- `cheats_panel` loses its test-only `build_canvas`; the test draws onto a bare canvas like every other panel test.

De-dup pass (4 strategies; S2-clones found **no** pair touching `cheats_panel.rs`):

- `Game::update`'s effect-forwarding block was byte-identical to the `apply_scene_effects` helper this branch added — the extraction should have replaced it and didn't. Now it does.
- `list_scroll::name_list` owns the 19px/8px name-list configuration that the scene launcher and the cheats page had each written out. #1507 shared the list *methods* and left the *configuration* to be pasted; this finishes it.
- The e2e pause/developer fixtures moved to `test/helpers/frontend-menu.ts`. The two copies had already diverged on units — one normalized, one not, under the same name.
- The main-menu launcher test is dropped: `dev-menu` already covers that slot. The reviewer thought its final `Done` → `main_menu` leg was uniquely new; checking it, `dev-menu.e2e.test.ts:122` already asserts exactly that, so nothing was lost.

Judged and **not** acted on, with reasons: extracting a shared framed-button draw across `pause_menu` and `developer.rs` (after the highlight simplification the remaining overlap is ~8 lines, so the extraction would add more indirection than it removes), and collapsing the 4th copy of the `PlayerInfo` pos+rot borrow (3 of the 4 sites are pre-existing and untouched by this change).

## Visuals

![Cheats page: pause → Developer → Cheats → Rain weapons → items fall and settle](https://gist.githubusercontent.com/tommy-xr/8e676f6ec4def810c064ee58019f96ef/raw/dev-cheats-demo.gif)

<sub>Pause overlay → Developer → Cheats → Rain weapons → Done → Done → Continue → the rained wrench falls and settles. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

**Flat — Cheats page** (header, two rows, framed "Done"):

![Flat Cheats page](https://gist.githubusercontent.com/tommy-xr/8e676f6ec4def810c064ee58019f96ef/raw/dev-cheats-page.png)

**Flat — rained weapons settled** on the floor after Continue:

![Flat settled rain](https://gist.githubusercontent.com/tommy-xr/8e676f6ec4def810c064ee58019f96ef/raw/dev-cheats-rain.png)

**VR — same Cheats page** on the world-space panel, reached via the controller-ray click path (§3 flat/VR parity evidence — same header, same two rows, same "Done" position relative to the pane):

![VR Cheats page](https://gist.githubusercontent.com/tommy-xr/8e676f6ec4def810c064ee58019f96ef/raw/dev-cheats-vr.png)