### PR TITLE
feat(hud): mount cuff ammo meters and emphasize compact readouts

### DIFF
--- a/.claude/skills/vr-ui-design/SKILL.md
+++ b/.claude/skills/vr-ui-design/SKILL.md
@@ -180,8 +180,14 @@ remaining gap - PR/issue and open/closed state are marked where it matters.
   back. `hud/virtual_arms.rs::wrist_panel_transform` places the bio readout at
   the wrist facing dorsally. The held weapon's ammo/psi readout caps the cuff
   opening where the arm enters, facing back along the forearm (local -Y),
-  with text up toward local +Z. Treat offsets as glove-specific fit values, not a
-  general UI spacing rule.
+  rotated 90 degrees counterclockwise as viewed face-on and sized inside the
+  cuff rim. Apply this roll in the panel plane after the cuff-facing rotation.
+  Treat offsets and size as glove-specific fit values, not a general UI spacing rule.
+- The compact gun layout lives in `hud/ammo_panel.rs::emit`, shared by the
+  flat HUD and glove: bold centered count, ammo icon left, condition badge
+  upper right, and ammo type/current fire mode below. The expanded interface
+  reserves room for its clickable controls. Bound type and mode separately so
+  long authored tags cannot displace the mode; resolve both from that hand's gun.
 - `interaction.rs` passes the final visible hand poses into
   `create_wrist_hud_panels`; preserve this attachment so weapon physics and
   support grips move glove and readout together. Mirrored hands already have

--- a/.claude/skills/vr-ui-design/SKILL.md
+++ b/.claude/skills/vr-ui-design/SKILL.md
@@ -173,6 +173,24 @@ remaining gap - PR/issue and open/closed state are marked where it matters.
     gun/psi-amp combinations. Preserve the complete authored UI canvas when
     mounting it on a glove; avoid arbitrary cropping to make it fit.
 
+## Glove readout implementation notes
+
+- `hand_glove::GloveRenderer::wrist_frame` provides the calibrated mount:
+  local +Y runs from wrist toward fingers and +Z points out of the glove's
+  back. `hud/virtual_arms.rs::wrist_panel_transform` places the bio readout at
+  the wrist facing dorsally. The held weapon's ammo/psi readout caps the cuff
+  opening where the arm enters, facing back along the forearm (local -Y),
+  with text up toward local +Z. Treat offsets as glove-specific fit values, not a
+  general UI spacing rule.
+- `interaction.rs` passes the final visible hand poses into
+  `create_wrist_hud_panels`; preserve this attachment so weapon physics and
+  support grips move glove and readout together. Mirrored hands already have
+  readable bases from `wrist_frame`; do not mirror the text a second time.
+- For a flush mount, inspect the cuff opening end-on for legibility and an
+  oblique view for clipping or a floating gap, with a weapon actually held. Check both
+  hands. Keep the shared canvas layout intact while adjusting its mount;
+  verify comfort and glance readability in-headset before calling the fit final.
+
 ## Evidence for physical interactions
 
 20. **Pair pictures with state assertions.** Before/after screenshots can show a

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -43,6 +43,14 @@ pub(crate) const CONDITION: Rect = Rect::new(235.0, 14.0, 14.0, 14.0);
 /// Ammo-type label (std/he/ap), across the bottom of the gauge well.
 pub(crate) const TYPE_LABEL: Rect = Rect::new(198.0, 42.0, 51.0, 13.0);
 
+// The passive compact meter can use the space occupied by the cycle control
+// in use mode. Flat HUD and glove emit this same layout, in panel pixels.
+const COMPACT_ICON: Rect = Rect::new(177.0, 24.0, 16.0, 16.0);
+const COMPACT_COUNT: Rect = Rect::new(194.0, 15.0, 39.0, 28.0);
+const COMPACT_TYPE: Rect = Rect::new(177.0, 43.0, 29.0, 12.0);
+const COMPACT_MODE: Rect = Rect::new(208.0, 43.0, 41.0, 12.0);
+const COMPACT_DETAIL: Rect = Rect::new(177.0, 43.0, 72.0, 12.0);
+
 /// The ammo-type cycle button (the original's `ammoarw` hotspot, 12x41 art).
 pub(crate) const CYCLE_BUTTON: Rect = Rect::new(186.0, 15.0, 12.0, 41.0);
 /// The fire-mode SETTING button. Its label is the gun's current mode header
