### PR TITLE
feat: add radiation and toxin damage with a VR wrist HUD

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -20,6 +20,7 @@ pub struct Gamesys {
     hrm_params: Option<HrmParams>,
     /// Skill-system tuning (`SKILLPARAM` file-var chunk).
     skill_params: Option<SkillParams>,
+    hazard_params: Option<crate::gamesys::HazardParams>,
 }
 
 impl Gamesys {
@@ -69,6 +70,10 @@ impl Gamesys {
         self.hrm_params.as_ref()
     }
 
+    pub fn hazard_params(&self) -> Option<&crate::gamesys::HazardParams> {
+        self.hazard_params.as_ref()
+    }
+
     pub fn skill_params(&self) -> Option<&SkillParams> {
         self.skill_params.as_ref()
     }
@@ -97,6 +102,7 @@ pub fn read<T: io::Read + io::Seek>(
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
     let hrm_params = HrmParams::read(&table_of_contents, reader);
     let skill_params = SkillParams::read(&table_of_contents, reader);
+    let hazard_params = crate::gamesys::HazardParams::read(&table_of_contents, reader);
 
     // Uncomment to output debug info for voices:
     // debug_print_voices(&sound_schema, &speech_db);
@@ -110,5 +116,6 @@ pub fn read<T: io::Read + io::Seek>(
         trainer_costs,
         hrm_params,
         skill_params,
+        hazard_params,
     }
 }

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -202,3 +202,59 @@ mod tests {
         assert_eq!(parsed.inaccuracy_degrees, 11.25);
     }
 }
+
+/// Endurance damage multipliers from STATPARAM (six header fields, eight floats).
+#[derive(Debug, Clone)]
+pub struct HazardParams(pub [f32; 8]);
+impl HazardParams {
+    pub fn read<T: io::Read + io::Seek>(
+        toc: &ChunkFileTableOfContents,
+        reader: &mut T,
+    ) -> Option<Self> {
+        let chunk = toc.get_chunk("STATPARAM".to_owned())?;
+        if chunk.length < 56 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset + 24)).ok()?;
+        let mut values = [0.0; 8];
+        for value in &mut values {
+            *value = reader.read_f32::<LittleEndian>().ok()?;
+            if !value.is_finite() || *value < 0.0 {
+                return None;
+            }
+        }
+        Some(Self(values))
+    }
+}
+
+#[cfg(test)]
+mod hazard_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn hazard_table_follows_six_stat_fields_and_respects_chunk_bounds() {
+        // Minimal chunk file. sStatParams is four ints, two floats, eight
+        // hazard floats; the extra 24 bytes here are NOT a chunk header.
+        let mut bytes = vec![0_u8; 512];
+        bytes[..4].copy_from_slice(&400_u32.to_le_bytes());
+        bytes[400..404].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[404..413].copy_from_slice(b"STATPARAM");
+        bytes[416..420].copy_from_slice(&280_u32.to_le_bytes());
+        bytes[420..424].copy_from_slice(&56_u32.to_le_bytes());
+        for (i, value) in [30_i32, 5, 20, 5, 0, 0].into_iter().enumerate() {
+            bytes[304 + 4 * i..308 + 4 * i].copy_from_slice(&value.to_le_bytes());
+        }
+        let expected = [1.0_f32, 0.94, 0.85, 0.73, 0.58, 0.4, 0.2, 0.01];
+        for (i, value) in expected.iter().enumerate() {
+            bytes[328 + 4 * i..332 + 4 * i].copy_from_slice(&value.to_le_bytes());
+        }
+        let mut reader = Cursor::new(bytes.clone());
+        let toc = crate::ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+        assert_eq!(HazardParams::read(&toc, &mut reader).unwrap().0, expected);
+        bytes[420..424].copy_from_slice(&52_u32.to_le_bytes());
+        let mut reader = Cursor::new(bytes);
+        let toc = crate::ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+        assert!(HazardParams::read(&toc, &mut reader).is_none());
+    }
+}

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -350,6 +350,18 @@ pub struct PropRadiationAbsorb(pub f32);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropRadiationDrain(pub f32);
 
+/// Authored room radiation ceiling (also used on radiating objects).
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRadiationLevel(pub f32);
+
+/// Retail armor layout: toxic, radiation, combat percentages.
+#[derive(Debug, Component, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct PropArmor {
+    pub toxic: f32,
+    pub radiation: f32,
+    pub combat: f32,
+}
+
 /// A container's inventory grid, in cells. The `Contains` link's ordinal is
 /// `y * width + x` against *this* width, so it is what makes a stored cell
 /// mean anything.
@@ -1882,6 +1894,22 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$RenderAlp",
             |reader, _len| read_single(reader),
             PropRenderAlpha,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RadLevel",
