### PR TITLE
test(vr): quarantine intermittent ragdoll handoff

### DIFF
--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -721,7 +721,13 @@ test(
 
 test(
   "a lethal VR Wrench contact seeds the death ragdoll along the physical swing",
-  { skip: !e2eEnabled, timeout: 600_000 },
+  {
+    // Main intermittently never creates a ragdoll after a confirmed lethal hit.
+    // Re-enable once the experimental ragdoll handoff is stable; retain this
+    // scenario so stabilization can restore its physical-impact coverage.
+    skip: "Experimental ragdoll handoff is intermittent; pending stabilization",
+    timeout: 600_000,
+  },
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",


### PR DESCRIPTION
The experimental ragdoll handoff intermittently fails after a confirmed lethal VR Wrench hit. Temporarily skip that scenario with an explicit reason, retaining its implementation for re-enabling once ragdolls stabilize. Other melee and ragdoll tests stay enabled.

On unchanged main `804fdd9e`, the scenario passed twice and then failed with `the contact kill should hand off to one ragdoll` (0 versus 1). The same failure appeared in the #1512 full-suite run. This test quarantine was requested while reviewing that run.

Validation: SDK unit suite 63 passed, 0 failed; explicitly enabling E2E and selecting the scenario reports 1 skipped with the stabilization reason; Rust format check passed. Test-only change with no product rendering or behavior change, so rendered before/after media does not apply.
