### PR TITLE
fix(vr): preserve held items through cold-load startup

### DIFF
--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -164,6 +164,16 @@ pub trait PlayerInteraction {
         hand: Handedness,
     ) -> Vec<VirtualHandEffect>;
 
+    /// Restore saved ownership without treating neutral startup input as a release.
+    fn restore_held(
+        &mut self,
+        world: &World,
+        entity_id: EntityId,
+        hand: Handedness,
+    ) -> Vec<VirtualHandEffect> {
+        self.grab(world, entity_id, hand)
+    }
+
     /// A held entity was recreated as `new`; track the new id.
     fn replace_entity(&mut self, old: EntityId, new: EntityId, rigid_body: RigidBodyHandle);
 
@@ -1443,6 +1453,24 @@ impl PlayerInteraction for VrInteraction {
             self.right_hand = self.right_hand.grab_entity(world, entity_id);
         }
         Vec::new()
+    }
+
+    fn restore_held(
+        &mut self,
+        world: &World,
+        entity_id: EntityId,
+        hand: Handedness,
+    ) -> Vec<VirtualHandEffect> {
+        let effects = self.grab(world, entity_id, hand);
+        let restored_hand = if hand == Handedness::Left {
+            &mut self.left_hand
+        } else {
+            &mut self.right_hand
+        };
+        if restored_hand.is_holding(entity_id) {
+            restored_hand.preserve_restored_grip();
+        }
+        effects
     }
 
     fn replace_entity(&mut self, old: EntityId, new: EntityId, rigid_body: RigidBodyHandle) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2275,10 +2275,10 @@ fn restore_held_item_interaction(
 ) -> Vec<VirtualHandEffect> {
     let mut effects = Vec::new();
     if let Some(entity_id) = left_hand_entity {
-        effects.extend(interaction.grab(world, entity_id, vr_config::Handedness::Left));
+        effects.extend(interaction.restore_held(world, entity_id, vr_config::Handedness::Left));
     }
     if let Some(entity_id) = right_hand_entity {
-        effects.extend(interaction.grab(world, entity_id, vr_config::Handedness::Right));
+        effects.extend(interaction.restore_held(world, entity_id, vr_config::Handedness::Right));
     }
     effects
 }