+            |reader, _| read_single(reader),
+            PropRadiationLevel,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Armor",
+            |reader, _| PropArmor {
+                toxic: read_single(reader),
+                radiation: read_single(reader),
+                combat: read_single(reader),
+            },
+            identity,
             accumulator::latest,
         ),
         define_prop(

--- a/projects/radiation-toxins.md
+++ b/projects/radiation-toxins.md
@@ -90,10 +90,16 @@ so transient stimulus refresh does not incorrectly display residual radiation.
 Flat use mode emits the widget only through the cyber canvas.
 
 VR mounts the same canvas below the existing left glove bio bracelet, at 0.16 m
-width. It remains available when the hand's glove mesh is hidden by a held item.
+width, deliberately larger than the 8.5 cm bio bracelet so the original toxin
+pips and radiation art can be inspected. That size and the extra hologram depth
+are provisional, not a validated comfort choice. It remains available when the hand's glove mesh is hidden by a held item.
 Radiation damage uses the existing peripheral damage-feedback layer tinted green,
 with the authored `raddmg` sound. This adapts the original full-screen green fade
-without adding a separate full-field VR flash.
+without adding a separate full-field VR flash. Visual review flags the saturated
+green tint and its contrast against green HUD art for the headset tuning pass.
+The sound database also contains environmental Geiger schemas (`ms_geigerf`,
+`eng_geigers`, etc.) using `geigerF1/F2`, `geigerS1/S2` and `geigerB1/B2`;
+this change confirms player damage audio, not every mission ambient sound.
 
 Deterministic flat, wrist and cyber PNG/GIF comparisons have been captured and
 inspected. A separate END1 scenario at frame 360 confirms HP 30→12, radiation
@@ -110,7 +116,11 @@ clocks and serialization phase. Runtime scenarios exercise actual player damage,
 Endurance, patch consumption and suit mitigation, plus the existing authored
 medsci2 Rad Barrel/Rad Patch scenario. Save/load verifies contamination and
 suit protection across entity remapping. A psi-amp cast verifies Toxin Shield
-protection and expiry. The full SDK suite is run before landing.
+protection and expiry. All 275 SDK test files were exercised across the initial
+batch, clean retries and remaining batch. The remaining 201-file batch finished
+with 524 passing tests, 24 failures and 10 skips. Every failure was compared
+with the unchanged base; the baseline cases are listed below. Core unit tests
+finish with 1,702 passed and 2 ignored. Strict core/runtime checks and PR CI pass.
 
 Cross-engine review findings fixed: duplicate implant parser, lost radiate
 multiplier, unresearched WormHeart activation, Worm Skin script wiring, missing
@@ -135,6 +145,24 @@ unchanged `ae2eaf5a`, as well as this branch:
 - `medsci-saved-vr-melee.e2e`: the fresh-control monkey reaches 0 HP rather
   than the expected 1, before its save/transition portion.
 - `melee-hitbox.e2e`: the same extra target entry is reported on both branches.
+- `psi.e2e`: tries to lower PSI from 6 to 2 through raise-only provisioning.
+- `ranged-hitbox.e2e`: its centered shot produces no creature damage.
+- `shodan-live-assassin-support.e2e`: cannot find the expected mission object 649.
+- `sound-awareness.e2e`: the expected alertness remains Lowest.
+- `trap-unlock.e2e`: the locked Engineering button does not emit the expected
+  refusal sound.
+- `vr-body-calibration.e2e`: exact thigh-position equality fails on tiny drift.
+- `vr-cyber-interface-deposit.e2e`: the expected cell rectangle uses an older scale.
+- `vr-cyber-interface-pointer.e2e`: its backpack lookup includes the held-item readout.
+- `vr-gun-support.e2e`: both pistol-hand support cases fail at the same assertion.
+- `vr-gun-weight.e2e`: both AR hands fail to acquire the lowered support socket.
+- `vr-held-model.e2e`: the expected full pistol mesh count and left/right melee
+  contact-volume equality fail identically on the base.
+- `vr-interface-readouts.e2e`: its expected-control list omits Logs.
+- `vr-strength-recoil.e2e`: the AR support-grip assertion fails.
+- `vr-support-region.e2e`: both wrench support-grip assertions fail.
+- `vr-weapon-handedness.e2e`: the forearm readout emits 5 elements, expected 4.
+- `weapon-selection.e2e`: spawning template -28 fails during setup.
 
 These are recorded separately from the hazard scenarios; this feature does not
 change their expected behavior. All 23 authored mission-load checks pass.

--- a/projects/radiation-toxins.md
+++ b/projects/radiation-toxins.md
@@ -1,0 +1,140 @@
+# Radiation and toxins
+
+Implemented on `feat/radiation-toxins`, based on local main `ae2eaf5a`.
+Audit date: 2026-09-12. Evidence is the local Dark Engine source, shipped
+`Data/shock2.gam` and missions, and x86 disassembly of `Data/allobjs.osm`.
+The OSM is a stripped September 1999 PE32 DLL; no separate symbol file was
+found. Binary-derived formulas are documented below so they can be compared
+with other releases; remaster-specific script differences remain unverified.
+
+## Gameplay evidence and implementation
+
+`references/darkengine/src/shock/shkhazpr.h` declares separate ambient radiation,
+accumulated radiation, absorption/recovery and toxin properties. The existing
+`ActiveRadiation` save state now carries toxin severity and its timer too.
+
+| Behavior | Authored/retail value | Evidence |
+| --- | --- | --- |
+| Radiation absorption | every 0.1 s, player default 0.05 toward ambient ceiling | OSM 0x100149f0/0x1001683c; RadRoom -1280 |
+| Radiation damage | every 6 s, truncate(level × END multiplier × metabolism) | OSM 0x10014a33/0x10016e52, arithmetic 0x1001690d–0x100169c8 |
+| Radiation recovery | subtract authored RadRecover after damage when ambient is zero | OSM 0x10016c9c–0x10016dbe; player property is disk-truncated `P$RadRecove`, value 3 |
+| Toxin damage | every 10 s, truncate(max(1, severity × END multiplier × metabolism)) | OSM 0x10014a76/0x100172c5; minimum 0x10016fd9–0x10016ff0 |
+| Toxin recovery | no natural decay | no decay write in toxin timer |
+| Endurance multipliers, END 1–8 | 1, .94, .85, .73, .58, .4, .2, .01 | STATPARAM; `shkparam.h` sStatParams; `shkscrpt.cpp` GetHazardResistance |
+| Strong Metabolism | radiation ×.75, toxin ×.5 | OSM trait checks; trait 1 |
+| Rad Patch | -6 radiation, -7.2 with Pharmo-Friendly | OSM RadPatch; trait 2 |
+| Detox Patch | -2 toxin, -2.4 with Pharmo-Friendly | OSM 0x1002366c and multiplier branch |
+| Vacc Suit / Worm Skin | 75% / 30% radiation and toxin protection | `P$Armor` toxic/radiation/combat floats, templates -83/-84 |
+| WormHeart | suppress toxin damage while equipped; leave severity intact | OSM 0x10016efb, implant type 12 |
+
+Direct `radiate` and `toxin` reactions raise severity to the maximum of current
+and protected incoming intensity, rather than adding every hit. See
+`shkreact.cpp` reaction handlers. Contact and blast reactions preserve authored
+amplification and the existing radiate multiplier resolver. A review nuance:
+original `shkreact.cpp::radiate_func` does not use its `increm` parameter, while
+that pre-existing resolver does. Non-unit authored parameters need a separate
+compatibility check; this change reuses the existing behavior. Persistent radius emitters remain ambient
+sources and room entry/exit drives ambient exposure through the existing
+`internal_room_trigger` sensor forwarding, not physical colliders on room markers.
+Overlaps choose the highest ceiling, then the highest absorption rate on ties.
+This is a deterministic policy for this port's overlapping room sensors; it does
+not claim to reproduce retail's room-boundary dispatch order.
+
+The previous partial radiation implementation used level ×.25 for damage. The
+OSM arithmetic uses the full level before Endurance/trait scaling; this change
+corrects that approximation. Radiation below one clears during recovery.
+Simulation clocks use f64 and process absorption/damage chronologically, so
+large updates agree with 60 Hz stepping. Death resets both hazards; save/load
+and deck transitions preserve severity and timer phase. Ambient room ownership
+is rebuilt in the destination and is not carried as stale runtime entity IDs.
+
+### Protection and cures
+
+Room accumulation and direct reactions intentionally differ. Armor scales the
+room absorption rate, not its final ambient ceiling. Rad Shield's authored value
+5 divides room absorption; the direct reaction treats player armor as a percentage
+(`shkreact.cpp`). Do not unify these formulas without new retail evidence.
+Toxin Shield authors 100% protection. Both powers use the existing sustained-psi
+activation/duration system (10 + 5 × PSI seconds) and active durations now survive
+save/load and deck transitions. Named templates are -1113 Toxin Shield and -1114
+Rad Shield. Protection prevents new exposure, not existing damage.
+
+Frob equips one hazard armor and one WormHeart implant, using carried entity
+identity; equipped markers persist through saves/transitions. Research-required
+items cannot equip until their object state permits use. This is a minimal
+integration with existing inventory use, not a complete armor/implant slot UI.
+Strong Metabolism is now purchasable through the existing live-trait gate.
+
+Patches consume their exact source item only when they reduce contamination.
+`TrapRadCleanse` and `TrapToxinCleanse` clear player status on TurnOn.
+`FlushRadiation` / `EraseRadiation` clear environmental RadLevel and ambient ownership, preserving
+player contamination. Clearing all non-player RadLevel properties is intentional:
+`shkscrpt.cpp` localClearRadiation does precisely this, rather than following
+links from the invoking object. `EraseRadiation` calls the legacy RadiationHack
+service; FlushRadiation calls ClearRadiation (OSM 0x100392b0/0x10039350).
+`EngineRemoveRad` (0x10039620) additionally slays descendants of its authored
+ConsumeType, sets EngineRadClear to raw 1, unlocks EngineCoreDoor and shows
+its optional localized UseMsg. Its Engineering runtime test verifies that
+subsequent room entry does not add radiation and existing player contamination
+survives. Existing persistent radius-source scripts are separate from room
+RadLevel ownership.
+
+## Presentation
+
+One 128×66 pixel canvas supplies flat HUD, cyber interface and left wrist:
+original radiation art (`radback`, `radmeter`, `radicon`/`radgray`) and toxin pips
+(`poisicon`, native 25×32, stride 22). More than five pips show an overflow marker.
+The cyber interface always displays status; runtime readouts appear during
+exposure or contamination. Active ambient exposure is latched for rendering,
+so transient stimulus refresh does not incorrectly display residual radiation.
+Flat use mode emits the widget only through the cyber canvas.
+
+VR mounts the same canvas below the existing left glove bio bracelet, at 0.16 m
+width. It remains available when the hand's glove mesh is hidden by a held item.
+Radiation damage uses the existing peripheral damage-feedback layer tinted green,
+with the authored `raddmg` sound. This adapts the original full-screen green fade
+without adding a separate full-field VR flash.
+
+Deterministic flat, wrist and cyber PNG/GIF comparisons have been captured and
+inspected. A separate END1 scenario at frame 360 confirms HP 30→12, radiation
+18→15, green feedback and `raddmg`. These establish rendering and simulation,
+not headset comfort. No Quest was attached: physical readability, occlusion with
+both hands occupied and seated/standing placement still need device testing.
+Keep the wrist offset provisional; do not promote it to a vr-ui-design rule yet.
+
+## Validation and review
+
+Regression coverage includes persistent/non-stacking toxin, minimum damage,
+WormHeart suppression, timestep partitioning, zero absorption/recovery, paused
+clocks and serialization phase. Runtime scenarios exercise actual player damage,
+Endurance, patch consumption and suit mitigation, plus the existing authored
+medsci2 Rad Barrel/Rad Patch scenario. Save/load verifies contamination and
+suit protection across entity remapping. A psi-amp cast verifies Toxin Shield
+protection and expiry. The full SDK suite is run before landing.
+
+Cross-engine review findings fixed: duplicate implant parser, lost radiate
+multiplier, unresearched WormHeart activation, Worm Skin script wiring, missing
+live-trait gate, stale active-exposure indicator and duplicate flat use-mode HUD.
+Other review concerns (room sensor forwarding, distinct psi formulas and global
+environment cleanup) were checked against existing infrastructure and original
+source, as documented above.
+
+### Baseline regression failures
+
+The broad SDK run also exercises older features. These assertions reproduce on
+unchanged `ae2eaf5a`, as well as this branch:
+
+- `ammo-readout.e2e`: three expected-control lists omit the existing Logs button.
+- `creature-loot.e2e`: expects a log reader bound to a discarded pickup entity;
+  the reader reports the global panel identity instead.
+- `earth-hacking.e2e`: expects a nanite pickup to remain in inventory after
+  the existing auto-collection path has converted it to currency.
+- `impact-sounds.e2e`: the expected creature collision sound is absent.
+- `inventory-strength.e2e`: the VR blocked-cell rectangle differs from the
+  test's expected pixel rectangle, identically on both branches.
+- `medsci-saved-vr-melee.e2e`: the fresh-control monkey reaches 0 HP rather
+  than the expected 1, before its save/transition portion.
+- `melee-hitbox.e2e`: the same extra target entry is reported on both branches.
+
+These are recorded separately from the hazard scenarios; this feature does not
+change their expected behavior. All 23 authored mission-load checks pass.

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -905,6 +905,7 @@ pub struct PlayerInfo {
     pub max_psi_points: Option<i32>,
     /// Accumulated retail radiation level (0 when clear).
     pub radiation_level: f32,
+    pub toxin_level: f32,
     /// The gamesys name of the selected psi power (what the psi amp casts),
     /// e.g. "Cryokinesis". Cycle with the `CyclePsiPower` input action.
     pub selected_psi_power: Option<String>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2446,6 +2446,7 @@ fn capture_frame_snapshot(
                     .as_ref()
                     .and_then(|s| s.psi_points.map(|(_, max)| max)),
                 radiation_level: state.as_ref().map(|s| s.radiation_level).unwrap_or(0.0),
+                toxin_level: state.as_ref().map(|s| s.toxin_level).unwrap_or(0.0),
                 selected_psi_power: state.as_ref().and_then(|s| s.selected_psi_power.clone()),
                 psi_charge: state.as_ref().and_then(|s| s.psi_charge.map(|(f, _)| f)),
                 psi_charge_phase: state

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1178,6 +1178,10 @@ pub struct DebugPathfindingStats {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum DebugEntityMessage {
+    Hazard {
+        toxin: bool,
+        amount: f32,
+    },
     /// Deal `amount` damage (drives `InternalSimpleHealth` / AI health).
     /// `direction` (world-space, need not be normalized) and `point` optionally
     /// describe the blow so a death ragdoll reacts to it - same data a real
@@ -1198,7 +1202,9 @@ pub enum DebugEntityMessage {
     /// Frob (use) the entity.
     Frob,
     /// Send a named AI signal.
-    Signal { name: String },
+    Signal {
+        name: String,
+    },
     /// Force an AI's alertness level (clamped by its alert cap).
     SetAlertness {
         level: dark::properties::AIAlertLevel,
@@ -1210,7 +1216,9 @@ pub enum DebugEntityMessage {
     /// Set a gun's condition (`P$GunState`, 0..100). Not a script message:
     /// it writes the property directly, so a test can put a gun at the wear
     /// it wants without firing hundreds of rounds into it.
-    SetGunCondition { condition: f32 },
+    SetGunCondition {
+        condition: f32,
+    },
     /// Set an object's `P$ObjState` (Normal, Broken, ...) directly - e.g. to
     /// break a gun outright rather than waiting on its break roll.
     SetObjectState {

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -171,6 +171,7 @@ pub fn hurt_schema(damage: f32) -> &'static str {
 /// and asked for its current strength, and knows nothing about rendering.
 #[derive(Debug, Default)]
 pub struct HitFeedback {
+    radiation: bool,
     /// Strength the current hit started at.
     peak: f32,
     /// Total and remaining lifetime of the current hit, in seconds.
@@ -192,12 +193,19 @@ impl HitFeedback {
     /// the peak and the lifetime are the larger of the incoming hit and what
     /// is already on screen.
     pub fn trigger(&mut self, damage: f32) {
+        self.radiation = false;
         if damage <= 0.0 {
             return;
         }
         self.peak = peak_opacity(damage).max(self.intensity());
         self.duration = duration_secs(damage).max(self.remaining);
         self.remaining = self.duration;
+    }
+
+    /// Radiation uses the same comfortable rim geometry, tinted green.
+    pub fn trigger_radiation(&mut self, damage: f32) {
+        self.trigger(damage);
+        self.radiation = true;
     }
 
     /// Advance the decay by `delta_time_secs`.
@@ -237,6 +245,16 @@ impl HitFeedback {
         let intensity = self.intensity();
         if intensity <= 0.0 {
             return None;
+        }
+        if self.radiation {
+            return Some(vignette_layer(
+                view_extents,
+                eye_position,
+                eye_forward,
+                vec3(0.0, 1.0, 0.0),
+                intensity,
+                crate::util::render_source::HIT_FEEDBACK,
+            ));
         }
         Some(hit_layer(
             view_extents,

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -147,7 +147,7 @@ pub(crate) fn create_flat_hud(
     use_mode: bool,
     messages: &[String],
 ) -> Vec<SceneObject> {
-    let canvas = build_flat_hud_canvas(
+    let mut canvas = build_flat_hud_canvas(
         use_mode,
         get_health_percentage(world),
         get_psi_percentage(world),
@@ -157,6 +157,14 @@ pub(crate) fn create_flat_hud(
         &AmmoReadout::from_world(world, false),
         messages,
     );
+    if !use_mode {
+        super::hazards::emit(
+            &mut canvas,
+            super::hazards::SCREEN_ORIGIN,
+            &super::hazards::HazardReadout::from_world(world),
+            false,
+        );
+    }
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
 }

--- a/shock2vr/src/hud/hazards.rs
+++ b/shock2vr/src/hud/hazards.rs
@@ -1,0 +1,84 @@
+//! A single pixel layout for flat, cyber-interface, and wrist hazard readouts.
+use crate::{
+    scripts::radiation::{ActiveRadiation, RadiationRooms},
+    ui::{HAlign, Rect, UiCanvas, VAlign},
+};
+use cgmath::{Vector2, vec2};
+use shipyard::{UniqueView, World};
+
+pub const SIZE: Vector2<f32> = vec2(128.0, 66.0);
+pub const SCREEN_ORIGIN: Vector2<f32> = vec2(10.0, 345.0);
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct HazardReadout {
+    pub radiation: f32,
+    pub toxin: f32,
+    pub exposed: bool,
+}
+impl HazardReadout {
+    pub fn from_world(world: &World) -> Self {
+        world
+            .borrow::<UniqueView<ActiveRadiation>>()
+            .map(|state| Self {
+                radiation: state.level(),
+                toxin: state.toxin_level(),
+                exposed: state.is_exposed()
+                    || world
+                        .borrow::<UniqueView<RadiationRooms>>()
+                        .is_ok_and(|r| !r.0.is_empty()),
+            })
+            .unwrap_or_default()
+    }
+    pub fn active(&self) -> bool {
+        self.exposed || self.radiation > 0.0 || self.toxin > 0.0
+    }
+}
+
+pub fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, state: &HazardReadout, always: bool) {
+    if !always && !state.active() {
+        return;
+    }
+    let at = |x, y, w, h| Rect::new(origin.x + x, origin.y + y, w, h);
+    // shkHazrd: toxin at (10,345), radiation at (10,379), icon spacing 22.
+    let pips = state.toxin.ceil().clamp(0.0, 5.0) as usize;
+    if pips == 0 && always {
+        canvas.text_native(
+            at(0.0, 0.0, 128.0, 32.0),
+            "TOX 0",
+            "mainfont.fon",
+            HAlign::Left,
+            VAlign::Middle,
+        );
+    }
+    for i in 0..pips {
+        canvas.image(at(i as f32 * 22.0, 0.0, 25.0, 32.0), "poisicon.pcx");
+    }
+    if state.toxin > 5.0 {
+        canvas.text_native(
+            at(113.0, 0.0, 15.0, 32.0),
+            "+",
+            "mainfont.fon",
+            HAlign::Center,
+            VAlign::Middle,
+        );
+    }
+    canvas.image(at(0.0, 34.0, 128.0, 32.0), "radback.pcx");
+    canvas.image(
+        at(0.0, 34.0, 32.0, 32.0),
+        if state.exposed {
+            "radicon.pcx"
+        } else {
+            "radgray.pcx"
+        },
+    );
+    canvas.bar(
+        at(32.0, 34.0, 96.0, 32.0),
+        "radmeter.pcx",
+        (state.radiation / 35.0).clamp(0.0, 1.0),
+    );
+}
+
+pub fn wrist_canvas(state: &HazardReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(SIZE);
+    emit(&mut canvas, vec2(0.0, 0.0), state, false);
+    canvas
+}

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -140,3 +140,5 @@ pub(crate) fn hud_strings(world: &World) -> HudStrings {
         .map(|s| s.clone())
         .unwrap_or_default()
 }
+
+pub(crate) mod hazards;

--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -166,6 +166,7 @@ pub(crate) struct UseModeReadouts {
     pub weapon: Option<shipyard::EntityId>,
     /// Spendable nanites and cyber modules, in the order of the native wells.
     pub resources: [i32; 2],
+    pub hazards: Option<super::hazards::HazardReadout>,
 }
 
 impl UseModeReadouts {
@@ -175,6 +176,7 @@ impl UseModeReadouts {
     pub(crate) fn from_world(world: &World, weapon: Option<shipyard::EntityId>) -> Self {
         Self {
             weapon,
+            hazards: Some(super::hazards::HazardReadout::from_world(world)),
             bio: BioReadout::from_world(world),
             ammo: AmmoReadout::for_weapon(world, weapon, true),
             resources: [
@@ -191,6 +193,9 @@ impl UseModeReadouts {
 /// Emit the expanded bio + ammo readouts along the bottom of the shared
 /// 640x480 interface canvas.
 pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
+    if let Some(hazards) = &readouts.hazards {
+        super::hazards::emit(canvas, super::hazards::SCREEN_ORIGIN, hazards, true);
+    }
     emit_bio(
         canvas,
         BIO_ORIGIN,
@@ -254,6 +259,7 @@ mod tests {
         UseModeReadouts {
             weapon: None,
             resources: [0; 2],
+            hazards: Default::default(),
             bio: BioReadout {
                 health_fraction: 1.0,
                 psi_fraction: 0.75,

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -33,6 +33,28 @@ pub fn create_wrist_hud_panels(
         let root = Matrix4::from_translation(poses[i].position)
             * Matrix4::from(poses[i].rotation)
             * wrist_frames[i];
+        if hand == Handedness::Left {
+            let canvas =
+                super::hazards::wrist_canvas(&super::hazards::HazardReadout::from_world(world));
+            if canvas.element_count() > 0 {
+                // Hologram anchored above the calibrated glove, independent of
+                // weapon hand meshes. Pixel placement remains in hazards::emit.
+                let transform = root
+                    * Matrix4::from_translation(vec3(0.0, -0.06, 0.08))
+                    * Matrix4::from_nonuniform_scale(
+                        0.16,
+                        0.16 * canvas.size().y / canvas.size().x,
+                        1.0,
+                    );
+                objects.extend(canvas.render_world_space(
+                    asset_cache,
+                    transform,
+                    None,
+                    None,
+                    0.001,
+                ));
+            }
+        }
         if let Some(notice) = crate::wielded_weapon::held_by_hand(world, hand).and_then(|weapon| {
             crate::weapon_requirements::active_weapon_skill_notice(world, weapon)
         }) {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -516,6 +516,8 @@ struct PendingTransition {
     quest_info: QuestInfo,
     held_data: HeldItemSaveData,
     player_vitals: Option<PlayerVitals>,
+    hazards: crate::scripts::radiation::ActiveRadiation,
+    active_psi: crate::psi::ActivePsiPowers,
     /// The CPU parse running on a worker thread. While this is in flight the loading
     /// screen renders (and animates) every frame; once it finishes, the main thread runs
     /// the GPU `build` and swaps to the mission.
@@ -577,6 +579,8 @@ struct PreservedSceneState {
     quest_info: QuestInfo,
     held_data: HeldItemSaveData,
     player_vitals: Option<PlayerVitals>,
+    hazards: crate::scripts::radiation::ActiveRadiation,
+    active_psi: crate::psi::ActivePsiPowers,
 }
 
 pub struct Game {
@@ -721,6 +725,7 @@ pub struct PlayerStateSnapshot {
     /// Accumulated retail `RadLevel` after ambient absorption. Zero when the
     /// player has no active radiation status.
     pub radiation_level: f32,
+    pub toxin_level: f32,
     /// The gamesys name of the currently selected psi power (what the psi amp
     /// casts), e.g. "Cryokinesis".
     pub selected_psi_power: Option<String>,
@@ -873,6 +878,10 @@ impl Game {
                         .ok()
                         .map(|p| (p.psi_points, p.max_psi_points))
                 }),
+            toxin_level: world
+                .borrow::<shipyard::UniqueView<crate::scripts::radiation::ActiveRadiation>>()
+                .map(|state| state.toxin_level())
+                .unwrap_or(0.0),
             radiation_level: world
                 .borrow::<shipyard::UniqueView<crate::scripts::radiation::ActiveRadiation>>()
                 .map(|radiation| radiation.level())
@@ -954,6 +963,18 @@ impl Game {
             quest_info: current_quest_info,
             held_data,
             player_vitals,
+            active_psi: self
+                .active_game_scene
+                .world()
+                .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+                .map(|v| (*v).clone())
+                .unwrap_or_default(),
+            hazards: self
+                .active_game_scene
+                .world()
+                .borrow::<UniqueView<crate::scripts::radiation::ActiveRadiation>>()
+                .map(|v| (*v).clone())
+                .unwrap_or_default(),
         }
     }
 
@@ -992,12 +1013,16 @@ impl Game {
             quest_info,
             held_data,
             mut player_vitals,
+            mut hazards,
+            mut active_psi,
         } = match preserved {
             Some(preserved) => preserved,
             None => self.save_active_scene(),
         };
         if vitals_transition == PlayerVitalsTransition::InitializeFromDestination {
             player_vitals = None;
+            hazards = Default::default();
+            active_psi = Default::default();
         }
 
         // Spawn the GL-free parse off-thread. It owns `Arc`s of the asset-path layer and
@@ -1024,6 +1049,8 @@ impl Game {
             quest_info,
             held_data,
             player_vitals,
+            hazards,
+            active_psi,
             parse_handle,
             frames_shown: 0,
             parse_done_frame: None,
@@ -1066,6 +1093,21 @@ impl Game {
             &self.options,
         );
         save_load::restore_player_vitals(&mission.mission_core.world, pending.player_vitals);
+        if let Ok(mut psi) = mission
+            .mission_core
+            .world
+            .borrow::<shipyard::UniqueViewMut<crate::psi::ActivePsiPowers>>()
+        {
+            *psi = pending.active_psi;
+        }
+        if let Ok(mut status) = mission
+            .mission_core
+            .world
+            .borrow::<shipyard::UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+        {
+            *status = pending.hazards;
+            status.reset_ambient();
+        }
         self.set_active_scene(Box::new(mission));
         self.campaign_completed = false;
 
@@ -1924,6 +1966,12 @@ impl Game {
                 .borrow::<UniqueView<crate::scripts::healing_item::ActiveHealing>>()
                 .map(|active| active.clone())
                 .unwrap_or_default(),
+            active_psi: self
+                .active_game_scene
+                .world()
+                .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+                .map(|v| (*v).clone())
+                .unwrap_or_default(),
             active_radiation: self
                 .active_game_scene
                 .world()
@@ -2037,6 +2085,9 @@ impl Game {
                     Some(scene) => self.set_active_scene(scene),
                     None => warn!("Unknown debug scene '{}'", name),
                 }
+            }
+            GlobalEffect::PlayerRadiationHit { damage } => {
+                self.hit_feedback.trigger_radiation(damage);
             }
             GlobalEffect::PlayerHit { damage } => {
                 self.hit_feedback.trigger(damage);

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -3062,6 +3062,7 @@ mod tests {
         UseModeReadouts {
             weapon: None,
             resources: [0; 2],
+            hazards: Default::default(),
             bio: Default::default(),
             ammo: crate::hud::ammo_panel::AmmoReadout {
                 ammo: Some(12),
@@ -3195,6 +3196,7 @@ mod tests {
         host.set_readouts(Some(UseModeReadouts {
             weapon: None,
             resources: [0; 2],
+            hazards: Default::default(),
             bio: Default::default(),
             ammo: Default::default(),
         }));

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -988,6 +988,15 @@ fn apply_radiation_patch_use(
     entity_id: EntityId,
     amount: f32,
 ) -> RadiationPatchUseOutcome {
+    apply_hazard_patch_use(world, entity_id, amount, false)
+}
+
+fn apply_hazard_patch_use(
+    world: &World,
+    entity_id: EntityId,
+    amount: f32,
+    toxin: bool,
+) -> RadiationPatchUseOutcome {
     let is_alive = world
         .borrow::<EntitiesView>()
         .is_ok_and(|entities| entities.is_alive(entity_id));
@@ -1004,7 +1013,13 @@ fn apply_radiation_patch_use(
 
     let cleared = world
         .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
-        .is_ok_and(|mut radiation| radiation.clear(amount));
+        .is_ok_and(|mut radiation| {
+            if toxin {
+                radiation.clear_toxin(amount)
+            } else {
+                radiation.clear(amount)
+            }
+        });
     if !cleared {
         return RadiationPatchUseOutcome::NotUsed;
     }
@@ -2489,6 +2504,13 @@ impl MissionCore {
         world.add_unique(crate::psi::ActivePsiPowers::default());
         world.add_unique(crate::scripts::healing_item::ActiveHealing::default());
         world.add_unique(crate::scripts::radiation::ActiveRadiation::default());
+        world.add_unique(crate::scripts::radiation::RadiationRooms::default());
+        world.add_unique(crate::scripts::radiation::HazardResistance(
+            game_entity_info
+                .hazard_params()
+                .map(|p| p.0)
+                .unwrap_or([1.0; 8]),
+        ));
         world.add_unique(DamageFlash::default());
         world.add_unique(crate::hud::HudMessages::default());
 
@@ -3139,6 +3161,12 @@ impl MissionCore {
             return Vec::new();
         }
 
+        if let Ok(mut status) = self
+            .world
+            .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+        {
+            *status = Default::default();
+        }
         let paid_respawn = active_resurrection_target(&self.world).and_then(|target| {
             crate::scripts::script_util::debit_player_nanites(
                 &self.world,
@@ -3529,7 +3557,7 @@ impl MissionCore {
             &self.world,
             time.elapsed.as_secs_f32(),
         ) {
-            effects.push(radiation);
+            effects.extend(Effect::flatten(vec![radiation]));
         }
         // Runs before the sustained-power countdown below, which is the
         // decrement the drain's per-second accounting predicts.
@@ -5726,13 +5754,31 @@ impl MissionCore {
                 stim_template_id,
                 felt_intensity,
             );
-            crate::scripts::radiation::apply_player_stimulus(
-                &self.world,
-                entity_id,
+            if source_entity_id.is_none() {
+                crate::scripts::radiation::apply_player_stimulus(
+                    &self.world,
+                    entity_id,
+                    &receptrons,
+                    stim_template_id,
+                    felt_intensity,
+                );
+            }
+            for effect in crate::mission::stim_response::hazard_effects(
                 &receptrons,
                 stim_template_id,
                 felt_intensity,
-            );
+                entity_id,
+            ) {
+                if let Effect::ApplyHazard { toxin, amount, .. } = effect {
+                    if !toxin && source_entity_id.is_none() {
+                        continue;
+                    }
+                    self.script_world.dispatch(Message {
+                        to: entity_id,
+                        payload: MessagePayload::Hazard { toxin, amount },
+                    });
+                }
+            }
             if let Some(duration_seconds) = crate::mission::stim_response::resolve_stim_freeze(
                 &receptrons,
                 stim_template_id,
@@ -7189,7 +7235,140 @@ impl MissionCore {
         let mut player_grunted = false;
         let mut effects = VecDeque::from(effects);
         while let Some(effect) = effects.pop_front() {
+            let toxin_patch = matches!(&effect, Effect::UseToxinPatch { .. });
             match effect {
+                Effect::ApplyHazard {
+                    entity_id,
+                    toxin,
+                    amount,
+                } => {
+                    if entity_id != player_entity || !self.player_is_alive() {
+                        continue;
+                    }
+                    let amount =
+                        crate::scripts::radiation::protected_exposure(&self.world, toxin, amount);
+                    if let Ok(mut status) = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+                    {
+                        status.expose(toxin, amount);
+                    }
+                }
+                Effect::RadiationRoom { entity_id, entered } => {
+                    let level = self
+                        .world
+                        .borrow::<View<dark::properties::PropRadiationLevel>>()
+                        .ok()
+                        .and_then(|v| v.get(entity_id).ok().map(|v| v.0))
+                        .unwrap_or(0.0);
+                    let absorb = self
+                        .world
+                        .borrow::<View<dark::properties::PropRadiationAbsorb>>()
+                        .ok()
+                        .and_then(|v| v.get(entity_id).ok().map(|v| v.0))
+                        .unwrap_or(0.05);
+                    if let Ok(mut rooms) = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::scripts::radiation::RadiationRooms>>()
+                    {
+                        if entered && level.is_finite() && level > 0.0 {
+                            rooms.0.insert(entity_id, (level, absorb));
+                        } else {
+                            rooms.0.remove(&entity_id);
+                        }
+                    }
+                }
+                Effect::ClearHazard { toxin } => {
+                    if let Ok(mut status) = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+                    {
+                        if toxin {
+                            status.clear_toxin(f32::MAX);
+                        } else {
+                            status.clear(f32::MAX);
+                        }
+                    }
+                }
+                Effect::ClearEnvironmentalRadiation => {
+                    if let Ok(mut status) = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+                    {
+                        status.reset_ambient();
+                    }
+                    if let Ok(mut levels) = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropRadiationLevel>>()
+                    {
+                        for (entity, level) in (&mut levels).iter().with_id() {
+                            if entity != player_entity {
+                                level.0 = 0.0;
+                            }
+                        }
+                    }
+                    if let Ok(mut rooms) = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::scripts::radiation::RadiationRooms>>()
+                    {
+                        rooms.0.clear();
+                    }
+                }
+                Effect::ToggleHazardArmor { entity_id } => {
+                    if self.world.borrow::<View<PropObjState>>().is_ok_and(|v| {
+                        v.get(entity_id)
+                            .is_ok_and(|s| s.0 == dark::properties::ObjectState::Unresearched)
+                    }) {
+                        continue;
+                    }
+                    if !crate::scripts::script_util::player_carried_items(&self.world)
+                        .contains(&entity_id)
+                    {
+                        continue;
+                    }
+                    let armor = self
+                        .world
+                        .borrow::<View<dark::properties::PropArmor>>()
+                        .is_ok_and(|v| v.get(entity_id).is_ok());
+                    let implant = self
+                        .world
+                        .borrow::<View<dark::properties::PropImplantDesc>>()
+                        .is_ok_and(|v| v.get(entity_id).is_ok_and(|v| v.0 == 12));
+                    if !armor && !implant {
+                        continue;
+                    }
+                    let mut equipped = self
+                        .world
+                        .borrow::<ViewMut<crate::runtime_props::RuntimePropHazardEquipment>>()
+                        .unwrap();
+                    let was_equipped = equipped.get(entity_id).is_ok();
+                    let armors = self
+                        .world
+                        .borrow::<View<dark::properties::PropArmor>>()
+                        .unwrap();
+                    let to_remove: Vec<_> = (&equipped)
+                        .iter()
+                        .with_id()
+                        .filter_map(|(id, _)| (armors.get(id).is_ok() == armor).then_some(id))
+                        .collect();
+                    for id in to_remove {
+                        equipped.remove(id);
+                    }
+                    drop(armors);
+                    drop(equipped);
+                    if !was_equipped {
+                        self.world.add_component(
+                            entity_id,
+                            crate::runtime_props::RuntimePropHazardEquipment,
+                        );
+                    }
+                    game_log!(
+                        INFO,
+                        "Equipment {}",
+                        if was_equipped { "removed" } else { "equipped" }
+                    );
+                }
+
                 Effect::AcquireKeyCard { key_card } => {
                     let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                     quests.add_key_card(key_card);
@@ -8147,10 +8326,15 @@ impl MissionCore {
                     }
                 }
 
-                Effect::UseRadiationPatch { entity_id, amount } => {
-                    let outcome = apply_radiation_patch_use(&self.world, entity_id, amount);
+                Effect::UseRadiationPatch { entity_id, amount }
+                | Effect::UseToxinPatch { entity_id, amount } => {
+                    let outcome = if toxin_patch {
+                        apply_hazard_patch_use(&self.world, entity_id, amount, true)
+                    } else {
+                        apply_radiation_patch_use(&self.world, entity_id, amount)
+                    };
                     if outcome == RadiationPatchUseOutcome::NotUsed {
-                        game_log!(INFO, "No current radiation to remove.");
+                        game_log!(INFO, "No contamination to remove.");
                         continue;
                     }
 
@@ -14749,6 +14933,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     })
                 }),
             },
+            DebugEntityMessage::Hazard { toxin, amount } => {
+                MessagePayload::Hazard { toxin, amount }
+            }
             DebugEntityMessage::Frob => MessagePayload::Frob,
             DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
             DebugEntityMessage::SetAlertness { level } => {

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -552,3 +552,66 @@ mod tests {
         assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 0.0);
     }
 }
+
+/// Status responses travel beside HP damage so mixed toxin/melee attacks keep both.
+pub fn contact_hazard_effects(
+    world: &World,
+    emitter: i32,
+    victim: EntityId,
+    scale: f32,
+) -> crate::scripts::Effect {
+    let Ok(sources) = world.borrow::<UniqueView<GlobalContactStims>>() else {
+        return crate::scripts::Effect::NoEffect;
+    };
+    let Some(stims) = sources.0.get(&emitter) else {
+        return crate::scripts::Effect::NoEffect;
+    };
+    let receptrons = victim_receptrons(world, victim);
+    let effects: Vec<_> = stims
+        .iter()
+        .flat_map(|(stim, amount)| hazard_effects(&receptrons, *stim, amount * scale, victim))
+        .collect();
+    if effects.is_empty() {
+        crate::scripts::Effect::NoEffect
+    } else {
+        crate::scripts::Effect::combine(effects)
+    }
+}
+
+pub fn hazard_effects(
+    receptrons: &[(i32, ReceptronOptions)],
+    stim: i32,
+    intensity: f32,
+    victim: EntityId,
+) -> Vec<crate::scripts::Effect> {
+    let mut amplify = 1.0;
+    let mut toxin = false;
+    for (_, response) in receptrons.iter().filter(|(id, _)| *id == stim) {
+        match &response.effect {
+            ReceptronEffect::Abort => return vec![],
+            ReceptronEffect::Amplify { factor } => amplify *= factor,
+            ReceptronEffect::Unhandled(name) if name.eq_ignore_ascii_case("toxin") => toxin = true,
+            _ => {}
+        }
+    }
+    let amount = intensity * amplify;
+    if !amount.is_finite() || amount <= 0.0 {
+        return vec![];
+    }
+    let mut effects = Vec::new();
+    if toxin {
+        effects.push(crate::scripts::Effect::ApplyHazard {
+            entity_id: victim,
+            toxin: true,
+            amount,
+        });
+    }
+    if let Some(amount) = resolve_stim_radiation(receptrons, stim, intensity) {
+        effects.push(crate::scripts::Effect::ApplyHazard {
+            entity_id: victim,
+            toxin: false,
+            amount,
+        });
+    }
+    effects
+}

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -346,7 +346,7 @@ fn learned_bit_set(dword1: u32, dword2: u32, power_id: i32) -> bool {
 }
 
 /// One currently-active sustained psi power on the player.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ActivePsiPower {
     pub template_id: i32,
     /// The gamesys symbolic name (e.g. "Inviso").
@@ -356,9 +356,8 @@ pub struct ActivePsiPower {
 
 /// The player's active sustained psi powers, ticked down each frame by
 /// `MissionCore::update` and removed on expiry. Re-casting an active power
-/// refreshes its duration. (Not yet persisted across save/load or level
-/// transitions - like the psi pool and selection.)
-#[derive(Unique, Clone, Default)]
+/// refreshes its duration. Saved with the player across load and deck changes.
+#[derive(Unique, Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ActivePsiPowers(pub Vec<ActivePsiPower>);
 
 impl ActivePsiPowers {

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -431,3 +431,7 @@ pub struct RuntimePropHolstered {
 /// 0 is left, 1 is right. Inventory membership gates recall availability.
 #[derive(Component, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct RuntimePropShoulderWeapon(pub u8);
+
+/// Explicitly worn armor; saved with its item and effective only while carried.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropHazardEquipment;

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -25,6 +25,9 @@ pub struct EntitySaveData {
     /// the field and load with no generated terminal poses.
     #[serde(default)]
     pub death_poses: HashMap<u64, RuntimePropDeathPose>,
+    /// Equipped hazard armor/implant identities; remapped with carried entities.
+    #[serde(default)]
+    pub hazard_equipment: Vec<u64>,
     /// Selected projectile-link index for weapons whose ammo type has been
     /// changed. Persisted separately because runtime components are not part of
     /// the Dark property registry.
@@ -65,6 +68,7 @@ impl EntitySaveData {
             properties: HashMap::new(),
             links: HashMap::new(),
             death_poses: HashMap::new(),
+            hazard_equipment: Vec::new(),
             selected_ammo: HashMap::new(),
             holstered: HashMap::new(),
             shoulder_weapons: HashMap::new(),
@@ -117,6 +121,13 @@ impl EntitySaveData {
             }
         }
 
+        for id in &self.hazard_equipment {
+            if let Some(old) = EntityId::from_inner(*id) {
+                if let Some(new) = old_entity_id_to_new_entity_id.get(&old) {
+                    world.add_component(*new, crate::runtime_props::RuntimePropHazardEquipment);
+                }
+            }
+        }
         for (old_entity_id, death_pose) in &self.death_poses {
             let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
             if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -204,6 +204,14 @@ pub fn to_save_data_with_scripts(
         }
     }
 
+    let (held_hazard_equipment, world_hazard_equipment): (Vec<_>, Vec<_>) = world
+        .borrow::<View<crate::runtime_props::RuntimePropHazardEquipment>>()
+        .unwrap()
+        .iter()
+        .with_id()
+        .map(|(id, _)| id.inner())
+        .filter(|id| !entities_to_filter.contains(id))
+        .partition(|id| held_entities.contains(id));
     let raw_selected_ammo: HashMap<u64, usize> = v_selected_ammo
         .iter()
         .with_id()
@@ -279,6 +287,7 @@ pub fn to_save_data_with_scripts(
         all_entities: all_world_entities,
         death_poses: world_death_poses,
         selected_ammo: world_selected_ammo,
+        hazard_equipment: world_hazard_equipment,
         holstered: world_holstered,
         shoulder_weapons: world_shoulders,
         canonical_template_ids: world_canonical_templates,
@@ -295,6 +304,7 @@ pub fn to_save_data_with_scripts(
         properties: held_serialized_properties,
         death_poses: held_death_poses,
         selected_ammo: held_selected_ammo,
+        hazard_equipment: held_hazard_equipment,
         holstered: held_holstered,
         shoulder_weapons: held_shoulders,
         canonical_template_ids: held_canonical_templates,

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -56,6 +56,8 @@ pub struct GlobalData {
     /// Accumulated player radiation and its retail damage/recovery clock.
     #[serde(default)]
     pub active_radiation: ActiveRadiation,
+    #[serde(default)]
+    pub active_psi: crate::psi::ActivePsiPowers,
     pub active_mission: String,
     /// Whether the player was crouched at save time. Defaults false for
     /// saves that predate crouch.
@@ -78,6 +80,7 @@ mod tests {
             player_vitals,
             active_healing: ActiveHealing::default(),
             active_radiation: ActiveRadiation::default(),
+            active_psi: Default::default(),
             active_mission: "earth.mis".to_owned(),
             is_crouched: false,
         }
@@ -144,6 +147,11 @@ mod tests {
         assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0), 0);
         let encoded = serde_json::to_value(&original).unwrap();
         let decoded: GlobalData = serde_json::from_value(encoded.clone()).unwrap();
+        assert!(
+            !decoded.active_radiation.is_exposed(),
+            "ambient ownership is rebuilt after load"
+        );
+        original.active_radiation.reset_ambient();
         assert_eq!(decoded.active_radiation, original.active_radiation);
 
         let mut legacy = encoded;

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -303,6 +303,7 @@ pub fn load_mission_from_save_data(
     let current_mission = save_data.global_data.active_mission.clone();
     let active_healing = save_data.global_data.active_healing.clone();
     let active_radiation = save_data.global_data.active_radiation.clone();
+    let active_psi = save_data.global_data.active_psi.clone();
 
     let populator: Box<dyn EntityPopulator> = {
         if let Some(save_data) = save_data
@@ -350,6 +351,14 @@ pub fn load_mission_from_save_data(
         .borrow::<shipyard::UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
     {
         *radiation = active_radiation;
+    }
+
+    if let Ok(mut powers) = active_mission
+        .mission_core
+        .world
+        .borrow::<shipyard::UniqueViewMut<crate::psi::ActivePsiPowers>>()
+    {
+        *powers = active_psi;
     }
 
     // A loaded mission rebuilds Rapier from scratch. Mark the restored player

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -711,19 +711,28 @@ pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &Physic
         weapon_template_id,
         player_entity_id,
     );
+    let hazard = crate::mission::stim_response::contact_hazard_effects(
+        world,
+        weapon_template_id,
+        player_entity_id,
+        1.0,
+    );
     if damage <= 0.0 {
-        return Effect::NoEffect;
+        return hazard;
     }
 
-    Effect::Send {
-        msg: crate::scripts::Message {
-            to: player_entity_id,
-            payload: crate::scripts::MessagePayload::Damage {
-                amount: damage,
-                impact: None,
+    Effect::combine(vec![
+        hazard,
+        Effect::Send {
+            msg: crate::scripts::Message {
+                to: player_entity_id,
+                payload: crate::scripts::MessagePayload::Damage {
+                    amount: damage,
+                    impact: None,
+                },
             },
         },
-    }
+    ])
 }
 
 /// Where this AI should chase: its last-known target position when it has

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -32,6 +32,9 @@ pub enum PlayerVitalsTransition {
 
 #[derive(Clone, Debug)]
 pub enum GlobalEffect {
+    PlayerRadiationHit {
+        damage: f32,
+    },
     // Save the game state to the given file_name
     Save {
         file_name: String,
@@ -177,6 +180,26 @@ pub enum AIPropertyUpdate {
 #[derive(Clone, Debug)]
 pub enum Effect {
     NoEffect,
+    ApplyHazard {
+        entity_id: EntityId,
+        toxin: bool,
+        amount: f32,
+    },
+    RadiationRoom {
+        entity_id: EntityId,
+        entered: bool,
+    },
+    ClearHazard {
+        toxin: bool,
+    },
+    ClearEnvironmentalRadiation,
+    UseToxinPatch {
+        entity_id: EntityId,
+        amount: f32,
+    },
+    ToggleHazardArmor {
+        entity_id: EntityId,
+    },
 
     AwardXP {
         amount: i32,

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -48,6 +48,7 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 ];
 
 /// Retail trait ids with live gameplay effects here (see the effect handler).
+pub const TRAIT_STRONG_METABOLISM: u8 = 1;
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
 pub const TRAIT_PACK_RAT: u8 = 3;
 pub const TRAIT_PHARMO_FRIENDLY: u8 = 2;
@@ -401,6 +402,7 @@ fn hovered_trait(cursor: cgmath::Point2<f32>) -> Option<u8> {
 /// One-line note of a trait's live effect, if implemented (for logs).
 pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
+        TRAIT_STRONG_METABOLISM => Some("25% less radiation damage, 50% less toxin damage"),
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
         TRAIT_PACK_RAT => Some("+3 pack slots, +1 VR holster"),

--- a/shock2vr/src/scripts/hazard_objects.rs
+++ b/shock2vr/src/scripts/hazard_objects.rs
@@ -1,0 +1,104 @@
+use super::{Effect, MessagePayload, Script};
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
+
+pub enum HazardObject {
+    Room,
+    ToxinPatch,
+    Cleanse(bool),
+    Environment,
+    EngineCleanup,
+    Armor,
+}
+impl Script for HazardObject {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match self {
+            Self::Room => {
+                let (with, entered) = match msg {
+                    MessagePayload::SensorBeginIntersect { with } => (*with, true),
+                    MessagePayload::SensorEndIntersect { with } => (*with, false),
+                    _ => return Effect::NoEffect,
+                };
+                if world
+                    .borrow::<UniqueView<PlayerInfo>>()
+                    .is_ok_and(|p| p.entity_id == with)
+                {
+                    Effect::RadiationRoom { entity_id, entered }
+                } else {
+                    Effect::NoEffect
+                }
+            }
+            Self::ToxinPatch if matches!(msg, MessagePayload::Frob) => {
+                let pharma = world
+                    .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                    .is_ok_and(|q| {
+                        q.player_stats()
+                            .has_os_trait(crate::scripts::gui::TRAIT_PHARMO_FRIENDLY)
+                    });
+                Effect::UseToxinPatch {
+                    entity_id,
+                    amount: if pharma { 2.4 } else { 2.0 },
+                }
+            }
+            Self::Cleanse(toxin) if matches!(msg, MessagePayload::TurnOn { .. }) => {
+                Effect::ClearHazard { toxin: *toxin }
+            }
+            Self::EngineCleanup if matches!(msg, MessagePayload::TurnOn { .. }) => {
+                // allobjs 0x10039620: SlayAllByName(ConsumeType), ClearRadiation,
+                // EngineRadClear=1, unlock EngineCoreDoor, then optional UseMsg.
+                let mut effects = vec![
+                    Effect::ClearEnvironmentalRadiation,
+                    Effect::SetQuestBit {
+                        quest_bit_name: "EngineRadClear".to_owned(),
+                        quest_bit_value: dark::properties::QuestBitValue::INCOMPLETE,
+                    },
+                ];
+                if let Ok((values, metadata, hierarchy, templates)) = world.borrow::<(
+                    View<dark::properties::PropConsumeType>,
+                    UniqueView<crate::mission::mission_core::GlobalEntityMetadata>,
+                    UniqueView<crate::mission::mission_core::GlobalTemplateHierarchy>,
+                    View<dark::properties::PropTemplateId>,
+                )>() {
+                    if let Ok(name) = values.get(entity_id) {
+                        if let Some(class) = metadata.0.get(&name.0.to_ascii_lowercase()) {
+                            for (id, _) in (&templates).iter().with_id() {
+                                if super::script_util::entity_class_template_id(world, id)
+                                    .is_some_and(|t| {
+                                        hierarchy.is_or_descends_from(t, class.template_id)
+                                    })
+                                {
+                                    effects.push(Effect::SlayEntity { entity_id: id });
+                                }
+                            }
+                        }
+                    }
+                }
+                effects.extend(
+                    super::script_util::get_entities_by_name(world, "enginecoredoor")
+                        .into_iter()
+                        .map(|entity_id| Effect::SetLocked {
+                            entity_id,
+                            locked: false,
+                        }),
+                );
+                effects.push(
+                    super::trap_message::TrapMessage.handle_message(entity_id, world, physics, msg),
+                );
+                Effect::combine(effects)
+            }
+            Self::Environment if matches!(msg, MessagePayload::TurnOn { .. }) => {
+                Effect::ClearEnvironmentalRadiation
+            }
+            Self::Armor if matches!(msg, MessagePayload::Frob) => {
+                Effect::ToggleHazardArmor { entity_id }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -30,6 +30,7 @@ mod energy_weapon;
 mod exp_cookie;
 mod frob_qb;
 pub mod gui;
+mod hazard_objects;
 pub mod healing_item;
 mod homing;
 mod impact_sound;
@@ -232,6 +233,10 @@ pub struct DamageImpact {
 
 #[derive(Clone, Debug)]
 pub enum MessagePayload {
+    Hazard {
+        toxin: bool,
+        amount: f32,
+    },
     Frob,
 
     /// This entity's MFD panel was opened. Frobbing used to be the only way in,
@@ -988,8 +993,8 @@ impl ScriptWorld {
             // TODO: Necessary
             "changeinterface" => Box::new(NoopScript::new()),
             "reducehp" => Box::new(NoopScript::new()),
-            "engineremoverad" => Box::new(NoopScript::new()),
-            "radroom" => Box::new(NoopScript::new()),
+            "engineremoverad" => Box::new(hazard_objects::HazardObject::EngineCleanup),
+            "radroom" => Box::new(hazard_objects::HazardObject::Room),
             // SHODAN's ordinary creature/base-monster scripts own combat and
             // death state. Keep the retail finale hook inert until its ending
             // sequence is implemented; TrapSpawn must still be able to create
@@ -1010,8 +1015,8 @@ impl ScriptWorld {
             "triggerdamage" => Box::new(TriggerDamage::new()),
             // many.micontain
             "brain" => Box::new(NoopScript::new()),
-            "wormheartimplant" => Box::new(NoopScript::new()),
-            "wormskin" => Box::new(NoopScript::new()),
+            "wormheartimplant" => Box::new(hazard_objects::HazardObject::Armor),
+            "wormskin" => Box::new(hazard_objects::HazardObject::Armor),
             // shodan.mis
             "toggleshodantexture" => Box::new(NoopScript::new()),
             "changedelay" => Box::new(NoopScript::new()), //?
@@ -1117,7 +1122,9 @@ impl ScriptWorld {
             "freezefx" => Box::new(UnimplementedScript::new(&script_name)), // command1
             "torpedolift" => Box::new(UnimplementedScript::new(&script_name)), // rick1
             "torpedohack" => Box::new(UnimplementedScript::new(&script_name)), // rick1
-            "eraseradiation" => Box::new(UnimplementedScript::new(&script_name)), // rick1
+            "flushradiation" | "eraseradiation" => {
+                Box::new(hazard_objects::HazardObject::Environment)
+            } // rick1
 
             // station:
             "oldstylebaseelevator" => Box::new(UnimplementedScript::new(&script_name)),
@@ -1200,8 +1207,9 @@ impl ScriptWorld {
             "minigamecart" => Box::new(NoopScript::new()),
             "forcedoor" => Box::new(UnimplementedScript::new(&script_name)),
             "wormpilescript" => Box::new(UnimplementedScript::new(&script_name)),
-            "trapradcleanse" => Box::new(UnimplementedScript::new(&script_name)),
-            "armorscript" => Box::new(NoopScript::new()),
+            "traptoxincleanse" => Box::new(hazard_objects::HazardObject::Cleanse(true)),
+            "trapradcleanse" => Box::new(hazard_objects::HazardObject::Cleanse(false)),
+            "armorscript" => Box::new(hazard_objects::HazardObject::Armor),
             "battery" => Box::new(UnimplementedScript::new(&script_name)),
             "healingstation" => Box::new(UnimplementedScript::new(&script_name)),
             "brokenhealingstation" => Box::new(UnimplementedScript::new(&script_name)),
@@ -1287,7 +1295,7 @@ impl ScriptWorld {
             "setupinitialdebrief" => {
                 Box::new(setup_initial_debrief::SetupInitialDebriefScript::new())
             }
-            "toxinpatch" => Box::new(UnimplementedScript::new(&script_name)),
+            "toxinpatch" => Box::new(hazard_objects::HazardObject::ToxinPatch),
             "triggerecology" => Box::new(TriggerEcology::new()),
             // Retail's difficulty variant applies shock.cfg/difficulty
             // population adjustments before entering this same state machine.

--- a/shock2vr/src/scripts/player_script.rs
+++ b/shock2vr/src/scripts/player_script.rs
@@ -25,6 +25,11 @@ impl Script for PlayerScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
+            MessagePayload::Hazard { toxin, amount } => Effect::ApplyHazard {
+                entity_id,
+                toxin: *toxin,
+                amount: *amount,
+            },
             MessagePayload::Damage { amount, .. } => {
                 // A dead player takes no further hits (death handling itself
                 // is not implemented yet - see #561 follow-ups).

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -1,6 +1,6 @@
 use dark::properties::{PropRadiationAbsorb, PropRadiationRecovery, ReceptronOptions};
 use serde::{Deserialize, Serialize};
-use shipyard::{Get, Unique, UniqueView, View, World};
+use shipyard::{EntityId, Get, Unique, UniqueView, UniqueViewMut, View, World};
 
 use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
 
@@ -14,13 +14,15 @@ pub const RAD_PATCH_CLEAR_AMOUNT: f32 = 6.0;
 pub const RAD_PATCH_PHARMO_CLEAR_AMOUNT: f32 = 7.2;
 
 /// Retail schedules `RadDamage` every 6000 ms. The shipped implementation
-/// converts the stored level to damage with a 0.25 multiplier before the
-/// normal-difficulty scalar (shock2quest currently has no difficulty option).
-pub const RADIATION_DAMAGE_INTERVAL_SECS: f32 = 6.0;
-pub const RADIATION_CHECK_INTERVAL_SECS: f32 = 0.1;
-const RADIATION_DAMAGE_PER_LEVEL: f32 = 0.25;
+/// multiplies stored level by the Endurance table and Metabolism modifier
+/// before truncating to whole HP (allobjs 0x1001690d–0x100169c8).
+pub const RADIATION_DAMAGE_INTERVAL_SECS: f64 = 6.0;
+pub const RADIATION_CHECK_INTERVAL_SECS: f64 = 0.1;
+const RADIATION_DAMAGE_PER_LEVEL: f32 = 1.0;
 const DEFAULT_RADIATION_ABSORB: f32 = 0.05;
 const DEFAULT_RADIATION_RECOVERY: f32 = 3.0;
+const TOXIN_SHIELD_TEMPLATE_ID: i32 = -1113;
+const RAD_SHIELD_TEMPLATE_ID: i32 = -1114;
 
 /// Retail `RadPatch`: clear part of the player's accumulated radiation and
 /// consume one patch only when radiation is actually present.
@@ -55,11 +57,15 @@ impl Script for RadPatchScript {
     }
 }
 
-fn default_damage_timer() -> f32 {
+fn default_toxin_timer() -> f64 {
+    10.0
+}
+
+fn default_damage_timer() -> f64 {
     RADIATION_DAMAGE_INTERVAL_SECS
 }
 
-fn default_check_timer() -> f32 {
+fn default_check_timer() -> f64 {
     RADIATION_CHECK_INTERVAL_SECS
 }
 
@@ -70,21 +76,33 @@ fn default_check_timer() -> f32 {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Unique)]
 pub struct ActiveRadiation {
     level: f32,
+    #[serde(default)]
+    toxin: f32,
+    #[serde(skip)]
+    last_radiation_damage: i32,
+    #[serde(skip)]
+    exposed_last_tick: bool,
+    #[serde(default = "default_toxin_timer")]
+    seconds_until_toxin: f64,
     #[serde(default, skip)]
     ambient_level: f32,
     #[serde(default = "default_check_timer")]
-    seconds_until_check: f32,
+    seconds_until_check: f64,
     #[serde(default = "default_damage_timer")]
-    seconds_until_damage: f32,
+    seconds_until_damage: f64,
 }
 
 impl Default for ActiveRadiation {
     fn default() -> Self {
         Self {
             level: 0.0,
+            toxin: 0.0,
+            last_radiation_damage: 0,
+            exposed_last_tick: false,
+            seconds_until_toxin: 10.0,
             ambient_level: 0.0,
-            seconds_until_check: RADIATION_CHECK_INTERVAL_SECS,
-            seconds_until_damage: RADIATION_DAMAGE_INTERVAL_SECS,
+            seconds_until_check: default_check_timer(),
+            seconds_until_damage: default_damage_timer(),
         }
     }
 }
@@ -92,6 +110,40 @@ impl Default for ActiveRadiation {
 impl ActiveRadiation {
     pub fn level(&self) -> f32 {
         self.level
+    }
+
+    pub fn toxin_level(&self) -> f32 {
+        self.toxin
+    }
+    pub fn is_exposed(&self) -> bool {
+        self.ambient_level > 0.0 || self.exposed_last_tick
+    }
+
+    /// Environmental ownership is recomputed on scene changes and reactor cleanup.
+    pub fn reset_ambient(&mut self) {
+        self.exposed_last_tick = false;
+        self.ambient_level = 0.0;
+    }
+
+    /// Contact reactions replace weaker contamination; they are not ambient sources.
+    pub fn expose(&mut self, toxin: bool, amount: f32) {
+        if !amount.is_finite() || amount <= 0.0 {
+            return;
+        }
+        let level = if toxin {
+            &mut self.toxin
+        } else {
+            &mut self.level
+        };
+        *level = level.max(amount);
+    }
+
+    pub fn clear_toxin(&mut self, amount: f32) -> bool {
+        if !amount.is_finite() || amount <= 0.0 || self.toxin <= 0.0 {
+            return false;
+        }
+        self.toxin = (self.toxin - amount).max(0.0);
+        true
     }
 
     /// Refresh the final act/react ambient intensity after
@@ -125,6 +177,17 @@ impl ActiveRadiation {
         absorb_per_check: f32,
         recovery_per_tick: f32,
     ) -> i32 {
+        self.advance_resisted(elapsed_secs, absorb_per_check, recovery_per_tick, 1.0, 1.0)
+    }
+
+    fn advance_resisted(
+        &mut self,
+        elapsed_secs: f32,
+        absorb_per_check: f32,
+        recovery_per_tick: f32,
+        resistance: f32,
+        toxin_resistance: f32,
+    ) -> i32 {
         if !elapsed_secs.is_finite() || elapsed_secs <= 0.0 {
             return 0;
         }
@@ -135,50 +198,80 @@ impl ActiveRadiation {
             self.ambient_level = 0.0;
         }
         if !self.seconds_until_check.is_finite()
-            || self.seconds_until_check < -RADIATION_CHECK_INTERVAL_SECS
+            || self.seconds_until_check <= 0.0
+            || self.seconds_until_check > default_check_timer()
         {
-            self.seconds_until_check = RADIATION_CHECK_INTERVAL_SECS;
+            self.seconds_until_check = default_check_timer();
         }
         if !self.seconds_until_damage.is_finite()
-            || self.seconds_until_damage < -RADIATION_DAMAGE_INTERVAL_SECS
+            || self.seconds_until_damage <= 0.0
+            || self.seconds_until_damage > default_damage_timer()
         {
-            self.seconds_until_damage = RADIATION_DAMAGE_INTERVAL_SECS;
+            self.seconds_until_damage = default_damage_timer();
         }
-        let absorb = if absorb_per_check.is_finite() && absorb_per_check > 0.0 {
+        let absorb = if absorb_per_check.is_finite() && absorb_per_check >= 0.0 {
             absorb_per_check
         } else {
             DEFAULT_RADIATION_ABSORB
         };
-        let recovery = if recovery_per_tick.is_finite() && recovery_per_tick > 0.0 {
+        let recovery = if recovery_per_tick.is_finite() && recovery_per_tick >= 0.0 {
             recovery_per_tick
         } else {
             DEFAULT_RADIATION_RECOVERY
         };
 
-        self.seconds_until_check -= elapsed_secs;
-        while self.seconds_until_check <= 0.0 {
-            if self.ambient_level > self.level {
-                self.level += absorb.min(self.ambient_level - self.level);
-            }
-            self.seconds_until_check += RADIATION_CHECK_INTERVAL_SECS;
-        }
-
-        self.seconds_until_damage -= elapsed_secs;
+        // Advance in chronological order: a large step must not apply all
+        // absorption before the first damage pulse (or differ from 60 Hz).
+        self.last_radiation_damage = 0;
+        let mut remaining = f64::from(elapsed_secs);
         let mut damage = 0_i32;
-        while self.seconds_until_damage <= 0.0 {
-            if self.level >= 1.0 {
-                let pulse = (self.level * RADIATION_DAMAGE_PER_LEVEL)
-                    .trunc()
-                    .clamp(0.0, i32::MAX as f32) as i32;
-                damage = damage.saturating_add(pulse);
+        while remaining > 0.0 {
+            let step = remaining
+                .min(self.seconds_until_check.max(0.0))
+                .min(self.seconds_until_damage.max(0.0));
+            self.seconds_until_check -= step;
+            self.seconds_until_damage -= step;
+            remaining -= step;
+            if self.seconds_until_check <= 0.000001 {
+                if self.ambient_level > self.level {
+                    self.level += absorb.min(self.ambient_level - self.level);
+                }
+                self.seconds_until_check = default_check_timer();
             }
-            if self.ambient_level <= 0.0 {
-                self.level = (self.level - recovery).max(0.0);
+            if self.seconds_until_damage <= 0.000001 {
+                if self.level >= 1.0 {
+                    let pulse =
+                        (self.level * RADIATION_DAMAGE_PER_LEVEL * resistance).trunc() as i32;
+                    damage = damage.saturating_add(pulse);
+                    self.last_radiation_damage = self.last_radiation_damage.saturating_add(pulse);
+                }
+                if self.ambient_level <= 0.0 {
+                    self.level = (self.level - recovery).max(0.0);
+                    if self.level < 1.0 {
+                        self.level = 0.0;
+                    }
+                }
+                self.seconds_until_damage = default_damage_timer();
             }
-            self.seconds_until_damage += RADIATION_DAMAGE_INTERVAL_SECS;
         }
-        // Radius sources refresh this after the effect pass. Clearing it here
-        // lets the following frame faithfully represent leaving the source.
+        if !self.toxin.is_finite() || self.toxin < 0.0 {
+            self.toxin = 0.0;
+        }
+        if !self.seconds_until_toxin.is_finite()
+            || self.seconds_until_toxin <= 0.0
+            || self.seconds_until_toxin > 10.0
+        {
+            self.seconds_until_toxin = 10.0;
+        }
+        self.seconds_until_toxin -= f64::from(elapsed_secs);
+        while self.seconds_until_toxin <= 0.000001 {
+            if self.toxin > 0.0 && toxin_resistance > 0.0 {
+                damage =
+                    damage.saturating_add((self.toxin * toxin_resistance).max(1.0).trunc() as i32);
+            }
+            self.seconds_until_toxin += 10.0;
+        }
+        self.exposed_last_tick = self.ambient_level > 0.0;
         self.ambient_level = 0.0;
         damage
     }
@@ -212,6 +305,13 @@ pub fn apply_player_stimulus(
         .is_ok_and(|mut radiation| radiation.observe_ambient(amount))
 }
 
+/// Membership is rebuilt by room sensors, not serialized as stale entity IDs.
+#[derive(Unique, Default)]
+pub struct RadiationRooms(pub std::collections::HashMap<EntityId, (f32, f32)>);
+
+#[derive(Unique)]
+pub struct HazardResistance(pub [f32; 8]);
+
 pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect> {
     let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
     let recovery = world
@@ -224,15 +324,105 @@ pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect>
         .ok()
         .and_then(|values| values.get(player).ok().map(|value| value.0))
         .unwrap_or(DEFAULT_RADIATION_ABSORB);
+    if world
+        .borrow::<View<dark::properties::PropHitPoints>>()
+        .ok()
+        .and_then(|hp| hp.get(player).ok().map(|v| v.hit_points <= 0))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let (endurance, metabolism) = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|q| {
+            (
+                q.player_stats().endurance.clamp(1, 8) as usize,
+                q.player_stats()
+                    .has_os_trait(crate::scripts::gui::TRAIT_STRONG_METABOLISM),
+            )
+        })
+        .unwrap_or((1, false));
+    let resistance = world
+        .borrow::<UniqueView<HazardResistance>>()
+        .map(|r| r.0[endurance - 1])
+        .unwrap_or(1.0);
+    let room = world
+        .borrow::<UniqueView<RadiationRooms>>()
+        .ok()
+        .and_then(|rooms| {
+            rooms
+                .0
+                .values()
+                .copied()
+                .max_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.total_cmp(&b.1)))
+        });
+    let mut absorb = absorb;
+    if let Some((ambient, rate)) = room {
+        if let Ok(mut radiation) = world.borrow::<UniqueViewMut<ActiveRadiation>>() {
+            radiation.observe_ambient(ambient);
+        }
+        absorb = rate;
+    }
+    let wormheart = super::script_util::player_carried_items(world)
+        .into_iter()
+        .any(|id| {
+            world
+                .borrow::<View<crate::runtime_props::RuntimePropHazardEquipment>>()
+                .is_ok_and(|v| v.get(id).is_ok())
+                && world
+                    .borrow::<View<dark::properties::PropImplantDesc>>()
+                    .is_ok_and(|v| v.get(id).is_ok_and(|v| v.0 == 12))
+        });
+    let protection = hazard_protection(world);
+    // Retail armor slows accumulation; it does not lower the room ceiling.
+    absorb *= 1.0 - protection.radiation / 100.0;
+    let psi_armor = psi_hazard_protection(world);
+    if psi_armor.radiation > 0.0 {
+        // RadShield authors a divisor (retail 5), unlike percentage suit armor.
+        absorb /= psi_armor.radiation;
+    }
     let damage = world
         .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
         .ok()
-        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery))
+        .map(|mut radiation| {
+            radiation.advance_resisted(
+                elapsed_secs,
+                absorb,
+                recovery,
+                resistance * if metabolism { 0.75 } else { 1.0 },
+                if wormheart {
+                    0.0
+                } else {
+                    resistance * if metabolism { 0.5 } else { 1.0 }
+                },
+            )
+        })
         .unwrap_or(0);
-    (damage > 0).then_some(Effect::AdjustHitPoints {
+    if damage <= 0 {
+        return None;
+    }
+    let rad_damage = world
+        .borrow::<UniqueView<ActiveRadiation>>()
+        .map(|s| s.last_radiation_damage)
+        .unwrap_or(0);
+    let mut effects = vec![Effect::AdjustHitPoints {
         entity_id: player,
         delta: -damage,
-    })
+    }];
+    if rad_damage > 0 {
+        effects.push(Effect::GlobalEffect(
+            super::GlobalEffect::PlayerRadiationHit {
+                damage: rad_damage as f32,
+            },
+        ));
+        effects.push(Effect::PlaySound {
+            handle: engine::audio::AudioHandle::new(),
+            name: "raddmg".to_owned(),
+            source: Some(player),
+            spatial: false,
+        });
+    }
+    Some(Effect::combine(effects))
 }
 
 #[cfg(test)]
@@ -317,9 +507,9 @@ mod tests {
         assert!(radiation.observe_ambient(8.0));
         assert_eq!(radiation.advance(5.89, 0.05, 3.0), 0);
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.02, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(0.02, 0.05, 3.0), 8);
         assert_eq!(radiation.level(), 8.0, "active exposure delays recovery");
-        assert_eq!(radiation.advance(6.0, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(6.0, 0.05, 3.0), 8);
         assert_eq!(radiation.level(), 5.0);
     }
 
@@ -388,5 +578,185 @@ mod tests {
                 .level(),
             0.05
         );
+    }
+}
+
+/// Protection is evaluated at use time, so removing armor or expiring psi
+/// immediately changes subsequent exposure without curing existing status.
+pub fn hazard_protection(world: &World) -> dark::properties::PropArmor {
+    let mut result = dark::properties::PropArmor::default();
+    let carried = super::script_util::player_carried_items(world);
+    if let Ok(armor) = world.borrow::<View<dark::properties::PropArmor>>() {
+        if let Ok(equipped) =
+            world.borrow::<View<crate::runtime_props::RuntimePropHazardEquipment>>()
+        {
+            for entity in carried {
+                if equipped.get(entity).is_ok() {
+                    if let Ok(value) = armor.get(entity) {
+                        result = *value;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    result.radiation = result.radiation.clamp(0.0, 100.0);
+    result.toxic = result.toxic.clamp(0.0, 100.0);
+    result
+}
+
+fn psi_hazard_protection(world: &World) -> dark::properties::PropArmor {
+    let mut armor = dark::properties::PropArmor::default();
+    let Ok(active) = world.borrow::<UniqueView<crate::psi::ActivePsiPowers>>() else {
+        return armor;
+    };
+    let Ok(registry) = world.borrow::<UniqueView<crate::psi::GlobalPsiPowers>>() else {
+        return armor;
+    };
+    let psi = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|q| q.player_stats().psionic_ability)
+        .unwrap_or(1);
+    for power in registry
+        .0
+        .iter()
+        .filter(|p| active.is_active(p.template_id))
+    {
+        let value = power.power.data[0] + power.power.data[1] * (psi - 1).max(0) as f32;
+        match power.template_id {
+            RAD_SHIELD_TEMPLATE_ID => armor.radiation = value,
+            TOXIN_SHIELD_TEMPLATE_ID => armor.toxic = value,
+            _ => {}
+        }
+    }
+    armor
+}
+
+// shkreact.cpp applies player armor as a percentage here, including RadShield's
+// value 5. The room RadCheck division above is a distinct retail script path.
+pub fn protected_exposure(world: &World, toxin: bool, amount: f32) -> f32 {
+    let armor = hazard_protection(world);
+    let psi = psi_hazard_protection(world);
+    let percentages = if toxin {
+        [armor.toxic, psi.toxic]
+    } else {
+        [armor.radiation, psi.radiation]
+    };
+    percentages.into_iter().fold(amount, |value, pct| {
+        value * (1.0 - pct.clamp(0.0, 100.0) / 100.0)
+    })
+}
+
+#[cfg(test)]
+mod hazard_regressions {
+    use super::*;
+
+    #[test]
+    fn overlapping_rooms_choose_strongest_rate_and_exit_stops_exposure() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        let slow_room = world.add_entity(());
+        let fast_room = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: cgmath::vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(ActiveRadiation::default());
+        world.add_unique(RadiationRooms(std::collections::HashMap::from([
+            (slow_room, (35.0, 0.05)),
+            (fast_room, (35.0, 0.1)),
+        ])));
+        assert!(tick_player_radiation(&world, 1.0).is_none());
+        let level = world
+            .borrow::<UniqueView<ActiveRadiation>>()
+            .unwrap()
+            .level();
+        assert!((level - 1.0).abs() < 0.0001);
+        assert!(
+            world
+                .borrow::<UniqueView<ActiveRadiation>>()
+                .unwrap()
+                .is_exposed()
+        );
+        world
+            .borrow::<UniqueViewMut<RadiationRooms>>()
+            .unwrap()
+            .0
+            .clear();
+        assert!(tick_player_radiation(&world, 1.0).is_none());
+        let status = world.borrow::<UniqueView<ActiveRadiation>>().unwrap();
+        assert_eq!(status.level(), level);
+        assert!(!status.is_exposed());
+    }
+
+    #[test]
+    fn toxin_persists_and_weaker_attacks_do_not_stack() {
+        let mut status = ActiveRadiation::default();
+        status.expose(true, 4.0);
+        status.expose(true, 2.0);
+        assert_eq!(status.toxin_level(), 4.0);
+        assert_eq!(status.advance(9.0, 0.05, 3.0), 0);
+        assert_eq!(status.advance(1.0, 0.05, 3.0), 4);
+        assert_eq!(status.advance(10.0, 0.05, 3.0), 4);
+        assert_eq!(status.toxin_level(), 4.0);
+        assert!(status.clear_toxin(2.0));
+        assert_eq!(status.toxin_level(), 2.0);
+        assert!(status.clear_toxin(2.4));
+        assert_eq!(status.toxin_level(), 0.0);
+        assert!(!status.clear_toxin(2.0));
+    }
+
+    #[test]
+    fn toxin_minimum_damage_does_not_turn_endurance_into_immunity() {
+        let mut status = ActiveRadiation::default();
+        status.expose(true, 1.0);
+        assert_eq!(status.advance_resisted(10.0, 0.05, 3.0, 0.01, 0.01), 1);
+        // WormHeart suppresses damage while equipped, without removing poison.
+        assert_eq!(status.advance_resisted(10.0, 0.05, 3.0, 0.01, 0.0), 0);
+        assert_eq!(status.toxin_level(), 1.0);
+    }
+
+    #[test]
+    fn radiation_checks_and_damage_are_independent_of_step_partition() {
+        let mut large = ActiveRadiation::default();
+        large.observe_ambient(35.0);
+        let large_damage = large.advance(30.0, 0.05, 3.0);
+        let mut small = ActiveRadiation::default();
+        let mut small_damage = 0;
+        for _ in 0..1800 {
+            small.observe_ambient(35.0);
+            small_damage += small.advance(1.0 / 60.0, 0.05, 3.0);
+        }
+        assert_eq!(large_damage, small_damage);
+        assert!((large.level() - small.level()).abs() < 0.001);
+    }
+
+    #[test]
+    fn pause_and_save_restore_preserve_tick_phase() {
+        let mut status = ActiveRadiation::default();
+        status.expose(true, 3.0);
+        status.advance(9.0, 0.05, 3.0);
+        let saved = serde_json::to_string(&status).unwrap();
+        assert_eq!(status.advance(0.0, 0.05, 3.0), 0);
+        assert_eq!(serde_json::to_string(&status).unwrap(), saved);
+        let mut restored: ActiveRadiation = serde_json::from_str(&saved).unwrap();
+        assert_eq!(restored.advance(1.0, 0.05, 3.0), 3);
+        assert_eq!(restored.toxin_level(), 3.0);
+    }
+
+    #[test]
+    fn full_protection_and_zero_recovery_are_respected() {
+        let mut status = ActiveRadiation::default();
+        status.observe_ambient(35.0);
+        assert_eq!(status.advance(6.0, 0.0, 0.0), 0);
+        assert_eq!(status.level(), 0.0);
+        status.expose(false, 12.0);
+        assert_eq!(status.advance_resisted(6.0, 0.0, 0.0, 0.5, 1.0), 6);
+        assert_eq!(status.level(), 12.0);
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -68,6 +68,17 @@ pub(crate) fn projectile_contact_effects(
     } else {
         Effect::NoEffect
     };
+    let hazard = crate::mission::stim_response::contact_hazard_effects(
+        world,
+        template,
+        receiver,
+        crate::runtime_props::RuntimePropShotModifiers::of(world, projectile).stim,
+    );
+    let damage = if matches!(hazard, Effect::NoEffect) {
+        damage
+    } else {
+        Effect::combine(vec![damage, hazard])
+    };
     if let Some(duration_seconds) = crate::mission::stim_response::contact_stim_freeze(
         world,
         template,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -130,6 +130,7 @@ export interface PathfindingTestStatus {
  * Mirrors the engine's `DebugEntityMessage`; the `type` field is the serde tag.
  */
 export type DebugEntityMessage =
+  | { type: "Hazard"; toxin: boolean; amount: number }
   | {
       type: "Damage";
       amount: number;
@@ -633,6 +634,7 @@ export interface PlayerSnapshot {
   max_psi_points: number | null;
   /** Accumulated retail radiation level (zero when clear). */
   radiation_level: number;
+  toxin_level: number;
   /** The gamesys name of the selected psi power (what the psi amp casts),
    * e.g. "Cryokinesis". Cycle with the CyclePsiPower input action. */
   selected_psi_power: string | null;

--- a/tools/shock2-sdk/test/hazards.e2e.test.ts
+++ b/tools/shock2-sdk/test/hazards.e2e.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { pullTrigger } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("hazards: toxin persists, weaker exposure does not stack, and Endurance mitigates ticks", { skip: !enabled, timeout: 120_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis" });
+  await game.step({ frames: 2 });
+  const initial = (await game.info()).player;
+  assert.ok(initial.entity_id !== null);
+  await game.entities.sendMessage(initial.entity_id, { type: "Hazard", toxin: true, amount: 4 });
+  await game.step({ frames: 1 });
+  await game.entities.sendMessage(initial.entity_id, { type: "Hazard", toxin: true, amount: 2 });
+  await game.step({ frames: 1 });
+  assert.equal((await game.info()).player.toxin_level, 4);
+  const hp = (await game.info()).player.hit_points!;
+  await game.step({ frames: 601 });
+  const poisoned = (await game.info()).player;
+  assert.equal(poisoned.toxin_level, 4);
+  assert.equal(poisoned.hit_points, hp - 4);
+  await game.player.setStats({ endurance: 6 });
+  await game.step({ frames: 600 });
+  assert.equal((await game.info()).player.toxin_level, 4);
+  assert.equal((await game.info()).player.hit_points, hp - 5, "poison retains its one-point minimum at END 6");
+  const patch = await game.player.spawnItem("Detox Patch");
+  await game.entities.sendMessage(patch.entity_id, { type: "Frob" });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 2);
+  assert.ok(!(await game.player.inventory()).items.some(item => item.entity_id === patch.entity_id));
+  const suit = await game.player.spawnItem(-83);
+  await game.entities.sendMessage(suit.entity_id, { type: "Frob" });
+  await game.step({ frames: 2 });
+  await game.entities.sendMessage(initial.entity_id, { type: "Hazard", toxin: true, amount: 12 });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 3, "Vacc Suit reduces new toxin exposure by 75%");
+  const save = `hazards-${Date.now()}`;
+  await game.save(save);
+  const cure = await game.player.spawnItem("Detox Patch");
+  await game.entities.sendMessage(cure.entity_id, { type: "Frob" });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 1);
+  await game.load(save);
+  assert.equal((await game.info()).player.toxin_level, 3);
+  const restoredPlayer = (await game.info()).player.entity_id!;
+  await game.entities.sendMessage(restoredPlayer, { type: "Hazard", toxin: true, amount: 16 });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 4, "equipped suit survives entity remapping on load");
+});
+
+
+test("hazards: authored Engineering room accumulates radiation only while occupied", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "eng1.mis" });
+  await game.step({ frames: 2 });
+  const start = (await game.info()).player.position;
+  // ROOM_DB object 226 has a generated forwarding sensor and a marker at zero.
+  // Discover its runtime sensor rather than hardcoding a per-launch entity id.
+  const room = (await game.entities.list()).entities.find(e => e.template_id === 226 && e.name === "Base Room");
+  assert.ok(room);
+  await game.player.teleport({ x: room.position[0], y: room.position[1] - .5, z: room.position[2] });
+  await game.step({ frames: 60 });
+  const exposed = (await game.info()).player.radiation_level;
+  assert.ok(exposed > .5, `room sensor must accumulate radiation, got ${exposed}`);
+  await game.player.teleport({ x: start[0], y: start[1], z: start[2] });
+  await game.step({ frames: 60 });
+  assert.equal((await game.info()).player.radiation_level, exposed, "exit removes ambient exposure without curing stored radiation");
+  const cleanup = (await game.entities.list({ filter: "RadBeGone" })).entities.find(e => e.template_id === 178);
+  assert.ok(cleanup);
+  await game.entities.sendMessage(cleanup.id, { type: "TurnOn" });
+  await game.step({ frames: 2 });
+  assert.equal(await game.quests.get("EngineRadClear"), "incomplete", "retail sets the raw quest flag to 1");
+  const afterCleanup = (await game.info()).player.radiation_level;
+  assert.equal(afterCleanup, exposed, "reactor cleanup does not cure the player");
+  await game.player.teleport({ x: room.position[0], y: room.position[1] - .5, z: room.position[2] });
+  await game.step({ frames: 60 });
+  assert.equal((await game.info()).player.radiation_level, afterCleanup, "reactor cleanup disables subsequent room exposure");
+
+});
+
+
+test("hazards: casting Toxin Shield prevents new contamination", { skip: !enabled, timeout: 120_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_psi" });
+  await game.step({ frames: 10 });
+  for (let i = 0; i < 40; i++) {
+    if ((await game.info()).player.selected_psi_power === "Toxin Shield") break;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 1 });
+  }
+  assert.equal((await game.info()).player.selected_psi_power, "Toxin Shield");
+  await pullTrigger(game);
+  await game.step({ frames: 10 });
+  const player = (await game.info()).player;
+  assert.ok(player.active_psi_powers.includes("Toxin Shield"));
+  await game.entities.sendMessage(player.entity_id!, { type: "Hazard", toxin: true, amount: 10 });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 0);
+  await game.step({ frames: 3000 });
+  assert.ok(!(await game.info()).player.active_psi_powers.includes("Toxin Shield"));
+  await game.entities.sendMessage(player.entity_id!, { type: "Hazard", toxin: true, amount: 3 });
+  await game.step({ frames: 2 });
+  assert.equal((await game.info()).player.toxin_level, 3, "protection ends with the sustained power");
+});


### PR DESCRIPTION
Radiation and toxins now persist on the player and apply periodic damage, including authored room exposure and contact sources. Separate indicators appear in the flat HUD and cyber interface; during VR play they follow the left wrist.

Implements Endurance and Strong Metabolism resistance, shield powers, protective equipment, detox/rad patches, cleansing scripts and the Engineering radiation cleanup sequence. Contamination, active psi durations and equipped protection survive save/load and level transitions. The audit in `projects/radiation-toxins.md` records Dark Engine source, allobjs binary and gamesys evidence, including differences from the initial recollection.

Validation:
- 1,702 core unit tests passed; 2 ignored. Hazard parser test passed.
- Warnings-as-errors checks passed for shock2vr, desktop_runtime and debug_runtime.
- Runtime hazard scenarios passed: persistent toxin, Endurance, cures, suit mitigation, save/load, room entry/exit, Engineering cleanup and shield expiry. All 23 mission-load checks passed.
- Full SDK regression: all 275 test files exercised across initial, retry and remaining batches. Final 201-file batch: 524 passed, 24 failed, 10 skipped. These 24 failures and 5 earlier failures reproduce on unchanged ae2eaf5a; the audit lists every affected scenario. This is **not a green full-suite result**, but no feature-specific regression was found.
- Cross-engine code and duplication review completed; correctness fixes verified, visual tuning questions noted below. Deterministic flat/VR visual captures inspected.

Draft follow-ups: no Quest was attached. Wrist readability, occlusion and seated/standing comfort need physical headset testing; the offset remains provisional. Protective equipment uses a minimal carried-item Frob toggle. Visual review also flags green-tint brightness and the 16 cm hazard panel versus the 8.5 cm health bracelet as tuning questions for the headset pass.

## Earlier implementation captures — wrist placement superseded below

![Wrist radiation and toxin hologram](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/1db9732f6cdfc83f00fbfb3ebd236ce5e8579f18/wrist.gif)

The hazard readout follows the left wrist below the health/psi bracelet. Flat and cyber-interface views share the same pixel layout.

| Flat HUD | VR cyber interface |
| --- | --- |
| ![Flat before and after](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/1d7b412f87ce9220841f2d7acb80908d751c5cf3/flat-before-after.png) | ![Cyber interface before and after](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/71bf105feb83f2e6cff85ce5d251c95c0f43a9b9/cyber-before-after.png) |

![Wrist before and after](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/3cf4ea5edc8ab3ff858eaadc03621477ced7ef03/wrist-before-after.png)

![Radiation damage feedback](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/52000059495c896fe257a43e7cd487470ae4944e/radiation-damage.gif)

At Endurance 1, radiation 18 causes the six-second tick: HP 30 → 12, radiation 18 → 15, a green vignette, and the recorded `raddmg` sound. [Damage still](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/d45a007305c0072b4460f05c896429105bc04b99/radiation-hit.png); [before the tick](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/37723be3eddc28a82e495db8b1fc226c08df86da/before-hit.png).

Captured through the headless debug runtime with fixed 60 Hz stepping. Before/after uses the same scene and poses; the new hazard state is injected only in the after build. VR images verify tracked rendering, not physical headset comfort.

## Earlier wrist layout options — before the 45° tilt

The previous, parallel-to-hand wrist layout kept the same physical size, places hazards above health/psi, centers toxin pips, and hides inactive hazard rows. Flat and cyber-interface HUD pixels remain unchanged.

![Current framed wrist hazard states: toxin only, radiation only, both](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/867efff19db7bdb5dc21f68e9030e58ed9ff610d/wrist-framed-states.png)

![Wrist readout tracks the hand above the health bar](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/a84eb02d5304f988e868e3b2d7d231e106cce566/wrist-above-health.gif)

<details>
<summary>Borderless alternative and edge cases</summary>

![Framed and borderless comparison](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/ee973294acec81a5e6c1bb69f38d608e5ed7f131/wrist-border-comparison.png)

These framed/borderless alternatives were captured before the 45° tilt; the current implementation below retains the frame. [Borderless states](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/37a958d358408070ae35e1b71b07571492af75eb/wrist-borderless-states.png), [one toxin pip](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/a002e433ab83f9bb65c01201cf368688ecb887a1/wrist-one-toxin.png), [overflow: five pips plus “+”](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/3b690295caf26c49bf77e6cd318426f58f0a5983/wrist-toxin-overflow.png).

</details>

## Current wrist hologram — tilted 45°

The hazard panel now hinges upward from its lower edge, projecting 45° away from the glove while keeping the same size and position above health/psi.

![Tilted wrist hazards: toxin only, radiation only, both](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/1d895205cb4b77f0c33b881194280192ae9a8c7e/wrist-tilted-states.png)

![Oblique view showing the hologram projecting away from the glove](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/c39cea8f6d447fe1e059738484b32916e08bdf86/wrist-tilted-oblique.png)

![Tilted hologram follows the wrist](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/bdcfbbbe670bfc185794ea116b7cce2ea79987a9/wrist-tilted.gif)

<details>
<summary>Before/after tilt and edge cases</summary>

![Parallel panel versus 45-degree hologram](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/46f0978599396e1eb21fc6ed797f9f73f6959994/wrist-tilt-comparison.png)

[One toxin pip](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/2061a4d36843c15eebd54f510ff24b16299dbebb/wrist-tilted-one-toxin.png) · [Toxin overflow](https://gist.githubusercontent.com/tommy-xr/b498a4236333314e7b3adf2b1b6b18ae/raw/d5f2c4e391d300f7c706d5b4679f2c43396e27d4/wrist-tilted-overflow.png)

</details>

The oblique view confirms visible separation from the glove; labels remain unmirrored and health/psi stays unobscured. Flat and cyber-interface HUD captures remain pixel-identical in the HUD region. These are headless tracked-pose captures, not headset comfort testing.
