### PR TITLE
fix(physics): bound the flat melee swing to MELEE_RANGE

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6721,6 +6721,12 @@ impl PhysicsWorld {
         }
     }
 
+    /// An effectively unbounded probe: casts a fixed **100 world units**.
+    ///
+    /// `direction` is normalized before the cast, so scaling it does NOT bound
+    /// the reach - pass the distance to [`Self::ray_cast2`]'s `max_toi` when a
+    /// ray is meant to stop short (issue #1327: a flat melee swing scaled its
+    /// direction by `MELEE_RANGE` and reached across the room).
     pub fn ray_cast(
         &self,
         start_point: Point3<f32>,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -29,8 +29,17 @@ use crate::{
 /// of spawning inside it. World units.
 const FLAT_MUZZLE_CLEARANCE: f32 = SCALE_FACTOR;
 
-/// Reach of a flat melee swing (raycast along the crosshair ray), in world units.
-const MELEE_RANGE: f32 = 1.2;
+/// Reach of a flat melee swing (raycast along the crosshair ray), in world
+/// units - the same retail-derived distance as a frob.
+///
+/// The ray starts at the *eye*, 2.24 world units above the floor, so the reach
+/// has to cover the hypotenuse down to a low target: a Baby Arachnid you are
+/// standing on top of is still ~2.05 units away. The 1.2 this replaces could
+/// never hit one - it was a magic number that, until #1327, bounded nothing
+/// and so was never exercised. The game authors no melee reach of its own
+/// (`P$Melee Typ` is a type index), so borrow the one distance that IS
+/// retail-derived: if the player can frob it, the swing can reach it.
+const MELEE_RANGE: f32 = crate::virtual_hand::FROB_REACH;
 /// Damage dealt by a flat melee hit. TODO: derive from the weapon's `Melee Typ`.
 const MELEE_DAMAGE: f32 = 6.0;
 
@@ -655,12 +664,18 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
 /// distance along the current crosshair ray and damage the hit entity (hitbox
 /// proxies resolve to their parent).
 fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World) -> Effect {
-    let hit = physics.ray_cast(
+    // `ray_cast` normalizes its direction and casts a fixed 100 units, so the
+    // reach has to be passed as `ray_cast2`'s max_toi - scaling the direction
+    // bounds nothing.
+    let hit = physics.ray_cast2(
         aim.origin,
-        aim.forward.normalize() * MELEE_RANGE,
+        aim.forward.normalize(),
+        MELEE_RANGE,
         InternalCollisionGroups::ENTITIES
             | InternalCollisionGroups::HITBOX
             | InternalCollisionGroups::SELECTABLE,
+        None,
+        true,
     );
     if let Some(RayCastResult {
         maybe_entity_id: Some(target),
@@ -1479,6 +1494,109 @@ mod tests {
                 .iter()
                 .any(|effect| matches!(effect, Effect::AdjustAmmo { .. })),
             "and the round is not spent"
+        );
+    }
+
+    /// `PhysicsWorld::ray_cast` normalizes its direction and casts a fixed 100
+    /// world units, so scaling the direction by `MELEE_RANGE` bounded nothing -
+    /// a flat swing connected with anything on the crosshair across the room.
+    /// A target well past the swing's reach must take no damage.
+    #[test]
+    fn a_flat_swing_does_not_reach_past_melee_range() {
+        use crate::physics::{CollisionGroup, PhysicsWorld};
+        use cgmath::vec3;
+
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+
+        let far = world.add_entity(PropWeaponType(0));
+        let far_z = -(MELEE_RANGE * 8.0);
+        physics.add_kinematic(
+            far,
+            vec3(0.0, 0.0, far_z),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+
+        let mut player = physics.create_player(
+            vec3(100.0, 100.0, 100.0),
+            EntityId::from_inner(1000).unwrap(),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let aim = RuntimePropFlatAim {
+            origin: point3(0.0, 0.0, 0.0),
+            forward: vec3(0.0, 0.0, -1.0),
+        };
+
+        // Guard the fixture: the unbounded 100-unit ray DOES reach it, so a
+        // miss below is the bound doing its job, not an unreachable target.
+        assert!(far_z.abs() < 100.0);
+        assert!(
+            physics
+                .ray_cast(
+                    aim.origin,
+                    aim.forward,
+                    InternalCollisionGroups::ENTITIES
+                        | InternalCollisionGroups::HITBOX
+                        | InternalCollisionGroups::SELECTABLE,
+                )
+                .and_then(|hit| hit.maybe_entity_id)
+                == Some(far),
+            "fixture must be visible to an unbounded ray for this test to mean anything"
+        );
+
+        assert!(
+            matches!(flat_melee_hit(&physics, aim, &world), Effect::NoEffect),
+            "a target 8x past MELEE_RANGE must not be hit"
+        );
+    }
+
+    /// The other half of the bound: a target inside the swing's reach still
+    /// takes its damage, so the fix cannot pass by never connecting at all.
+    #[test]
+    fn a_flat_swing_still_hits_within_melee_range() {
+        use crate::physics::{CollisionGroup, PhysicsWorld};
+        use cgmath::vec3;
+
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+
+        let near = world.add_entity(PropWeaponType(0));
+        physics.add_kinematic(
+            near,
+            vec3(0.0, 0.0, -MELEE_RANGE / 2.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+        let mut player = physics.create_player(
+            vec3(100.0, 100.0, 100.0),
+            EntityId::from_inner(1000).unwrap(),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let aim = RuntimePropFlatAim {
+            origin: point3(0.0, 0.0, 0.0),
+            forward: vec3(0.0, 0.0, -1.0),
+        };
+
+        assert!(
+            matches!(
+                flat_melee_hit(&physics, aim, &world),
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Damage { .. },
+                    },
+                } if to == near
+            ),
+            "a target inside MELEE_RANGE must still take the swing"
         );
     }
 }


### PR DESCRIPTION
## The bug

`flat_melee_hit` resolved its swing with

```rust
physics.ray_cast(aim.origin, aim.forward.normalize() * MELEE_RANGE, ...)
```

but `ray_cast` normalizes the direction (`direction / norm_sq.sqrt()`) and forwards to `ray_cast2(..., 100.0, ...)`. The `* MELEE_RANGE` scaling was discarded, so a flat swing's real reach was **100 world units** — a wrench connected with anything on the crosshair across the room. Now the reach is passed as `ray_cast2`'s `max_toi`.

## MELEE_RANGE itself was never real

Enforcing the bound exposed a second problem. `1.2` was a bare magic number added with the first flat swing (#319), and because it bounded nothing it was never exercised.

The crosshair ray starts at the **eye**, `PLAYER_EYE_HEIGHT` = 2.24 world units above the floor. So the reach must cover the hypotenuse down to a low target: a Baby Arachnid you are standing directly on top of is still **~2.05 units** away. With a 1.2 bound you cannot wrench any floor-level creature, ever — `baby-arachnid.e2e.test.ts` caught precisely that (aimed wrench swing from 1.08 units, no damage).

The game authors no melee reach of its own (`P$Melee Typ` is a 4-byte type index, not a distance), so the reach now borrows the one retail-derived distance in the codebase: `FROB_REACH` = `sqrt(50) / SCALE_FACTOR` from `GAMEPARAM.Frob Dist = 50`. **If the player can frob it, the swing can reach it.**

## Caller audit

Only three `.ray_cast(` call sites exist. The other two are tests that deliberately want the unbounded probe and pass unit vectors, so this was the sole production caller. `ray_cast` now documents its fixed 100-unit reach and that it ignores the direction magnitude, so the next caller doesn't repeat this.

## Verification

- Unit tests both ways in `weapon_script.rs`: a target 8× past `MELEE_RANGE` takes nothing, one inside still takes the swing. The negative test was **verified to fail before the fix** — and it carries a fixture guard asserting an unbounded ray *does* reach the target, because my first version silently passed against the buggy code (`add_kinematic` isn't queryable until `physics.update()` runs).
- `baby-arachnid.e2e.test.ts` passes (fails on this branch with the old 1.2).
- `cargo test -p shock2vr`: 1698 passed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

### Full e2e suite: no regressions

703 tests, 32 failures — all accounted for against a freshly-built `origin/main` worktree:

| | |
|---|---|
| pre-existing on `main` (#1262) | 28 |
| flaky (`world-surface-material`, `vr-strength-recoil`) | 3 |
| real regression, now fixed | 1 (`baby-arachnid`) |

The recoil failure moved between "shotgun", "AR" and "pistol" across runs, and `world-surface-material` passed on re-run — both flaky rather than related. `medsci-saved-vr-melee`, `a lethal VR Wrench contact…` and `every shot… names the limb` fail identically on `main` in isolation.

Fixes #1327