### PR TITLE
fix(vr): fit inventory drops and preview their placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   insert is the only way to change ammo type in the headset, so the types you
   can select are the ones you are carrying clips for. There is no reload or
   ammo-swap button on the controllers; the gesture is the control.
+- Quest VR: rearrange inventory by gripping an item, pointing at its new
+  location, and releasing. Tall items slide up to fit the chosen column.
+  The ghost footprint previews the destination: green for placement or merging,
+  amber for automatic placement elsewhere, and red when the pack has no room
+  and releasing will drop the item into the world.
 - Quest VR: with that hand free, press an upper face button (left `Y` / right
   `B`) to open the newest unread audio log. Press it again to close it; after
   every log is read, it replays the most recently collected log. Holding a

--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -248,6 +248,23 @@ impl Inventory {
         true
     }
 
+    /// Keep a pointed-at item's footprint inside the grid. Near the bottom or
+    /// right edge, slide its origin back just enough to fit; never move over
+    /// another item or treat an off-grid pointer as a valid target.
+    pub fn placement_at(
+        &self,
+        target: (usize, usize),
+        dimensions: (usize, usize),
+    ) -> Option<(usize, usize)> {
+        let (width, height) = dimensions;
+        if target.0 >= self.width || target.1 >= self.height || width == 0 || height == 0 {
+            return None;
+        }
+        let x = target.0.min(self.width.checked_sub(width)?);
+        let y = target.1.min(self.height.checked_sub(height)?);
+        self.has_capacity(x, y, width, height).then_some((x, y))
+    }
+
     pub fn all_items(&self) -> impl Iterator<Item = &ContainedEntityInfo> {
         self.items.iter()
     }