@@ -204,7 +212,7 @@ pub(crate) struct AmmoReadout {
     /// condition to wear down (the psi amp, a melee weapon).
     pub gun_condition: Option<&'static str>,
     /// The wielded gun's current fire-mode header ("NORM"/"BURST"/"AUTO") -
-    /// the SETTING button's label. Absent when the gun names no header.
+    /// the compact mode indicator and SETTING button label. Absent when unnamed.
     pub gun_setting_header: Option<String>,
     /// The weapon offers a different projectile type to switch to.
     pub can_cycle_ammo: bool,
@@ -374,22 +382,41 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
                 VAlign::Middle,
             );
     } else if let Some(rounds) = readout.ammo {
-        canvas.text_native(
-            at(origin, COUNT),
+        let compact = !readout.show_buttons;
+        canvas.text(
+            at(origin, if compact { COMPACT_COUNT } else { COUNT }),
             &format!("{rounds}"),
-            FONT,
+            if compact { "bignum.fon" } else { FONT },
+            if compact { 24.0 } else { 0.0 },
             HAlign::Center,
             VAlign::Middle,
         );
         if let Some(icon) = &readout.ammo_icon {
-            canvas.image(at(origin, ICON), icon);
+            canvas.image(at(origin, if compact { COMPACT_ICON } else { ICON }), icon);
         }
         if let Some(badge) = readout.gun_condition {
             canvas.image(at(origin, CONDITION), badge);
         }
-        if let Some(ammo_type) = &readout.ammo_type {
-            // Ellipsized: the class tag is data ("std", but also "lasershot"),
-            // and an over-wide label would spill out of the gauge well.
+        if compact {
+            // Keep each label's space independent: a long authored ammo tag
+            // must not push the current fire mode off the meter.
+            let paired = readout.ammo_type.is_some() && readout.gun_setting_header.is_some();
+            for (label, rect) in [
+                (&readout.ammo_type, COMPACT_TYPE),
+                (&readout.gun_setting_header, COMPACT_MODE),
+            ] {
+                if let Some(label) = label {
+                    canvas.text_fit(
+                        at(origin, if paired { rect } else { COMPACT_DETAIL }),
+                        &label.to_ascii_uppercase(),
+                        FONT,
+                        10.0,
+                        HAlign::Center,
+                        VAlign::Middle,
+                    );
+                }
+            }
+        } else if let Some(ammo_type) = &readout.ammo_type {
             canvas.text_native_fit(
                 at(origin, TYPE_LABEL),
                 &ammo_type.to_ascii_uppercase(),
@@ -631,7 +658,7 @@ mod tests {
                 .iter()
                 .find_map(|element| match element {
                     crate::ui::UiElement::Text { text, position, .. }
-                        if *position == vec2(COUNT.x, COUNT.y) =>
+                        if *position == vec2(COMPACT_COUNT.x, COMPACT_COUNT.y) =>
                     {
                         Some(text.clone())
                     }
@@ -697,6 +724,44 @@ mod tests {
     }
 
     #[test]
+    fn compact_meter_keeps_type_and_live_mode_below_the_bold_count() {
+        let mut readout = AmmoReadout {
+            show_buttons: false,
+            ..full_gun()
+        };
+        for mode in ["NORM", "BURST", "OVERLOAD"] {
+            readout.gun_setting_header = Some(mode.to_string());
+            let canvas = build_readout_canvas(&readout);
+            let labels: Vec<_> = canvas
+                .elements()
+                .iter()
+                .filter_map(|element| match element {
+                    crate::ui::UiElement::Text {
+                        text,
+                        position,
+                        font,
+                        font_size,
+                        ..
+                    } => Some((text.as_str(), *position, font.as_str(), *font_size)),
+                    _ => None,
+                })
+                .collect();
+            assert!(labels.contains(&(
+                "12",
+                vec2(COMPACT_COUNT.x, COMPACT_COUNT.y),
+                "bignum.fon",
+                24.0
+            )));
+            assert!(labels.contains(&("STD", vec2(COMPACT_TYPE.x, COMPACT_TYPE.y), FONT, 10.0)));
+            assert!(labels.contains(&(mode, vec2(COMPACT_MODE.x, COMPACT_MODE.y), FONT, 10.0)));
+        }
+        assert!(COMPACT_COUNT.y + COMPACT_COUNT.h <= COMPACT_TYPE.y);
+        assert!(COMPACT_ICON.x + COMPACT_ICON.w <= COMPACT_COUNT.x);
+        assert!(COMPACT_COUNT.x + COMPACT_COUNT.w <= CONDITION.x);
+        assert!(COMPACT_TYPE.x + COMPACT_TYPE.w <= COMPACT_MODE.x);
+    }
+
+    #[test]
     fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
         // Tier badge + discipline name = 2, and the amp's meaningless clip is
         // suppressed exactly as in flat.
@@ -716,6 +781,10 @@ mod tests {
             COUNT,
             ICON,
             TYPE_LABEL,
+            COMPACT_COUNT,
+            COMPACT_ICON,
+            COMPACT_TYPE,
+            COMPACT_MODE,
             CONDITION,
             CYCLE_BUTTON,
             SETTING_BUTTON,
@@ -752,6 +821,10 @@ mod tests {
             COUNT,
             ICON,
             TYPE_LABEL,
+            COMPACT_COUNT,
+            COMPACT_ICON,
+            COMPACT_TYPE,
+            COMPACT_MODE,
             CONDITION,
             PSI_TIER_BADGE,
             PSI_POWER_NAME,

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -86,19 +86,21 @@ pub fn create_wrist_hud_panels(
 
 /// Wrist-frame +Z points out of the glove's back; +Y points toward its fingers.
 /// Bio faces dorsally. Ammo caps the cuff opening and faces back along the
-/// forearm, with the top of its text toward the back of the hand.
+/// forearm, rotated counterclockwise in its face plane to fit inside the rim.
 fn wrist_panel_transform(
     root: Matrix4<f32>,
     canvas_size: cgmath::Vector2<f32>,
     ammo: bool,
 ) -> Matrix4<f32> {
-    const WIDTH: f32 = 0.085;
+    let width = if ammo { 0.058 } else { 0.085 };
     let mount = if ammo {
-        Matrix4::from_translation(vec3(0.0, -0.033, 0.0)) * Matrix4::from_angle_x(Deg(90.0))
+        Matrix4::from_translation(vec3(0.0, -0.033, -0.005))
+            * Matrix4::from_angle_x(Deg(90.0))
+            * Matrix4::from_angle_z(Deg(90.0))
     } else {
         Matrix4::from_translation(vec3(0.0, -0.015, 0.04))
     };
-    root * mount * Matrix4::from_nonuniform_scale(WIDTH, WIDTH * canvas_size.y / canvas_size.x, 1.0)
+    root * mount * Matrix4::from_nonuniform_scale(width, width * canvas_size.y / canvas_size.x, 1.0)
 }
 
 /// Get player health percentage (0.0 to 1.0)

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Compact readouts ride the calibrated visible glove, not the raw controller.
-/// Both wrists show health/psi dorsally; each underside shows only its own weapon.
+/// Both wrists show health/psi; each cuff opening shows only its own weapon.
 pub fn create_wrist_hud_panels(
     asset_cache: &mut AssetCache,
     world: &World,
@@ -57,7 +57,7 @@ pub fn create_wrist_hud_panels(
         ) {
             continue;
         }
-        for (under, canvas) in [
+        for (ammo, canvas) in [
             (false, readouts::build_watch_canvas(&bio)),
             (
                 true,
@@ -73,7 +73,7 @@ pub fn create_wrist_hud_panels(
             }
             objects.extend(canvas.render_world_space(
                 asset_cache,
-                wrist_panel_transform(root, canvas.size(), under, hand),
+                wrist_panel_transform(root, canvas.size(), ammo),
                 None,
                 None,
                 0.001,
@@ -85,27 +85,20 @@ pub fn create_wrist_hud_panels(
 }
 
 /// Wrist-frame +Z points out of the glove's back; +Y points toward its fingers.
-/// The underside turns around +Y so glyphs remain readable, never mirrored.
+/// Bio faces dorsally. Ammo caps the cuff opening and faces back along the
+/// forearm, with the top of its text toward the back of the hand.
 fn wrist_panel_transform(
     root: Matrix4<f32>,
     canvas_size: cgmath::Vector2<f32>,
-    under: bool,
-    hand: Handedness,
+    ammo: bool,
 ) -> Matrix4<f32> {
     const WIDTH: f32 = 0.085;
-    // The bio face runs around the wrist like a bracelet. Keep the ammo
-    // face oriented for an across-body underside glance.
-    let roll = if !under {
-        0.0
-    } else if hand == Handedness::Right {
-        -90.0
+    let mount = if ammo {
+        Matrix4::from_translation(vec3(0.0, -0.033, 0.0)) * Matrix4::from_angle_x(Deg(90.0))
     } else {
-        90.0
+        Matrix4::from_translation(vec3(0.0, -0.015, 0.04))
     };
-    root * Matrix4::from_translation(vec3(0.0, -0.015, if under { -0.06 } else { 0.04 }))
-        * Matrix4::from_angle_y(Deg(if under { 180.0 } else { 0.0 }))
-        * Matrix4::from_angle_z(Deg(roll))
-        * Matrix4::from_nonuniform_scale(WIDTH, WIDTH * canvas_size.y / canvas_size.x, 1.0)
+    root * mount * Matrix4::from_nonuniform_scale(WIDTH, WIDTH * canvas_size.y / canvas_size.x, 1.0)
 }
 
 /// Get player health percentage (0.0 to 1.0)
@@ -276,15 +269,10 @@ mod tests {
     use cgmath::{InnerSpace, SquareMatrix};
 
     #[test]
-    fn opposite_watch_faces_are_outward_and_text_is_never_mirrored() {
-        for (under, hand) in [
-            (false, Handedness::Left),
-            (true, Handedness::Left),
-            (false, Handedness::Right),
-            (true, Handedness::Right),
-        ] {
+    fn glove_readouts_are_outward_and_text_is_never_mirrored() {
+        for ammo in [false, true] {
             let transform =
-                wrist_panel_transform(Matrix4::identity(), cgmath::vec2(128.0, 44.0), under, hand);
+                wrist_panel_transform(Matrix4::identity(), cgmath::vec2(128.0, 44.0), ammo);
             let normal = transform.z.truncate();
             assert!(normal.dot(transform.w.truncate()) > 0.0);
             assert!(transform.determinant() > 0.0);

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -793,6 +793,19 @@ where
         self.push_text(rect, text, font, 0.0, h, v, true)
     }
 
+    /// Explicitly sized text, ellipsized by the shared layout pass to its rect.
+    pub fn text_fit(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        font: &str,
+        size: f32,
+        h: HAlign,
+        v: VAlign,
+    ) -> &mut Self {
+        self.push_text(rect, text, font, size, h, v, true)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn push_text(
         &mut self,


### PR DESCRIPTION
Move each held weapon’s VR ammo/psi meter into the glove’s cuff opening, where the arm would enter. The meter faces back along the forearm, rotates 90° counterclockwise when viewed face-on, and fits inside the rim.

The shared compact meter now emphasizes a large, solid bold ammo count, with the ammo icon on the left and condition badge at the upper right. Ammo type and current fire mode sit below in separately bounded labels. Flat and VR use this same compact layout; the expanded cyber interface keeps its interactive layout. The VR UI skill documents the mounting frame and fit checks.

Validation:

- 73 HUD tests and 231 UI tests pass; workspace formatting and skill validation pass.
- Deterministic captures with 25AE assets cover both hands and pistol, shotgun, laser pistol, fusion cannon, worm launcher, and viral proliferator in VR and flat presentation, including alternate fire modes.
- Known visibility limitation: the shotgun stock hides most or all of the cuff meter, and worm-launcher geometry partly obscures the count/type, including checked oblique views. The gallery preserves those cases. Headset comfort remains to be tried.

![Cuff ammo meter rotating view](https://gist.githubusercontent.com/tommy-xr/e3e7249d1ed69da0ae37defc32c5ac40/raw/f89d96fdb6342708b6fa0f4ca06ed7b7cf42463f/after-right.gif)

![Before and after, cuff placement and compact layout](https://gist.githubusercontent.com/tommy-xr/e3e7249d1ed69da0ae37defc32c5ac40/raw/062239734eb6ff38b4503b2f7b2ba8ac0fc13598/before-after.png)

![Weapon and mode checks in VR and flat, including occlusion cases](https://gist.githubusercontent.com/tommy-xr/e3e7249d1ed69da0ae37defc32c5ac40/raw/ac861421fd1520d3a7990d83433e8098c66e97e5/weapon-gallery.png)