@@ -15048,6 +15048,61 @@ mod saved_script_namespace_tests {
 #[cfg(test)]
 mod held_item_restore_tests {
     use super::*;
+
+    #[test]
+    fn vr_restored_hands_survive_neutral_then_release_once_after_squeeze() {
+        let mut world = World::new();
+        let left = world.add_entity((PropModelName("test_item".into()),));
+        let right = world.add_entity((PropModelName("test_item".into()),));
+        let mut interaction = VrInteraction::new();
+        restore_held_item_interaction(&mut interaction, &world, Some(left), Some(right));
+        let physics = PhysicsWorld::new();
+        let mut input = InputContext::default();
+        for squeeze in [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0] {
+            input.left_hand.squeeze_value = squeeze;
+            input.right_hand.squeeze_value = squeeze;
+            let effects = interaction.update(&InteractionContext {
+                physics: &physics,
+                world: &world,
+                input: &input,
+                player_pos: vec3(0.0, 0.0, 0.0),
+                player_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                eye_height: 1.04,
+                step_dt: 1.0 / 60.0,
+                support_enabled: false,
+            });
+            assert_eq!(interaction.held_entities(), (Some(left), Some(right)));
+            assert!(
+                !effects
+                    .iter()
+                    .any(|e| matches!(e, VirtualHandEffect::DropItem { .. }))
+            );
+        }
+        input.left_hand.squeeze_value = 0.0;
+        input.right_hand.squeeze_value = 0.0;
+        for expected_drops in [2, 0] {
+            let effects = interaction.update(&InteractionContext {
+                physics: &physics,
+                world: &world,
+                input: &input,
+                player_pos: vec3(0.0, 0.0, 0.0),
+                player_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                eye_height: 1.04,
+                step_dt: 1.0 / 60.0,
+                support_enabled: false,
+            });
+            assert_eq!(
+                effects
+                    .iter()
+                    .filter(|e| matches!(e, VirtualHandEffect::DropItem { .. }))
+                    .count(),
+                expected_drops
+            );
+            assert_eq!(interaction.held_entities(), (None, None));
+        }
+    }
 
     /// #787: flat mode only has one wield slot, so restoring a VR save with
     /// two held items must retain the first grab's displacement effects. The

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -53,6 +53,8 @@ pub struct VirtualHand {
     rotation: Quaternion<f32>,
     trigger_value: f32,
     squeeze_value: f32,
+    // A restored hold has no physical squeeze yet. Arm release after the first squeeze.
+    restored_grip_pending: bool,
     raytrace_hit: Option<RayCastResult>,
 
     // Keep track of last frobbed entity so frobbing is 'semi-auto'
@@ -155,6 +157,7 @@ impl VirtualHand {
             },
             trigger_value: 0.0,
             squeeze_value: 0.0,
+            restored_grip_pending: false,
             raytrace_hit: None,
             last_frobbed_entity: None,
             hand_state: HandState::Empty,
@@ -162,6 +165,10 @@ impl VirtualHand {
             feedback: HandFeedback::default(),
         }
     }
+    pub(crate) fn preserve_restored_grip(&mut self) {
+        self.restored_grip_pending = self.get_held_entity().is_some();
+    }
+
     pub fn destroy_entity(&self, entity_to_destroy_id: EntityId) -> VirtualHand {
         match self.hand_state {
             // Nothing to do here!
@@ -241,6 +248,7 @@ impl VirtualHand {
 
         VirtualHand {
             hand_state: HandState::Grabbing { entity_id },
+            restored_grip_pending: false,
             feedback: HandFeedback::default(),
             ..self.clone()
         }
@@ -298,7 +306,7 @@ impl VirtualHand {
                 let mut msgs = Vec::new();
 
                 // If we're holding onto something, but not grabbing, we can drop it
-                if input_hand.squeeze_value < 0.5 {
+                if input_hand.squeeze_value < 0.5 && !prev.restored_grip_pending {
                     let mut msgs = vec![VirtualHandEffect::DropItem { entity_id }];
 
                     // Releasing a tool against the weapon in the other hand is
@@ -336,6 +344,7 @@ impl VirtualHand {
                         rotation: hand_rotation,
                         trigger_value: input_hand.trigger_value,
                         squeeze_value: input_hand.squeeze_value,
+                        restored_grip_pending: false,
                         raytrace_hit: None,
                         last_frobbed_entity: None,
                         hand_state: HandState::Empty,
@@ -388,6 +397,8 @@ impl VirtualHand {
                         rotation: hand_rotation,
                         trigger_value: input_hand.trigger_value,
                         squeeze_value: input_hand.squeeze_value,
+                        restored_grip_pending: prev.restored_grip_pending
+                            && input_hand.squeeze_value < 0.5,
                         raytrace_hit: None,
                         last_frobbed_entity: None,
                         hand_state: next_hand_state,
@@ -641,6 +652,7 @@ fn handle_empty_hand_state(
         rotation: hand_rotation,
         trigger_value: input_hand.trigger_value,
         squeeze_value: input_hand.squeeze_value,
+        restored_grip_pending: false,
         raytrace_hit: result,
         last_frobbed_entity,
         hand_state: next_hand_state,

--- a/tools/shock2-sdk/test/vr-cold-load-held.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cold-load-held.e2e.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "VR cold load retains a physical Wrench through neutral startup and deliberate release",
+  {
+    skip: !e2eEnabled,
+    timeout: 600_000,
+  },
+  async () => {
+    const saveName = `vr_cold_load_held_${Date.now()}`;
+    try {
+      {
+        await using game = await GameServer.launch({
+          mission: "command2.mis",
+          debugFlags: ["--vr"],
+        });
+        await game.step({ frames: 10 });
+        const wrench = (
+          await game.entities.list({ filter: "Wrench", limit: 30 })
+        ).entities.find((e) => e.template_id === 786);
+        assert.ok(wrench, "authored command2 Wrench exists");
+        await game.player.teleport({
+          x: wrench.position[0],
+          y: wrench.position[1] - 1.4,
+          z: wrench.position[2] + 1.2,
+        });
+        await game.step({ frames: 2 });
+        await aimVrHandAt(game, wrench.position, 0.2, 1);
+        assert.equal(
+          (await game.info()).player.right_hand_entity_id,
+          wrench.id,
+        );
+        await game.input.set("right_hand.position", [0.2, 2.3, -0.45]);
+        await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+        await game.step({ frames: 20 });
+        assert.equal(
+          (await game.info()).player.right_hand_entity_id,
+          wrench.id,
+        );
+        assert.equal((await game.save(saveName)).success, true);
+      }
+      {
+        // A new runtime supplies genuinely neutral input; no squeeze is injected.
+        await using game = await GameServer.launch({
+          mission: "command2.mis",
+          debugFlags: ["--vr"],
+        });
+        assert.equal((await game.load(saveName)).success, true);
+        await game.input.set("right_hand.position", [0.2, 2.3, -0.45]);
+        await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+        await game.step({ frames: 5 });
+        const held = (await game.info()).player.right_hand_entity_id;
+        assert.notEqual(
+          held,
+          null,
+          "cold-loaded Wrench must survive neutral startup frames",
+        );
+        const detail = await game.entities.detail(held!);
+        assert.equal(
+          detail.properties.find((p) => p.name === "Model")?.value,
+          "wrench_h",
+        );
+        assert.ok(
+          (await game.scene.objects({ entityId: held! })).objects.length > 0,
+          "restored Wrench is rendered",
+        );
+        await game.step({ frames: 60 });
+        assert.equal((await game.info()).player.right_hand_entity_id, held);
+        // Strike the shipped one-HP pane while startup squeeze is still neutral.
+        // Same physical sweep as vr-melee-contact: ownership restored from disk
+        // must also retain the real WeaponBash damage path.
+        const pane = (
+          await game.entities.list({ filter: "Window 2", limit: 30 })
+        ).entities.find((e) => e.template_id === 82);
+        assert.ok(pane);
+        await game.player.teleport({
+          x: pane.position[0],
+          y: pane.position[1] - 1.04,
+          z: pane.position[2] - 2.6,
+        });
+        await game.input.set("right_hand.position", [0.7, 0.45, 0.3]);
+        await game.step({ frames: 30 });
+        const beforeAttack =
+          (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+        for (let frame = 1; frame <= 60; frame++) {
+          const t = frame / 60;
+          await game.input.set("right_hand.position", [
+            0.7 + (0.05 - 0.7) * t,
+            0.45,
+            0.3 + (3.4 - 0.3) * t,
+          ]);
+          await game.step({ frames: 1 });
+        }
+        const impacts = (await game.messages.recent()).messages.filter(
+          (m) => m.sequence > beforeAttack && m.to.entity_id === pane.id,
+        );
+        assert.ok(
+          impacts.some((m) => m.payload === "Damage"),
+          "restored Wrench deals physical melee damage",
+        );
+        assert.ok(
+          impacts.some((m) => m.payload === "Slay"),
+          "authored one-HP pane breaks",
+        );
+        assert.equal((await game.info()).player.right_hand_entity_id, held);
+        await game.input.set("right_hand.squeeze", 1);
+        await game.step({ frames: 5 });
+        assert.equal((await game.info()).player.right_hand_entity_id, held);
+        await game.input.set("right_hand.squeeze", 0);
+        await game.step({ frames: 5 });
+        assert.equal((await game.info()).player.right_hand_entity_id, null);
+        assert.equal(
+          (await game.entities.detail(held!)).properties.find(
+            (p) => p.name === "Model",
+          )?.value,
+          "wrench_w",
+        );
+        assert.equal(
+          (await game.physics.bodies({ entityId: held! })).bodies.length,
+          1,
+          "release creates exactly one loose item body",
+        );
+      }
+    } finally {
+      if (process.env.DARK_ASSET_PATH)
+        rmSync(join(process.env.DARK_ASSET_PATH, "saves", `${saveName}.sav`), {
+          force: true,
+        });
+    }
+  },
+);


### PR DESCRIPTION
Cold-loading a VR save restored held items only until the first neutral-input update, which immediately dropped them. Restored hands now retain ownership until their first physical squeeze arms normal release; ordinary grabs and flat restoration retain their existing behavior.

The real save/load path has a negative-first regression: on base `d5586abb`, the authored Command2 Wrench disappears from the right hand after five neutral frames. With the fix it remains held/rendered, then physically smashes an authored one-HP pane before any squeeze is injected. Squeezing and releasing afterward drops one loose body.

Validation:
- Negative unit test: both restored hands became empty on the first neutral frame before the fix.
- Restored VR both-hand neutral/held/release regression and existing flat two-hand displacement test: 2 passed.
- Authored Command2 cold-load/render/melee/release SDK scenario: passed again after rebase (56s); exact-base executable fails the neutral-startup ownership assertion (46s).
- Existing flat-load-from-VR-two-hand-save SDK scenario: passed (16s).
- Rust library suite after rebase: 1,721 passed, 2 ignored.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed after rebase.
- `cargo fmt --all -- --check` and SDK unit suite: passed.
- Full SDK E2E suite running on final branch; result will be added before delivery.

All runtime checks explicitly use `DARK_ASSET_PATH=/Users/bryan/ss2-25th`, verified by `sshock2.kpf` and remaster `mods/` archives.

Visual proof follows below. Captured fix source corresponds to pre-rebase commit `73537a9`; it was rebased onto `804fdd9e` (the unrelated flat-melee range fix), with no change to the VR implementation.

Fixes #1143

![Cold-load held wrench comparison](https://gist.githubusercontent.com/tommy-xr/69b971c475d46b25913385bc1c9a4db5/raw/cold-load.gif)

Saved with a physically grabbed wrench, then loaded in a fresh VR process with neutral grip input. Before, the first update drops the wrench; after, it remains attached. Both sides replay the same deterministic Earth mission sequence against base `d5586abb` and fix `73537a9` (identical VR source before rebasing), with `DARK_ASSET_PATH=/Users/bryan/ss2-25th` (`sshock2.kpf` and remaster `mods/`). The detached camera frames the saved hand position.

![Before and after cold loading](https://gist.githubusercontent.com/tommy-xr/69b971c475d46b25913385bc1c9a4db5/raw/before-after.png)

![Restored wrench remains held](https://gist.githubusercontent.com/tommy-xr/69b971c475d46b25913385bc1c9a4db5/raw/after.png)