@@ -432,6 +449,22 @@ mod tests {
             .find(|i| i.entity == entity)
             .map(|i| (i.x, i.y))
             .expect("item should be laid out")
+    }
+
+    #[test]
+    fn pointed_footprints_slide_inside_edges_without_crossing_occupants() {
+        let mut inventory = Inventory::new(8, 3);
+        for row in 0..3 {
+            assert_eq!(inventory.placement_at((5, row), (1, 3)), Some((5, 0)));
+        }
+        assert_eq!(inventory.placement_at((7, 2), (2, 2)), Some((6, 1)));
+        assert_eq!(inventory.placement_at((8, 1), (1, 1)), None);
+        assert_eq!(inventory.placement_at((2, 1), (1, 4)), None);
+        assert_eq!(inventory.placement_at((2, 1), (0, 1)), None);
+        let item = entities(1)[0];
+        inventory.insert_if_fits(item, 5, 0, 1, 1);
+        assert_eq!(inventory.placement_at((5, 1), (1, 3)), None);
+        assert_eq!(inventory.placement_at((4, 1), (1, 3)), Some((4, 0)));
     }
 
     /// An item keeps the cell stored on its containment link - it is not

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -238,6 +238,8 @@ pub struct FlatUiHost {
     /// The item lifted onto the cursor (the original's "cursor IS the item"
     /// drag, §2.4). `Some` between a lift and the place/throw that clears it.
     cursor_item: Option<CursorItem>,
+    /// Resolved inventory destination, drawn by the shared canvas in both presentations.
+    placement_preview: Option<PlacementPreview>,
     /// The most recent lift, for double-click (wield) detection. Counts down
     /// each frame and clears when the window elapses.
     last_lift: Option<LiftMark>,
@@ -293,6 +295,39 @@ struct StripSlot {
     components: Vec<GuiComponentRenderInfo>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PlacementStatus {
+    Place,
+    Merge,
+    AutoPlace,
+    NoRoom,
+}
+
+impl PlacementStatus {
+    pub(super) fn text(self) -> &'static str {
+        match self {
+            Self::Place => "RELEASE TO PLACE",
+            Self::Merge => "RELEASE TO MERGE",
+            Self::AutoPlace => "AUTO-PLACE ON RELEASE",
+            Self::NoRoom => "NO ROOM - RELEASE DROPS ITEM",
+        }
+    }
+
+    fn outline_texture(self) -> &'static str {
+        match self {
+            Self::Place | Self::Merge => "iface/resprog.pcx",
+            Self::AutoPlace => "HPBAR1.PCX",
+            Self::NoRoom => "HPBAR0.PCX",
+        }
+    }
+}
+
+struct PlacementPreview {
+    rect: Rect,
+    icon: Option<String>,
+    status: PlacementStatus,
+}
+
 impl FlatUiHost {
     pub fn new() -> FlatUiHost {
         FlatUiHost {
@@ -301,6 +336,7 @@ impl FlatUiHost {
             components: Vec::new(),
             strip: None,
             cursor_item: None,
+            placement_preview: None,
             last_lift: None,
             readouts: None,
             sticky_panel: false,
@@ -362,6 +398,30 @@ impl FlatUiHost {
         );
         let grid = crate::inventory::grid_for(world, strip.entity);
         crate::scripts::gui::backpack_cell_at(panel_pos, grid)
+    }
+
+    pub(super) fn set_placement_preview(
+        &mut self,
+        world: &World,
+        preview: Option<(EntityId, (usize, usize), (usize, usize), PlacementStatus)>,
+    ) {
+        self.placement_preview = preview.and_then(|(entity, cell, dimensions, status)| {
+            let strip = self.strip.as_ref()?;
+            let rect = self.strip_rect()?;
+            let size = strip.size_px?;
+            let footprint = crate::scripts::gui::backpack_footprint_rect(cell, dimensions);
+            let footprint = Rect::new(
+                rect.x + footprint.x * rect.w / size.x,
+                rect.y + footprint.y * rect.h / size.y,
+                footprint.w * rect.w / size.x,
+                footprint.h * rect.h / size.y,
+            );
+            Some(PlacementPreview {
+                rect: footprint,
+                icon: make_cursor_item(world, entity).icon,
+                status,
+            })
+        });
     }
 
     /// The item currently held on the cursor mid-drag (for `/v1/ui` `cursor`).
@@ -517,7 +577,10 @@ impl FlatUiHost {
 
     /// The mini-frame's current name line, for `GET /v1/ui`.
     pub fn name_strip_debug(&self) -> Option<String> {
-        self.name_strip.clone()
+        self.placement_preview
+            .as_ref()
+            .map(|preview| preview.status.text().to_owned())
+            .or_else(|| self.name_strip.clone())
     }
 
     /// Swallow a button that is already held as the host takes over input, so
@@ -676,6 +739,7 @@ impl FlatUiHost {
     /// strip just stashes and re-anchors it.
     pub fn set_strip(&mut self, entity: Option<EntityId>) {
         self.utilities = Default::default();
+        self.placement_preview = None;
         // The readout belongs to the bar: leaving use mode must not leave a
         // stale name behind for `/v1/ui` (the mission's per-frame update runs
         // before the effect that unbinds the strip).
@@ -1336,7 +1400,15 @@ impl FlatUiHost {
             // pixels - both presentations map this rect (AGENTS.md 3).
             let (frame, text) = name_strip_rects(rect);
             canvas.image(frame, "frame.pcx");
-            if let Some(name) = self.name_strip.as_deref() {
+            if let Some(preview) = self.placement_preview.as_ref() {
+                canvas.text_native_fit(
+                    text,
+                    preview.status.text(),
+                    NAME_STRIP_FONT,
+                    HAlign::Left,
+                    VAlign::Middle,
+                );
+            } else if let Some(name) = self.name_strip.as_deref() {
                 canvas.text_native_fit(text, name, NAME_STRIP_FONT, HAlign::Left, VAlign::Middle);
             } else if self.shoulder_weapons.iter().any(Option::is_some) {
                 canvas.text_native_fit(
@@ -1358,6 +1430,24 @@ impl FlatUiHost {
                     "closeoff.pcx"
                 },
             );
+        }
+        if strip_rect.is_some() {
+            if let Some(preview) = self.placement_preview.as_ref() {
+                let rect = preview.rect;
+                if let Some(icon) = &preview.icon {
+                    canvas.fitted_object_icon(rect, icon).opacity(0.45);
+                }
+                // Four explicit edges keep the full destination visible without
+                // stretching the frame art over the item's silhouette.
+                for edge in [
+                    Rect::new(rect.x, rect.y, rect.w, 2.0),
+                    Rect::new(rect.x, rect.y + rect.h - 2.0, rect.w, 2.0),
+                    Rect::new(rect.x, rect.y, 2.0, rect.h),
+                    Rect::new(rect.x + rect.w - 2.0, rect.y, 2.0, rect.h),
+                ] {
+                    canvas.image(edge, preview.status.outline_texture());
+                }
+            }
         }
         if let Some(cursor) = self.cursor_canvas {
             // The cursor IS the lifted item: draw its icon in place of the
@@ -1447,6 +1537,18 @@ impl FlatUiHost {
             (Some(strip), Some(rect)) => {
                 let mut elements =
                     self.elements_for(world, &strip.components, rect, self.held_entity());
+                if let Some(preview) = self.placement_preview.as_ref() {
+                    let footprint = preview.rect;
+                    elements.push(crate::game_scene::DebugUiElement {
+                        kind: "image".to_owned(),
+                        texture: Some(preview.status.outline_texture().to_owned()),
+                        text: None,
+                        label: Some(preview.status.text().to_owned()),
+                        entity_id: None,
+                        rect: [footprint.x, footprint.y, footprint.w, footprint.h],
+                        screen_rect: self.to_screen_rect(footprint),
+                    });
+                }
                 elements.extend(
                     self.utilities
                         .debug_elements()
@@ -2508,6 +2610,31 @@ mod tests {
             &[strip_item(wrench, 0)],
         );
         (world, host, wrench, inventory)
+    }
+
+    #[test]
+    fn placement_preview_uses_shared_canvas_and_clears_with_strip() {
+        let (mut world, mut host, wrench, inventory) = drag_world();
+        world.add_component(inventory, crate::inventory::PlayerInventoryEntity {});
+        host.set_placement_preview(
+            &world,
+            Some((wrench, (5, 0), (1, 3), PlacementStatus::Place)),
+        );
+        let preview = host
+            .strip_debug_elements(&world)
+            .into_iter()
+            .find(|element| element.label.as_deref() == Some("RELEASE TO PLACE"))
+            .unwrap();
+        let canvas = host.build_canvas().unwrap();
+        assert!(canvas.elements().iter().any(|element| matches!(element,
+            UiElement::Text { text, .. } if text == "RELEASE TO PLACE"
+        )));
+        assert_eq!(host.name_strip_debug().as_deref(), Some("RELEASE TO PLACE"));
+        let cell = host.strip_cell_at(vec2(preview.rect[0] + 1.0, preview.rect[1] + 1.0), &world);
+        assert_eq!(cell, Some((5, 0)));
+        host.set_strip(None);
+        assert!(host.placement_preview.is_none());
+        assert!(host.name_strip_debug().is_none());
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1,3 +1,4 @@
+use super::flat_ui_host::PlacementStatus;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     path::Path,
@@ -708,25 +709,103 @@ fn move_live_entity_into_container_at_cell(
     dropped_entity_id: EntityId,
     target_cell: (usize, usize),
 ) -> bool {
+    let Some((slot, _)) =
+        container_deposit_slot(world, container_entity_id, dropped_entity_id, target_cell)
+    else {
+        return false;
+    };
+    move_live_entity_into_container_at_slot(
+        world,
+        container_entity_id,
+        dropped_entity_id,
+        Some(slot),
+    )
+}
+
+/// Resolve both the release and its preview. The flag identifies first-free
+/// fallback so the UI can distinguish placement here from automatic placement.
+fn container_deposit_slot(
+    world: &World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+    target_cell: (usize, usize),
+) -> Option<(u32, bool)> {
     let grid = crate::inventory::grid_for(world, container_entity_id);
     let mut occupied =
         crate::inventory::Inventory::from_container(world, container_entity_id, grid);
-    // See `move_live_entity_into_container_at_slot`: a re-grab can still show
-    // the dropped entity occupying its own old cell here.
     occupied.remove_entity(dropped_entity_id);
     let dims = world
         .borrow::<View<dark::properties::PropInventoryDimensions>>()
         .ok()
-        .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+        .and_then(|v| {
+            v.get(dropped_entity_id)
+                .ok()
+                .map(|d| (d.width as usize, d.height as usize))
+        })
         .unwrap_or((1, 1));
-    let fits = occupied.has_capacity(
-        target_cell.0,
-        target_cell.1,
-        dims.0 as usize,
-        dims.1 as usize,
-    );
-    let slot = fits.then(|| occupied.slot_at(target_cell.0, target_cell.1));
-    move_live_entity_into_container_at_slot(world, container_entity_id, dropped_entity_id, slot)
+    if let Some((x, y)) = occupied.placement_at(target_cell, dims) {
+        return Some((occupied.slot_at(x, y), false));
+    }
+    occupied
+        .first_free_slot(dims.0, dims.1)
+        .map(|slot| (slot, true))
+}
+
+/// Preview the same stack/placement/fallback order used by the release handler.
+fn container_deposit_preview(
+    world: &World,
+    container: EntityId,
+    item: EntityId,
+    target: (usize, usize),
+) -> (EntityId, (usize, usize), (usize, usize), PlacementStatus) {
+    let grid = crate::inventory::grid_for(world, container);
+    let inventory = crate::inventory::Inventory::from_container(world, container, grid);
+    let merge = matching_stack_at_cell(world, container, item, target);
+    let placement = container_deposit_slot(world, container, item, target);
+    let merge = merge.or_else(|| {
+        placement
+            .is_none()
+            .then(|| find_mergeable_stack_anywhere(world, container, item))
+            .flatten()
+    });
+    if let Some(merge) = merge {
+        if let Some(occupant) = inventory.all_items().find(|entry| entry.entity == merge) {
+            return (
+                item,
+                (occupant.x, occupant.y),
+                (occupant.width, occupant.height),
+                PlacementStatus::Merge,
+            );
+        }
+    }
+    if let Some((slot, fallback)) = placement {
+        let cell = inventory.cell_of(slot).unwrap();
+        let dims = world
+            .borrow::<View<dark::properties::PropInventoryDimensions>>()
+            .ok()
+            .and_then(|v| {
+                v.get(item)
+                    .ok()
+                    .map(|d| (d.width as usize, d.height as usize))
+            })
+            .unwrap_or((1, 1));
+        return (
+            item,
+            cell,
+            dims,
+            if fallback {
+                PlacementStatus::AutoPlace
+            } else {
+                PlacementStatus::Place
+            },
+        );
+    }
+    (
+        item,
+        (target.0.min(grid.0 - 1), target.1.min(grid.1 - 1)),
+        (1, 1),
+        PlacementStatus::NoRoom,
+    )
 }
 
 /// The occupant of `target_cell` in `container_entity_id`'s grid, if that
@@ -1294,6 +1373,62 @@ mod cell_deposit_tests {
         );
     }
 
+    #[test]
+    fn preview_distinguishes_fallback_merge_and_full_inventory() {
+        let (mut world, container) = container_with_item_at(Some((2, 2)));
+        let item = world.add_entity((
+            PropHasRefs(false),
+            PropInventoryDimensions {
+                width: 1,
+                height: 3,
+            },
+        ));
+        let preview = container_deposit_preview(&world, container, item, (2, 2));
+        assert_eq!(preview.3, PlacementStatus::AutoPlace);
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (2, 2)
+        ));
+        assert_eq!(
+            contains_slot(&world, container, item),
+            (preview.1.1 * 4 + preview.1.0) as u32
+        );
+
+        let (world, container, _, item) = stack_world(42);
+        assert_eq!(
+            container_deposit_preview(&world, container, item, (0, 0)).3,
+            PlacementStatus::Merge
+        );
+
+        let (mut world, container) = container_with_item_at(None);
+        let occupying = world.add_entity((
+            PropHasRefs(false),
+            PropInventoryDimensions {
+                width: 4,
+                height: 4,
+            },
+        ));
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            occupying,
+            (0, 0)
+        ));
+        let item = world.add_entity(PropHasRefs(false));
+        assert_eq!(
+            container_deposit_preview(&world, container, item, (2, 2)).3,
+            PlacementStatus::NoRoom
+        );
+        assert!(!move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (2, 2)
+        ));
+    }
+
     /// A target cell holding a same-template stack is a merge candidate, not
     /// a claim - `MissionCore::drop_entity_into_container_at_cell` sums the
     /// counts and destroys the dropped entity instead of placing it.
@@ -1320,10 +1455,9 @@ mod cell_deposit_tests {
         );
     }
 
-    /// A multi-cell item's target still respects capacity: a target cell that
-    /// cannot fit the item's authored footprint is not claimed, even empty.
+    /// A tall item stays in the pointed column when its origin must slide up.
     #[test]
-    fn a_target_cell_too_small_for_the_items_footprint_falls_back() {
+    fn a_tall_item_slides_up_to_fit_the_pointed_column() {
         let (mut world, container) = container_with_item_at(None);
         let item = world.add_entity((
             PropHasRefs(false),
@@ -1333,19 +1467,18 @@ mod cell_deposit_tests {
             },
         ));
 
-        // (0, 3) is the last row of a 4-tall grid - a 1x3 item cannot fit
-        // starting there.
+        // The last row cannot be the origin of a 1x3 item; use row 1.
         assert!(move_live_entity_into_container_at_cell(
             &mut world,
             container,
             item,
-            (0, 3),
+            (2, 3),
         ));
 
         assert_eq!(
             contains_slot(&world, container, item),
-            0,
-            "falls back to the first free cell, (0,0)"
+            6,
+            "slides up to (2,1), keeping the pointed column"
         );
     }
 }
@@ -4785,6 +4918,33 @@ impl MissionCore {
         }
         self.flat_ui
             .set_hand_items(&self.world, asset_cache, hand_items);
+        let placement_preview = self.vr_use_mode_pointer.as_ref().and_then(|pass| {
+            // Use the same per-hand rays as release detection, including a
+            // carrying hand when the other controller owns the UI cursor.
+            pass.active_ray()
+                .into_iter()
+                .chain(pass.rays.iter())
+                .find_map(|ray| {
+                    let item = hand_items[hand_slot(ray.handedness)]?;
+                    let point = ray.canvas_hit?;
+                    if !self.flat_ui.strip_contains(point) {
+                        return None;
+                    }
+                    let container = self.flat_ui.strip_entity()?;
+                    let cell = self
+                        .flat_ui
+                        .strip_cell_at(point, &self.world)
+                        .unwrap_or((usize::MAX, usize::MAX));
+                    Some(container_deposit_preview(
+                        &self.world,
+                        container,
+                        item,
+                        cell,
+                    ))
+                })
+        });
+        self.flat_ui
+            .set_placement_preview(&self.world, placement_preview);
         self.refresh_readouts();
         if self
             .weapon_settings_gun

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -116,6 +116,19 @@ const LOOT_GRID_TOP_MARGIN: f32 = 34.0;
 /// paperdoll owns everything right of x = 527.
 const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 
+/// The same cell pitch and origin used by the backpack's item icons.
+pub fn backpack_footprint_rect(
+    cell: (usize, usize),
+    dimensions: (usize, usize),
+) -> crate::ui::Rect {
+    crate::ui::Rect::new(
+        BACKPACK_GRID_ORIGIN.x + SLOT_PITCH.x * cell.0 as f32,
+        BACKPACK_GRID_ORIGIN.y + SLOT_PITCH.y * cell.1 as f32,
+        SLOT_PITCH.x * dimensions.0 as f32,
+        SLOT_PITCH.y * dimensions.1 as f32,
+    )
+}
+
 /// `res/iface/BLOCK.PCX` is authored to cover one cell's 34x32 interior,
 /// leaving the separators in `INVBACK.PCX` visible around it.
 const BLOCK_SIZE: Vector2<f32> = Vector2::new(34.0, 32.0);

--- a/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
@@ -36,17 +36,19 @@ const BELOW_STRIP_CANVAS: [number, number] = [320, 400];
 const STRIP_ANCHOR: [number, number] = [2, 0];
 const BACKPACK_GRID_ORIGIN: [number, number] = [4, 17];
 const SLOT_PITCH: [number, number] = [35, 34];
+// The strip makes room for the mirrored 37px arm readout.
+const STRIP_SCALE = 635 / (635 + 37);
 
 function cellTopLeft(cellX: number, cellY: number): [number, number] {
   return [
-    STRIP_ANCHOR[0] + BACKPACK_GRID_ORIGIN[0] + SLOT_PITCH[0] * cellX,
-    STRIP_ANCHOR[1] + BACKPACK_GRID_ORIGIN[1] + SLOT_PITCH[1] * cellY,
+    STRIP_ANCHOR[0] + (BACKPACK_GRID_ORIGIN[0] + SLOT_PITCH[0] * cellX) * STRIP_SCALE,
+    STRIP_ANCHOR[1] + (BACKPACK_GRID_ORIGIN[1] + SLOT_PITCH[1] * cellY) * STRIP_SCALE,
   ];
 }
 
 function cellCenter(cellX: number, cellY: number): [number, number] {
   const [x, y] = cellTopLeft(cellX, cellY);
-  return [x + SLOT_PITCH[0] / 2, y + SLOT_PITCH[1] / 2];
+  return [x + SLOT_PITCH[0] * STRIP_SCALE / 2, y + SLOT_PITCH[1] * STRIP_SCALE / 2];
 }
 
 async function launchWithHeldClip(port: number): Promise<{
@@ -326,10 +328,53 @@ test(
     );
     assert.ok(slot, `the deposited clip must have a strip slot: ${JSON.stringify(strip?.elements)}`);
     const [expectedX, expectedY] = cellTopLeft(...targetCell);
-    assert.deepEqual(
-      [slot.rect[0], slot.rect[1]],
-      [expectedX, expectedY],
+    assert.ok(
+      Math.abs(slot.rect[0] - expectedX) < 0.01 && Math.abs(slot.rect[1] - expectedY) < 0.01,
       `the clip must land at cell (${targetCell.join(",")}) = (${expectedX}, ${expectedY}), got rect ${JSON.stringify(slot.rect)}`,
     );
+  },
+);
+
+
+test(
+  "a wrench gripped out of inventory previews and lands in the column pointed at in any row",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const wrench = await game.player.spawnItem("Wrench");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const initial = (await game.ui.state()).strip!.elements.find(e => e.entity_id === wrench.entity_id)!;
+    const pose = (await game.ui.state()).panel_pose!;
+    await aimVrHandAtCanvas(game, pose, [320, 240], { hand: "left", facing: "away" });
+    // Derive the rendered pitch from this authored 1x3 item, so the test
+    // remains valid when the shared strip is scaled to accommodate hand UI.
+    const pitchX = initial.rect[2];
+    const pitchY = initial.rect[3] / 3;
+    for (const [column, row] of [[5, 1], [3, 2], [1, 0]]) {
+      const slot = (await game.ui.state()).strip!.elements.find(e => e.entity_id === wrench.entity_id)!;
+      const source: [number, number] = [slot.rect[0] + pitchX / 2, slot.rect[1] + pitchY * 1.5];
+      await aimVrHandAtCanvas(game, pose, source, { squeeze: 0 });
+      await game.step({ frames: 3 });
+      await aimVrHandAtCanvas(game, pose, source, { squeeze: 1 });
+      await game.step({ frames: 5 });
+      assert.equal((await game.info()).player.right_hand_entity_id, wrench.entity_id);
+      const target: [number, number] = [initial.rect[0] + (column + 0.5) * pitchX, initial.rect[1] + (row + 0.5) * pitchY];
+      await aimVrHandAtCanvas(game, pose, target, { squeeze: 1 });
+      await game.step({ frames: 5 });
+      const preview = (await game.ui.state()).strip!.elements.find(e => e.label === "RELEASE TO PLACE");
+      assert.ok(preview, "a valid held placement must be previewed before release");
+      assert.ok(Math.abs(preview.rect[0] - (initial.rect[0] + column * pitchX)) < 0.01);
+      assert.ok(Math.abs(preview.rect[1] - initial.rect[1]) < 0.01);
+      assert.ok(Math.abs(preview.rect[3] - initial.rect[3]) < 0.01);
+      await game.input.set("right_hand.squeeze", 0);
+      await game.step({ frames: 10 });
+      assert.equal((await game.info()).player.right_hand_entity_id, null);
+      const after = (await game.ui.state()).strip!.elements.find(e => e.entity_id === wrench.entity_id)!;
+      for (let i = 0; i < 4; i++) assert.ok(Math.abs(after.rect[i] - preview.rect[i]) < 0.01, "release must match preview");
+      assert.equal((await game.physics.bodies({ entityId: wrench.entity_id })).bodies.length, 0);
+      assert.ok(!(await game.ui.state()).strip!.elements.some(e => e.label === "RELEASE TO PLACE"));
+    }
   },
 );


### PR DESCRIPTION
Releasing a gripped wrench over the middle or bottom cell of an empty inventory column used to send it back to the first free slot. Placement now shifts multi-cell items inside the grid so the wrench stays in the column the player points at. This closes the tall-item gap left by #1158.

While holding an item over the inventory, a ghost footprint shows the destination before release. Green indicates placement or merging, amber indicates automatic placement elsewhere, and red warns that the inventory is full and releasing will drop the item. The preview uses the release placement calculation and the shared flat/VR canvas.

## Validation

- `cargo test -p shock2vr --lib`: 1,699 passed, 2 ignored.
- VR regression grabs the same wrench from inventory and releases over the top, middle, and bottom rows; checks destination against preview, hand ownership, and removal of world physics.
- Existing deposit scenarios pass, including off-panel/world drops and return to inventory. Updated the older targeted-cell assertion to account for the strip's existing scale.
- Unit coverage includes occupied destinations, merging, full inventory, edge adjustment, and preview cleanup.
- Built debug runtime; formatting and diff checks pass. Captured and inspected VR feedback and flat/VR layout parity. Headset install/testing not performed.

## Demo

![VR inventory placement demo](https://gist.githubusercontent.com/tommy-xr/a4989329c66b5c079144bade2f7233bb/raw/placement-demo.gif)

Grip the wrench, point at an empty column’s middle cell, and release. The preview shows its fitted footprint; amber indicates automatic placement elsewhere, and red warns that a full inventory will drop the item.

### Before / after

![Before and after placement feedback](https://gist.githubusercontent.com/tommy-xr/a4989329c66b5c079144bade2f7233bb/raw/before-after.png)

### Automatic placement and full inventory

![Occupied target previews automatic placement](https://gist.githubusercontent.com/tommy-xr/a4989329c66b5c079144bade2f7233bb/raw/after-blocked-held.png)

![Full inventory warns before release](https://gist.githubusercontent.com/tommy-xr/a4989329c66b5c079144bade2f7233bb/raw/after-full-held.png)
