### PR TITLE
fix(turrets): use authored model articulation and device settings

### DIFF
--- a/dark/src/lib.rs
+++ b/dark/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mission;
 pub mod model;
 pub mod motion;
 pub mod name_map;
+pub mod object_articulation;
 pub mod ss2_bin_ai_loader;
 pub mod ss2_bin_header;
 pub mod ss2_bin_obj_loader;

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -85,6 +85,7 @@ pub struct AnimatedModel {
     /// there is no record of the pose the model is actually drawn in, and a
     /// corpse lying flat would be bounded by the standing rest skeleton.
     posed_bounds: Option<Aabb3<f32>>,
+    object_articulation: Option<std::sync::Arc<crate::object_articulation::ObjectArticulation>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -204,6 +205,7 @@ impl AnimatedModel {
             vhots: self.vhots.clone(),
             sub_objects: self.sub_objects.clone(),
             bind: self.bind.clone(),
+            object_articulation: self.object_articulation.clone(),
             posed_bounds: joint_box_bounds(&animated_skeleton.get_transforms(), &self.hit_boxes),
         }
     }
@@ -229,6 +231,7 @@ impl AnimatedModel {
             sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
             posed_bounds: model.posed_bounds,
+            object_articulation: model.object_articulation.clone(),
         }
     }
 
@@ -285,6 +288,9 @@ impl Model {
                     sub_objects,
                     bind: None,
                     posed_bounds: None,
+                    object_articulation: Some(std::sync::Arc::new(
+                        ss2_bin_obj_loader::object_articulation(&static_mesh),
+                    )),
                 }),
             }
         } else {
@@ -355,6 +361,7 @@ impl Model {
                 sub_objects: vec![],
                 bind,
                 posed_bounds: None,
+                object_articulation: None,
             }),
         }
     }
@@ -382,6 +389,7 @@ impl Model {
                     sub_objects: vec![],
                     bind: None,
                     posed_bounds: None,
+                    object_articulation: None,
                 }),
             }
         } else {
@@ -442,8 +450,17 @@ impl Model {
         }
     }
 
-    /// The LGMD sub-object pivots (see [`SubObject`]). Empty unless this model
-    /// came from an object `.bin`.
+    /// Authored LGMD parameter mapping and attachment ownership.
+    pub fn object_articulation(
+        &self,
+    ) -> Option<&std::sync::Arc<crate::object_articulation::ObjectArticulation>> {
+        match &self.inner {
+            InnerModel::Animated(model) => model.object_articulation.as_ref(),
+            InnerModel::Static(_) => None,
+        }
+    }
+
+    /// The LGMD sub-object pivots (see [`SubObject`]). Empty for other formats.
     pub fn sub_objects(&self) -> &[SubObject] {
         match &self.inner {
             InnerModel::Animated(animated_model) => &animated_model.sub_objects,
@@ -703,6 +720,7 @@ mod tests {
                 sub_objects: Vec::new(),
                 bind: None,
                 posed_bounds,
+                object_articulation: None,
             }),
         }
     }

--- a/dark/src/object_articulation.rs
+++ b/dark/src/object_articulation.rs
@@ -1,0 +1,162 @@
+//! LGMD scalar parameters are shared by any number of sub-objects, not bone IDs.
+//! See Dark's `md_start_subobj` in tech/libsrc/md/render.c: enter the authored
+//! axle frame, then rotate or slide along its X axis. Joint positions use
+//! degrees for rotation and Dark feet for translation (not normalized ranges).
+use std::{collections::HashMap, ops::Range};
+
+use cgmath::{Deg, Matrix4, Point3, Transform, vec3};
+
+use crate::{SCALE_FACTOR, ss2_bin_obj_loader::Vhot, ss2_skeleton::Skeleton};
+
+#[derive(Clone, Debug)]
+pub struct ObjectJoint {
+    pub index: u32,
+    pub parameter: i32,
+    pub motion_type: u8,
+    pub vhot_range: Range<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ss2_skeleton::Bone;
+    use cgmath::{InnerSpace, SquareMatrix, point3};
+
+    fn rig(remastered: bool) -> ObjectArticulation {
+        let (cap, gun) = if remastered { (1, 2) } else { (2, 1) };
+        ObjectArticulation {
+            skeleton: Skeleton::create_from_bones(vec![
+                Bone {
+                    joint_id: 0,
+                    parent_id: None,
+                    local_transform: Matrix4::identity(),
+                },
+                // Authored axle turns the converted -X slider axis upward.
+                Bone {
+                    joint_id: cap,
+                    parent_id: Some(0),
+                    local_transform: Matrix4::from_angle_z(Deg(-90.0)),
+                },
+                Bone {
+                    joint_id: gun,
+                    parent_id: Some(cap),
+                    local_transform: Matrix4::from_translation(vec3(0.0, 0.0, 1.0)),
+                },
+            ]),
+            joints: vec![
+                ObjectJoint {
+                    index: 0,
+                    parameter: -1,
+                    motion_type: 0,
+                    vhot_range: 0..0,
+                },
+                ObjectJoint {
+                    index: cap,
+                    parameter: 0,
+                    motion_type: 2,
+                    vhot_range: 0..0,
+                },
+                ObjectJoint {
+                    index: gun,
+                    parameter: 1,
+                    motion_type: 1,
+                    vhot_range: 0..1,
+                },
+            ],
+            vhots: vec![Vhot {
+                id: 7,
+                point: point3(0.0, 1.0, 0.0),
+            }],
+        }
+    }
+
+    #[test]
+    fn reordered_parts_keep_the_same_pose_and_animated_attachment() {
+        for angle in [0.0, 45.0, -90.0, 180.0] {
+            let parameters = [(0, 2.0), (1, angle)];
+            let before = rig(false).vhot_position(7, &parameters).unwrap();
+            let after = rig(true).vhot_position(7, &parameters).unwrap();
+            assert!((before - after).magnitude() < 1e-5);
+        }
+        let model = rig(true);
+        let closed = model.vhot_position(7, &[(0, 0.0), (1, 0.0)]).unwrap();
+        let open = model.vhot_position(7, &[(0, 2.0), (1, 0.0)]).unwrap();
+        assert!((open - closed - vec3(0.0, 2.0 / SCALE_FACTOR, 0.0)).magnitude() < 1e-5);
+        let aimed = model.vhot_position(7, &[(0, 2.0), (1, 90.0)]).unwrap();
+        assert!((aimed - point3(0.0, 2.0 / SCALE_FACTOR, 0.0)).magnitude() < 1e-5);
+        assert!(
+            model.vhot_position(0, &[]).is_none(),
+            "IDs are not array indices"
+        );
+    }
+
+    #[test]
+    fn one_parameter_can_drive_multiple_parts_and_unknown_parameters_are_ignored() {
+        let mut model = rig(true);
+        model.joints.push(ObjectJoint {
+            index: 3,
+            parameter: 0,
+            motion_type: 2,
+            vhot_range: 0..0,
+        });
+        let transforms = model.joint_transforms(&[(0, 2.0), (55, 99.0)]);
+        assert_eq!(transforms.len(), 2);
+        assert_eq!(transforms[&1], transforms[&3]);
+        assert!(model.joint_transforms(&[(0, f32::NAN)]).is_empty());
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ObjectArticulation {
+    pub skeleton: Skeleton,
+    pub joints: Vec<ObjectJoint>,
+    pub vhots: Vec<Vhot>,
+}
+
+impl ObjectArticulation {
+    pub fn joint_transforms(&self, parameters: &[(i32, f32)]) -> HashMap<u32, Matrix4<f32>> {
+        self.joints
+            .iter()
+            .filter_map(|joint| {
+                let value = parameters
+                    .iter()
+                    .rev()
+                    .find(|(id, _)| *id == joint.parameter)?
+                    .1;
+                if !value.is_finite() {
+                    return None;
+                }
+                // read_vec3 maps Dark (x,y,z) to (-x,z,y). The same basis
+                // conversion makes the authored axle -X in renderer space.
+                let transform = match joint.motion_type {
+                    1 => Matrix4::from_angle_x(Deg(-value)),
+                    2 => Matrix4::from_translation(vec3(-value / SCALE_FACTOR, 0.0, 0.0)),
+                    _ => return None,
+                };
+                Some((joint.index, transform))
+            })
+            .collect()
+    }
+
+    pub fn pose(&self, parameters: &[(i32, f32)]) -> [Matrix4<f32>; 40] {
+        Skeleton::set_joint_transforms(&self.skeleton, &self.joint_transforms(parameters))
+            .get_transforms()
+    }
+
+    /// Attachment ownership is a range in the file's vhot table; the attachment
+    /// ID itself may be sparse and is never a bone index.
+    pub fn vhot_position(&self, id: u32, parameters: &[(i32, f32)]) -> Option<Point3<f32>> {
+        let (index, vhot) = self
+            .vhots
+            .iter()
+            .enumerate()
+            .find(|(_, vhot)| vhot.id == id)?;
+        let owner = self
+            .joints
+            .iter()
+            .find(|joint| joint.vhot_range.contains(&index))?;
+        self.pose(parameters)
+            .get(owner.index as usize)
+            .map(|pose| pose.transform_point(vhot.point))
+    }
+}

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1136,6 +1136,10 @@ impl Links {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropPickBias(pub f32);
 
+/// AI movement turn rate, in degrees per second.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropAITurnRate(pub f32);
+
 /// Renderer\Transparency (alpha): 0.0 = invisible, 1.0 = opaque. Authored on
 /// holo/ghost entities (e.g. the CS9 cutscene exhibits) and animated by the
 /// Transluce script family.
@@ -1876,6 +1880,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$ParticleG",
             PropParticleGroup::read,
             identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_TurnR",
+            |reader, _len| read_single(reader),
+            PropAITurnRate,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -582,6 +582,29 @@ fn wrist_and_fingertip(points: &[Point3<f32>]) -> Option<(Point3<f32>, Point3<f3
     }
 }
 
+/// Preserve the LGMD parameter-to-part mapping independently of file order.
+pub fn object_articulation(
+    mesh: &SystemShock2ObjectMesh,
+) -> crate::object_articulation::ObjectArticulation {
+    use crate::object_articulation::{ObjectArticulation, ObjectJoint};
+    ObjectArticulation {
+        skeleton: obj_skeleton(mesh),
+        joints: mesh
+            .sub_objects
+            .iter()
+            .enumerate()
+            .map(|(index, part)| ObjectJoint {
+                index: index as u32,
+                parameter: part.parameter,
+                motion_type: part.motion_type,
+                vhot_range: part.vhot_start as usize
+                    ..(part.vhot_start as usize + part.vhot_count as usize),
+            })
+            .collect(),
+        vhots: mesh.vhots.clone(),
+    }
+}
+
 /// The model-space transform of every sub-object, paired with its name - the
 /// placement the artist authored for that part.
 ///
@@ -1007,8 +1030,8 @@ fn read_vertices<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Vec<V
 pub struct SubObjectHeader {
     #[allow(dead_code)]
     idx: u32,
-    #[allow(dead_code)]
-    parent_idx: i32,
+    pub parameter: i32,
+    pub motion_type: u8,
     pub name: String,
     transform: Matrix4<f32>,
     #[allow(dead_code)]
@@ -1019,6 +1042,8 @@ pub struct SubObjectHeader {
     next_sub_obj_idx: i16,
     point_start: u16,
     point_stop: u16,
+    vhot_start: u16,
+    vhot_count: u16,
 }
 
 fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Vec<SubObjectHeader> {
@@ -1031,8 +1056,8 @@ fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Ve
     let mut objs = Vec::new();
     for i in 0..header.num_objs {
         let name = read_string_with_size(reader, 8);
-        let _obj_type = read_u8(reader);
-        let parent_idx = read_i32(reader);
+        let motion_type = read_u8(reader);
+        let parameter = read_i32(reader);
         let min_range = read_single(reader);
         let max_range = read_single(reader);
 
@@ -1043,8 +1068,8 @@ fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Ve
 
         let child_sub_obj_idx = read_i16(reader);
         let next_sub_obj_idx = read_i16(reader);
-        let _vhot_start = read_i16(reader);
-        let _num_vhots = read_i16(reader);
+        let vhot_start = read_u16(reader);
+        let vhot_count = read_u16(reader);
         let point_start = read_u16(reader);
         let sub_num_points = read_u16(reader);
 
@@ -1053,7 +1078,8 @@ fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Ve
 
         let soh = SubObjectHeader {
             idx: i as u32,
-            parent_idx,
+            parameter,
+            motion_type,
             child_sub_obj_idx,
             next_sub_obj_idx,
             min_range,
@@ -1062,6 +1088,8 @@ fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Ve
             transform,
             point_start,
             point_stop: point_start + sub_num_points,
+            vhot_start,
+            vhot_count,
         };
         objs.push(soh);
     }
@@ -1208,6 +1236,31 @@ mod tests {
     use cgmath::vec3;
     use std::io::Cursor;
 
+    #[test]
+    fn subobject_parser_preserves_parameter_and_attachment_ownership() {
+        // A 93-byte LGMD record, with a deliberately unrelated file index,
+        // parameter ID and attachment ID. The old loader called parm a parent.
+        let mut bytes = vec![0u8; 93];
+        bytes[..8].copy_from_slice(b"@s07gun\0");
+        bytes[8] = 1;
+        bytes[9..13].copy_from_slice(&7i32.to_le_bytes());
+        bytes[13..17].copy_from_slice(&(-6.2f32).to_le_bytes());
+        bytes[69..71].copy_from_slice(&(-1i16).to_le_bytes());
+        bytes[71..73].copy_from_slice(&(-1i16).to_le_bytes());
+        bytes[73..75].copy_from_slice(&3u16.to_le_bytes());
+        bytes[75..77].copy_from_slice(&2u16.to_le_bytes());
+        let mut header = header_with_mat_extra(0);
+        header.num_objs = 1;
+        header.offset_objs = 0;
+        header.offset_mats = 93;
+        let objects = read_sub_objects(&header, &mut Cursor::new(bytes));
+        assert_eq!(objects[0].parameter, 7);
+        assert_eq!(objects[0].motion_type, 1);
+        assert_eq!(objects[0].vhot_start, 3);
+        assert_eq!(objects[0].vhot_count, 2);
+        assert_eq!(objects[0].min_range, -6.2);
+    }
+
     /// S_HIVOLT.BIN contains two coplanar, opposite-wound faces with inverse U
     /// mappings. Only its authored clockwise face reads left-to-right from the
     /// affected command1 placement; rendering both lets the mirrored face win
@@ -1283,7 +1336,8 @@ mod tests {
     fn sub_object(name: &str, local: Vector3<f32>, child: i16, next: i16) -> SubObjectHeader {
         SubObjectHeader {
             idx: 0,
-            parent_idx: -1,
+            parameter: -1,
+            motion_type: 0,
             name: name.to_owned(),
             transform: Matrix4::from_translation(local),
             min_range: 0.0,
@@ -1292,6 +1346,8 @@ mod tests {
             next_sub_obj_idx: next,
             point_start: 0,
             point_stop: 0,
+            vhot_start: 0,
+            vhot_count: 0,
         }
     }
 

--- a/projects/turret-articulation.md
+++ b/projects/turret-articulation.md
@@ -1,0 +1,72 @@
+# Turret articulation
+
+The 25AE replacements for `tu_f`, `tu_l`, and `tu_s` swap the cap and gun's
+sub-object indices. Their authored parameters and hierarchy are unchanged:
+
+| Part | Original index | 25AE index | Parameter | Motion |
+| --- | --- | --- | --- | --- |
+| Base | 0 | 0 | -1 | fixed |
+| Cap | 2 | 1 | 0 | slide |
+| Gun (child of cap) | 1 | 2 | 1 | rotate |
+
+The old turret script translated index 2 and rotated index 1, including an
+extra -90 degree correction. With the remaster it translated the gun and
+rotated the cap. It also used a fixed muzzle offset unrelated to the model.
+
+## Authored motion
+
+`ObjectArticulation` preserves LGMD sub-object type, parameter ID, hierarchy,
+axle transform and vhot ownership. Parameter IDs are independent of sub-object
+indices and can drive multiple parts. `SetObjectParameters` resolves them to
+the renderer's bone transforms. The same evaluator resolves the muzzle vhot
+through its owning part and all parents, using the current frame's parameters.
+
+The reference is Dark's
+[`mds_subobj`](https://github.com/infernuslord/DarkEngine/blob/master/tech/libsrc/md/mds.h)
+and [`md_start_subobj`](https://github.com/infernuslord/DarkEngine/blob/master/tech/libsrc/md/render.c):
+enter the authored axle frame, then rotate or translate about local X. Our
+coordinate conversion maps Dark `(x,y,z)` to `(-x,z,y)`, so that axle becomes
+local -X. Rotations receive degrees; translations receive Dark feet. The
+model's range metadata is not an animation fraction or a renderer clamp.
+
+The turret reads `AIDevice` for activation/rotation parameter IDs, inactive and
+active positions, activation speed, rotation activation, and facing tolerance.
+The shipped turret settings are parameter 0, positions 0 and 2, speed 0.1,
+rotation parameter 1, and tolerance 0.04 radians. Two Dark feet become 0.8
+renderer units, raising the cap and its gun child together.
+
+[`cAIJointSlideAction::Enact`](https://github.com/infernuslord/DarkEngine/blob/master/cam/src/ai/aiactjs.cpp)
+increments by `activateSpeed` each AI frame and ignores `deltaTime`. We normalize
+that legacy per-frame increment at the debug simulation's 60 Hz, then integrate
+with elapsed time in every runtime. Thus these settings take 20 simulation
+frames to open; this is an explicit frame-rate-independent timing policy,
+not a claim that the original frame-dependent code had one fixed duration.
+
+## Facing and closing
+
+An LGMD object's authored forward is Dark +X (our model -X). World targets are
+transformed into the mounted model's local frame. Only the FOV/projectile
+orientation boundary converts that direction to the helpers' +Z forward;
+there is no correction applied to the gun's bone.
+
+Turning takes the shortest angular path at `AI_TurnRate` degrees/second, with
+the original [`AIGetTurnRate`](https://github.com/infernuslord/DarkEngine/blob/master/cam/src/ai/aiprcore.h)
+default of 380. Firing requires an open turret, visible target, and facing
+within the authored epsilon. Loss of sight stops firing. The gun returns to
+parameter zero before lowering, as in
+[`cAIDevice::DeactivateSuggestActions`](https://github.com/infernuslord/DarkEngine/blob/master/cam/src/ai/aidev.cpp).
+Reacquisition reverses opening from the current height. Turret phase, height,
+facing and shot cooldown persist through BaseMonster's script-state payload.
+
+## Verification
+
+- Parser and pose tests cover parameter IDs, shared parameters, reordered
+  parts, sparse attachment IDs, parent motion, and axis conversion.
+- Turret tests cover time steps, facing relative to rotated mounts, firing
+  gates, shortest-path rotation, return-before-close, reacquisition and state
+  hydration through BaseMonster.
+- `tools/shock2-sdk/test/turret-articulation.e2e.test.ts` checks real assets in
+  both presentations: fixed base, both parts rising 0.8 units, and full closure.
+- Before/after media uses identical fixed-step requests with the 25AE assets,
+  approaching from -Z (old incorrect FOV) and +X (authored facing), then moving
+  sideways and withdrawing. The player must remain alive throughout.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -728,6 +728,16 @@ fn create_model(
         let model = maybe_model.unwrap();
         let model_ref = model.as_ref();
 
+        let mut rv_articulation = world
+            .borrow::<ViewMut<RuntimePropObjectArticulation>>()
+            .unwrap();
+        if let Some(rig) = model.object_articulation() {
+            entities.add_component(
+                entity_id,
+                &mut rv_articulation,
+                RuntimePropObjectArticulation(rig.clone()),
+            );
+        }
         let vhots = model.vhots();
         entities.add_component(entity_id, &mut rv_vhots, RuntimePropVhots(vhots));
         if let Some(muzzle) = crate::weapon_muzzle::load_fallback(asset_cache, &model_name) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8483,6 +8483,23 @@ impl MissionCore {
                 } => {
                     effects.extend(self.grab_entity_into_hand(asset_cache, entity_id, hand));
                 }
+                Effect::SetObjectParameters {
+                    entity_id,
+                    parameters,
+                } => {
+                    if let (Some(model), Some(player)) = (
+                        self.id_to_model.get(&entity_id),
+                        self.id_to_animation_player.get_mut(&entity_id),
+                    ) {
+                        if let Some(rig) = model.object_articulation() {
+                            for (joint, transform) in rig.joint_transforms(&parameters) {
+                                *player = AnimationPlayer::set_additional_joint_transform(
+                                    player, joint, transform,
+                                );
+                            }
+                        }
+                    }
+                }
                 Effect::SetJointTransform {
                     entity_id,
                     joint_id,
@@ -9062,6 +9079,16 @@ impl MissionCore {
                                 );
                             }
                         }
+                        self.world
+                            .remove::<crate::runtime_props::RuntimePropObjectArticulation>(
+                                entity_id,
+                            );
+                        if let Some(rig) = new_model.object_articulation() {
+                            self.world.add_component(
+                                entity_id,
+                                crate::runtime_props::RuntimePropObjectArticulation(rig.clone()),
+                            );
+                        }
                         self.id_to_model.insert(entity_id, new_model);
                         self.world
                             .add_component(entity_id, PropModelName(model_name));
@@ -9081,6 +9108,7 @@ impl MissionCore {
                     self.world.remove::<(
                         PropModelName,
                         RuntimePropVhots,
+                        crate::runtime_props::RuntimePropObjectArticulation,
                         crate::weapon_muzzle::MuzzleFallback,
                         crate::runtime_props::RuntimePropGloveWeapon,
                     )>(entity_id);

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -119,6 +119,11 @@ pub struct RuntimeBitmapAnimationFrameCount(pub u32);
 #[derive(Component, Debug)]
 pub struct RuntimePropVhots(pub Vec<Vhot>);
 
+#[derive(Component, Clone, Debug)]
+pub struct RuntimePropObjectArticulation(
+    pub std::sync::Arc<dark::object_articulation::ObjectArticulation>,
+);
+
 // RuntimePropDoNotSerialize - runtime prop to signal that this prop should not be serialized
 #[derive(Component)]
 pub struct RuntimePropDoNotSerialize;

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -416,7 +416,11 @@ pub(crate) fn is_entity_door(world: &shipyard::World, entity_id: shipyard::Entit
 /// Handles firing a projectile through the AIRangedWeapon link, which is a proxy between the main entity link
 /// Used primarily by turrets
 ///
-pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaternion<f32>) -> Effect {
+pub fn fire_ranged_weapon(
+    world: &World,
+    entity_id: EntityId,
+    muzzle_transform: Matrix4<f32>,
+) -> Effect {
     // First, let's find the link
     let maybe_ranged_weapon = get_first_link_with_template_and_data(world, entity_id, |link| {
         if matches!(link, Link::AIRangedWeapon) {
@@ -436,27 +440,19 @@ pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaterni
 
     let maybe_ranged_weapon_entity_id = find_first_entity_by_template_id(world, ranged_weapon);
 
-    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-    let root_transform = v_transform.get(entity_id).unwrap();
-    let forward_offset = 3.0 / SCALE_FACTOR;
-    let up_offset = 0.5 / SCALE_FACTOR;
-    let right_offset = 0.5 / SCALE_FACTOR;
-    let forward = vec3(right_offset, up_offset, 1.0 * forward_offset);
-    let firing_transform = root_transform.0 * Matrix4::from(rotation);
-    let muzzle_transform = firing_transform * Matrix4::from_translation(forward);
     let position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
 
     if maybe_ranged_weapon_entity_id.is_none() {
         // Let's create the proxy entity...
         Effect::CreateEntity {
             template_id: ranged_weapon,
-            position: point3(0.0, 0.0, 0.0) + forward,
+            position: point3(0.0, 0.0, 0.0),
             orientation: Quaternion::from_angle_y(Deg(90.0)),
-            root_transform: firing_transform,
+            root_transform: muzzle_transform,
             options: CreateEntityOptions::default(),
         }
     } else {
-        let transformed_forward = firing_transform.transform_vector(forward);
+        let transformed_forward = muzzle_transform.transform_vector(vec3(0.0, 0.0, 1.0));
         let debug_effect = Effect::DrawDebugLines {
             lines: vec![(
                 position,
@@ -513,9 +509,9 @@ pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaterni
         if let Some((muzzle_flash_template_id, _muzzle_flash_options)) = maybe_muzzle_flash {
             fire_effects.push(Effect::CreateEntity {
                 template_id: muzzle_flash_template_id,
-                position: point3(0.0, 0.0, 0.0) + forward,
+                position: point3(0.0, 0.0, 0.0),
                 orientation: Quaternion::from_angle_y(Deg(90.0)),
-                root_transform: firing_transform,
+                root_transform: muzzle_transform,
                 options: CreateEntityOptions::default(),
             })
         }
@@ -1345,8 +1341,8 @@ fn ai_team(world: &World, entity_id: EntityId) -> AITeam {
 ///   `pose.rotation` already contains the full orientation.
 /// - **Cameras**: Pass `Deg(view_angle + 90.0)` - rotation is via joint transforms,
 ///   not entity rotation. The +90 offset aligns with the joint coordinate system.
-/// - **Turrets**: Pass `-current_heading` - similar to cameras but with negated heading
-///   due to how the turret joint rotation is calculated.
+/// - **Turrets**: Pass `90 - joint_parameter_degrees`: LGMD models face -X,
+///   and the joint parameter rotates that authored direction around +Y.
 ///
 /// # Returns
 /// `true` if the player is within the FOV cone AND there's line-of-sight

--- a/shock2vr/src/scripts/ai/alertness.rs
+++ b/shock2vr/src/scripts/ai/alertness.rs
@@ -28,7 +28,7 @@ use shipyard::EntityId;
 use crate::scripts::{AIPropertyUpdate, Effect};
 
 /// Tracks the current alertness state for an AI entity.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct AlertnessState {
     /// Current alertness level
     pub current_level: AIAlertLevel,

--- a/shock2vr/src/scripts/ai/turret_ai.rs
+++ b/shock2vr/src/scripts/ai/turret_ai.rs
@@ -1,98 +1,146 @@
-use cgmath::{Deg, Matrix4, Quaternion, Rotation3, vec3};
-use dark::properties::{AIAlertLevel, PropAIAlertCap, PropAIAwareDelay};
+use cgmath::{Deg, Matrix4, Quaternion, Rotation3, SquareMatrix, Transform, point3};
+use dark::properties::{
+    AIAlertLevel, PropAIAlertCap, PropAIAwareDelay, PropAIDevice, PropAITurnRate,
+};
+use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, View, World};
-
-use crate::{physics::PhysicsWorld, time::Time};
 
 use super::{
     Effect, MessagePayload, Script,
     ai_debug_util::{self, AlertnessDebugConfig, FovDebugConfig},
     ai_util,
     alertness::{self, AlertnessState, AlertnessTimings},
-    steering::{ChasePlayerSteeringStrategy, SteeringStrategy},
+};
+use crate::{
+    physics::PhysicsWorld,
+    runtime_props::{RuntimePropObjectArticulation, RuntimePropTransform},
+    time::Time,
 };
 
-pub enum TurretState {
+const DEFAULT_ESCALATE_SECONDS: f32 = 2.0;
+const DEFAULT_DECAY_SECONDS: f32 = 4.0;
+// Dark aiprcore.h: AIGetTurnRate's default, in degrees/second.
+const DEFAULT_TURN_RATE: f32 = 380.0;
+// cAIJointSlideAction::Enact increments by activateSpeed each AI frame, ignoring
+// deltaTime. Normalize that legacy increment to our fixed 60 Hz simulation so
+// desktop/VR frame rates do not change the opening duration.
+const LEGACY_SLIDE_HZ: f32 = 60.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+enum TurretState {
     Closed,
-    Opening { progress: f32 },
-    Closing { progress: f32 },
+    Opening,
     Open,
+    Returning,
+    Closing,
 }
 
-impl TurretState {
-    pub fn update(
-        current_state: &TurretState,
-        entity_id: EntityId,
-        time: &Time,
-        world: &World,
-        is_player_visible: bool,
-    ) -> (TurretState, Effect) {
-        match current_state {
-            TurretState::Closed => {
-                if is_player_visible {
-                    (
-                        TurretState::Opening { progress: 0.0 },
-                        ai_util::play_positional_sound(
-                            entity_id,
-                            world,
-                            None,
-                            vec![("event", "activate")],
-                        ),
-                    )
-                } else {
-                    (TurretState::Closed, Effect::NoEffect)
-                }
-            }
-            TurretState::Opening { progress } => {
-                if *progress >= 1.0 {
-                    (TurretState::Open, Effect::NoEffect)
-                } else {
-                    (
-                        TurretState::Opening {
-                            progress: progress + time.elapsed.as_secs_f32() / OPEN_TIME,
-                        },
-                        Effect::NoEffect,
-                    )
-                }
-            }
-            TurretState::Closing { progress } => {
-                if *progress >= 1.0 {
-                    (TurretState::Closed, Effect::NoEffect)
-                } else {
-                    (
-                        TurretState::Closing {
-                            progress: progress + time.elapsed.as_secs_f32() / OPEN_TIME,
-                        },
-                        Effect::NoEffect,
-                    )
-                }
-            }
-            TurretState::Open => {
-                if !is_player_visible {
-                    (
-                        TurretState::Closing { progress: 0.0 },
-                        ai_util::play_positional_sound(
-                            entity_id,
-                            world,
-                            None,
-                            vec![("event", "deactivate")],
-                        ),
-                    )
-                } else {
-                    (TurretState::Open, Effect::NoEffect)
-                }
-            }
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct TurretPose {
+    state: TurretState,
+    activation: f32,
+    facing: f32,
+    fire_cooldown: f32,
+}
+
+/// Convert a world target into the mounted model's facing parameter. Doing this
+/// in model space also handles a rotated mount without subtracting Euler yaws.
+fn target_parameter(root: Matrix4<f32>, target: cgmath::Point3<f32>) -> Option<f32> {
+    let local = root.invert()?.transform_point(target);
+    if local.x * local.x + local.z * local.z < 1e-8 {
+        return None;
+    }
+    Some(angle_delta(local.x.atan2(local.z).to_degrees() + 90.0, 0.0))
+}
+
+fn angle_delta(target: f32, current: f32) -> f32 {
+    (target - current + 180.0).rem_euclid(360.0) - 180.0
+}
+fn approach(current: f32, target: f32, step: f32) -> f32 {
+    current + (target - current).clamp(-step, step)
+}
+fn turn(current: f32, target: f32, step: f32) -> f32 {
+    angle_delta(
+        current + angle_delta(target, current).clamp(-step, step),
+        0.0,
+    )
+}
+
+impl TurretPose {
+    fn new(inactive: f32) -> Self {
+        Self {
+            state: TurretState::Closed,
+            activation: inactive,
+            facing: 0.0,
+            fire_cooldown: 0.0,
         }
+    }
+    fn advance(
+        &mut self,
+        visible: bool,
+        target: f32,
+        device: &PropAIDevice,
+        turn_rate: f32,
+        dt: f32,
+    ) -> Option<&'static str> {
+        let dt = dt.max(0.0);
+        self.fire_cooldown = (self.fire_cooldown - dt).max(0.0);
+        let mut sound = None;
+        if visible
+            && matches!(
+                self.state,
+                TurretState::Closed | TurretState::Returning | TurretState::Closing
+            )
+        {
+            self.state = TurretState::Opening;
+            sound = Some("activate");
+        } else if !visible && matches!(self.state, TurretState::Open | TurretState::Opening) {
+            self.state = TurretState::Returning;
+        }
+        let activation_step = if device.activate_rotate {
+            turn_rate
+        } else {
+            device.activate_speed.abs() * LEGACY_SLIDE_HZ
+        } * dt;
+        match self.state {
+            TurretState::Opening => {
+                self.activation = approach(self.activation, device.active_pos, activation_step);
+                if self.activation == device.active_pos {
+                    self.state = TurretState::Open;
+                }
+            }
+            TurretState::Open => self.facing = turn(self.facing, target, turn_rate * dt),
+            TurretState::Returning => {
+                self.facing = turn(self.facing, 0.0, turn_rate * dt);
+                if self.facing == 0.0 {
+                    self.state = TurretState::Closing;
+                    sound = Some("deactivate");
+                }
+            }
+            TurretState::Closing => {
+                self.activation = approach(self.activation, device.inactive_pos, activation_step);
+                if self.activation == device.inactive_pos {
+                    self.state = TurretState::Closed;
+                }
+            }
+            TurretState::Closed => {}
+        }
+        sound
+    }
+    fn parameters(&self, device: &PropAIDevice) -> Vec<(i32, f32)> {
+        vec![
+            (device.joint_activate, self.activation),
+            (device.joint_rotate, self.facing),
+        ]
+    }
+    fn can_fire(&self, visible: bool, target: f32, epsilon: f32) -> bool {
+        visible
+            && self.state == TurretState::Open
+            && self.fire_cooldown == 0.0
+            && angle_delta(target, self.facing).abs() <= epsilon.to_degrees()
     }
 }
 
-const OPEN_TIME: f32 = 2.5;
-
-// Default timing constants for turrets (in seconds)
-const DEFAULT_ESCALATE_SECONDS: f32 = 2.0;
-const DEFAULT_DECAY_SECONDS: f32 = 4.0;
-
-/// Configuration for turret alertness behavior
 #[derive(Clone)]
 struct TurretConfig {
     alert_cap: PropAIAlertCap,
@@ -100,30 +148,25 @@ struct TurretConfig {
 }
 
 pub struct TurretAI {
-    next_fire: f32,
-    initial_yaw: Deg<f32>,
-    current_heading: Deg<f32>,
-    steering: ChasePlayerSteeringStrategy,
-    current_state: TurretState,
-    /// Alertness state tracking
+    pose: TurretPose,
+    restored: bool,
     alertness: AlertnessState,
-    /// Alertness configuration (loaded from entity properties)
     config: Option<TurretConfig>,
+    device: Option<PropAIDevice>,
+    turn_rate: f32,
 }
 
 impl TurretAI {
-    pub fn new() -> TurretAI {
-        TurretAI {
-            next_fire: 0.0,
-            initial_yaw: Deg(0.0),
-            steering: ChasePlayerSteeringStrategy,
-            current_heading: Deg(0.0),
-            current_state: TurretState::Closed,
+    pub fn new() -> Self {
+        Self {
+            pose: TurretPose::new(0.0),
+            restored: false,
             alertness: AlertnessState::default(),
             config: None,
+            device: None,
+            turn_rate: DEFAULT_TURN_RATE,
         }
     }
-
     fn build_config(world: &World, entity_id: EntityId) -> Option<TurretConfig> {
         let (v_alert_cap, v_aware_delay): (View<PropAIAlertCap>, View<PropAIAwareDelay>) =
             world.borrow().ok()?;
@@ -157,69 +200,41 @@ impl TurretAI {
 
         Some(TurretConfig { alert_cap, timings })
     }
-
-    fn try_to_shoot(
-        &mut self,
-        time: &Time,
-        world: &World,
-        entity_id: EntityId,
-        physics: &PhysicsWorld,
-    ) -> Effect {
-        let _quat = Quaternion::from_angle_x(Deg(time.total.as_secs_f32().sin() * 90.0));
-        let fire_projectile = if self.next_fire < time.total.as_secs_f32() {
-            self.next_fire = time.total.as_secs_f32() + 1.0;
-            let rotation = Quaternion::from_angle_y(self.current_heading - self.initial_yaw);
-            ai_util::fire_ranged_weapon(world, entity_id, rotation)
-        } else {
-            Effect::NoEffect
-        };
-
-        let maybe_desired_yaw =
-            self.steering
-                .steer(self.current_heading, world, physics, entity_id, time);
-
-        let rotation_effect = {
-            if let Some((steering_output, _effect)) = maybe_desired_yaw {
-                self.current_heading = steering_output.desired_heading;
-                let rotate = Quaternion::from_angle_x(Deg(self.initial_yaw.0
-                    - self.current_heading.0
-                    - 90.0));
-                let rotate_animation = Effect::SetJointTransform {
-                    entity_id,
-                    joint_id: 1,
-                    transform: rotate.into(),
-                };
-
-                Effect::combine(vec![rotate_animation, _effect])
-            } else {
-                Effect::NoEffect
-            }
-        };
-
-        Effect::combine(vec![fire_projectile, rotation_effect])
-    }
 }
 
 impl Script for TurretAI {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
-        self.initial_yaw = ai_util::current_yaw(entity_id, world);
-        // Steering returns an absolute world yaw. Seed it from the mounted
-        // orientation so the first steering update does not reinterpret zero
-        // as world-forward and turn a rotated turret away from its target.
-        self.current_heading = self.initial_yaw;
-
-        // Load alertness configuration
         self.config = Self::build_config(world, entity_id);
-
-        // Initialize alertness state
-        if let Some(config) = &self.config {
-            let initial_level = alertness::clamp_level(AIAlertLevel::Lowest, &config.alert_cap);
-            self.alertness = AlertnessState::new(initial_level);
-
-            // Sync initial alertness to ECS
-            return alertness::sync_alertness_effect(entity_id, &self.alertness);
+        if !self.restored {
+            if let Some(config) = &self.config {
+                self.alertness = AlertnessState::new(alertness::clamp_level(
+                    AIAlertLevel::Lowest,
+                    &config.alert_cap,
+                ));
+            }
         }
-
+        self.device = world
+            .borrow::<View<PropAIDevice>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().cloned());
+        self.turn_rate = world
+            .borrow::<View<PropAITurnRate>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|p| p.0))
+            .filter(|v| v.is_finite() && *v > 0.0)
+            .unwrap_or(DEFAULT_TURN_RATE);
+        if let Some(device) = &self.device {
+            if !self.restored {
+                self.pose = TurretPose::new(device.inactive_pos);
+            }
+            return Effect::combine(vec![
+                alertness::sync_alertness_effect(entity_id, &self.alertness),
+                Effect::SetObjectParameters {
+                    entity_id,
+                    parameters: self.pose.parameters(device),
+                },
+            ]);
+        }
         Effect::NoEffect
     }
 
@@ -230,90 +245,107 @@ impl Script for TurretAI {
         physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
-        let delta = time.elapsed.as_secs_f32();
-
-        // Turret FOV is 30 degrees half-angle (matches FovDebugConfig::turret())
-        // Turret uses joint transforms for rotation, negate heading to match visual direction
-        const TURRET_FOV_HALF_ANGLE: f32 = 30.0;
-        let is_visible = ai_util::is_player_visible_in_fov(
-            entity_id,
-            world,
-            physics,
-            self.initial_yaw - self.current_heading,
-            TURRET_FOV_HALF_ANGLE,
-        );
-
-        // Update alertness state
-        let alertness_effect = if let Some(config) = &self.config {
-            if let Some((_old_level, _new_level)) = alertness::process_alertness_update(
+        let Some(device) = &self.device else {
+            return Effect::NoEffect;
+        };
+        let dt = time.elapsed.as_secs_f32();
+        // Object models face Dark +X, converted to model -X. The shared FOV
+        // helper uses +Z and negates its heading argument; convert only here.
+        // This is a coordinate-system boundary, not a correction to a bone.
+        let heading = Deg(90.0 - self.pose.facing);
+        let visible = ai_util::is_player_visible_in_fov(entity_id, world, physics, heading, 30.0);
+        let target = ai_util::chase_target(world, entity_id)
+            .and_then(|target| {
+                let transforms = world.borrow::<View<RuntimePropTransform>>().ok()?;
+                let root = transforms.get(entity_id).ok()?.0;
+                target_parameter(root, point3(target.x, target.y, target.z))
+            })
+            .unwrap_or(self.pose.facing);
+        let mut effects = Vec::new();
+        if let Some(config) = &self.config {
+            if alertness::process_alertness_update(
                 &mut self.alertness,
-                is_visible,
-                delta,
+                visible,
+                dt,
                 &config.timings,
                 &config.alert_cap,
-            ) {
-                // Level changed - sync to ECS
-                alertness::sync_alertness_effect(entity_id, &self.alertness)
-            } else {
-                Effect::NoEffect
+            )
+            .is_some()
+            {
+                effects.push(alertness::sync_alertness_effect(entity_id, &self.alertness));
             }
-        } else {
-            Effect::NoEffect
-        };
-
-        // Existing turret state machine (now uses FOV-aware visibility)
-        let (new_state, state_eff) =
-            TurretState::update(&self.current_state, entity_id, time, world, is_visible);
-        self.current_state = new_state;
-
-        let open_amount = match self.current_state {
-            TurretState::Closed => 0.0,
-            TurretState::Opening { progress } => progress,
-            TurretState::Closing { progress } => 1.0 - progress,
-            TurretState::Open => 1.0,
-        };
-
-        let cap_animation = Effect::SetJointTransform {
+        }
+        if let Some(event) = self
+            .pose
+            .advance(visible, target, device, self.turn_rate, dt)
+        {
+            effects.push(ai_util::play_positional_sound(
+                entity_id,
+                world,
+                None,
+                vec![("event", event)],
+            ));
+        }
+        let parameters = self.pose.parameters(device);
+        effects.push(Effect::SetObjectParameters {
             entity_id,
-            joint_id: 2,
-            transform: Matrix4::from_translation(vec3(-0.75 * open_amount, 0.0, 0.0)),
-        };
-
-        let attack_eff = if matches!(self.current_state, TurretState::Open) {
-            self.try_to_shoot(time, world, entity_id, physics)
-        } else {
-            Effect::NoEffect
-        };
-
-        // Debug visualization - alertness bar
-        let alertness_debug_eff = ai_debug_util::draw_debug_alertness(
+            parameters: parameters.clone(),
+        });
+        if self.pose.can_fire(visible, target, device.facing_epsilon) {
+            let rig = world
+                .borrow::<View<RuntimePropObjectArticulation>>()
+                .unwrap();
+            let transforms = world.borrow::<View<RuntimePropTransform>>().unwrap();
+            if let (Ok(rig), Ok(root)) = (rig.get(entity_id), transforms.get(entity_id)) {
+                if let Some(muzzle) = rig.0.vhot_position(0, &parameters) {
+                    // Resolve from this frame's parameters, not the previous
+                    // frame's ECS palette: effects apply after scripts return.
+                    let position = root.0.transform_point(muzzle);
+                    let orientation = root.0
+                        * Matrix4::from(Quaternion::from_angle_y(Deg(self.pose.facing - 90.0)));
+                    let mut muzzle_transform = orientation;
+                    muzzle_transform.w = position.to_homogeneous();
+                    effects.push(ai_util::fire_ranged_weapon(
+                        world,
+                        entity_id,
+                        muzzle_transform,
+                    ));
+                    self.pose.fire_cooldown = 1.0;
+                }
+            }
+        }
+        effects.push(ai_debug_util::draw_debug_alertness(
             world,
             entity_id,
             &self.alertness,
-            is_visible,
+            visible,
             &AlertnessDebugConfig::turret(),
-        );
-
-        // Debug visualization - FOV cone
-        // Negate heading to match visibility check
-        let fov_debug_eff = ai_debug_util::draw_debug_fov(
+        ));
+        effects.push(ai_debug_util::draw_debug_fov(
             world,
             entity_id,
-            self.initial_yaw - self.current_heading,
-            is_visible,
+            Deg(90.0 - self.pose.facing),
+            visible,
             &FovDebugConfig::turret(),
-        );
-
-        Effect::combine(vec![
-            alertness_effect,
-            cap_animation,
-            state_eff,
-            attack_eff,
-            alertness_debug_eff,
-            fov_debug_eff,
-        ])
+        ));
+        Effect::combine(effects)
     }
 
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some("shock2vr.turret")
+    }
+    fn save_state(&self) -> Result<super::super::ScriptState, super::super::ScriptStateError> {
+        super::super::ScriptState::encode(1, &(&self.pose, &self.alertness), "shock2vr.turret")
+    }
+    fn restore_state(
+        &mut self,
+        state: &super::super::ScriptState,
+        _context: &super::super::ScriptRestoreContext<'_>,
+    ) -> Result<(), super::super::ScriptStateError> {
+        (self.pose, self.alertness) = state.decode(1, "shock2vr.turret")?;
+        self.restored = true;
+        Ok(())
+    }
     fn handle_message(
         &mut self,
         _entity_id: EntityId,
@@ -322,5 +354,129 @@ impl Script for TurretAI {
         _msg: &MessagePayload,
     ) -> Effect {
         Effect::NoEffect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scripts::{BaseMonster, ScriptRestoreContext};
+    use std::collections::HashMap;
+
+    fn device() -> PropAIDevice {
+        PropAIDevice {
+            joint_activate: 0,
+            inactive_pos: 0.0,
+            active_pos: 2.0,
+            activate_speed: 0.1,
+            joint_rotate: 1,
+            facing_epsilon: 0.04,
+            activate_rotate: false,
+        }
+    }
+
+    #[test]
+    fn target_facing_is_relative_to_the_mounted_models_authored_forward() {
+        for yaw in [0.0, 90.0, 180.0, -35.0] {
+            let root = Matrix4::from_translation(cgmath::vec3(4.0, 2.0, 12.0))
+                * Matrix4::from_angle_y(Deg(yaw));
+            for parameter in [0.0, 20.0, -25.0, 179.0] {
+                let local_target =
+                    Matrix4::from_angle_y(Deg(parameter)).transform_point(point3(-10.0, 0.0, 0.0));
+                let actual = target_parameter(root, root.transform_point(local_target)).unwrap();
+                assert!(angle_delta(parameter, actual).abs() < 0.001);
+            }
+        }
+    }
+
+    #[test]
+    fn authored_travel_is_frame_rate_independent_and_clamps_at_both_ends() {
+        for hz in [30, 60, 90, 120] {
+            let mut pose = TurretPose::new(0.0);
+            for _ in 0..hz {
+                pose.advance(true, 0.0, &device(), 90.0, 1.0 / hz as f32);
+            }
+            assert_eq!(pose.activation, 2.0);
+            assert_eq!(pose.state, TurretState::Open);
+            for _ in 0..hz {
+                pose.advance(false, 0.0, &device(), 90.0, 1.0 / hz as f32);
+            }
+            assert_eq!(pose.activation, 0.0);
+            assert_eq!(pose.state, TurretState::Closed);
+        }
+        let mut pose = TurretPose::new(0.0);
+        pose.advance(true, 0.0, &device(), 90.0, 0.1);
+        assert!((pose.activation - 0.6).abs() < 1e-6);
+        assert!(!pose.can_fire(true, 0.0, 0.04));
+    }
+
+    #[test]
+    fn turn_before_firing_and_return_home_before_lowering() {
+        let mut pose = TurretPose::new(0.0);
+        pose.advance(true, 30.0, &device(), 90.0, 1.0);
+        assert!(!pose.can_fire(true, 30.0, 0.04));
+        pose.advance(true, 30.0, &device(), 90.0, 0.1);
+        assert_eq!(pose.facing, 9.0);
+        pose.advance(true, 30.0, &device(), 90.0, 1.0);
+        assert!(pose.can_fire(true, 30.0, 0.04));
+        pose.advance(false, 30.0, &device(), 90.0, 0.1);
+        assert_eq!(pose.state, TurretState::Returning);
+        assert_eq!(pose.activation, 2.0);
+        assert_eq!(pose.facing, 21.0);
+        pose.advance(false, 30.0, &device(), 90.0, 1.0);
+        assert_eq!(pose.state, TurretState::Closing);
+        assert_eq!(pose.facing, 0.0);
+        assert_eq!(pose.activation, 2.0);
+        pose.advance(false, 30.0, &device(), 90.0, 1.0);
+        assert_eq!(pose.state, TurretState::Closed);
+    }
+
+    #[test]
+    fn reacquisition_reverses_from_current_height_and_turn_takes_shortest_arc() {
+        assert_eq!(turn(179.0, -179.0, 1.0), -180.0);
+        let mut pose = TurretPose::new(0.0);
+        pose.advance(true, 0.0, &device(), 90.0, 1.0);
+        pose.advance(false, 0.0, &device(), 90.0, 0.1);
+        pose.advance(false, 0.0, &device(), 90.0, 0.1);
+        assert!((pose.activation - 1.4).abs() < 1e-5);
+        pose.advance(true, 0.0, &device(), 90.0, 0.05);
+        assert!((pose.activation - 1.7).abs() < 1e-5);
+        assert_eq!(pose.state, TurretState::Opening);
+    }
+
+    #[test]
+    fn native_turret_pose_round_trips_through_base_monster() {
+        let mut turret = TurretAI::new();
+        turret.pose.activation = 1.1;
+        turret.pose.facing = 27.0;
+        turret.pose.state = TurretState::Returning;
+        turret.pose.fire_cooldown = 0.4;
+        turret.alertness.current_level = AIAlertLevel::High;
+        turret.alertness.hidden_time = 1.25;
+        let saved = turret.save_state().unwrap();
+        let outer = super::super::super::ScriptState::encode(
+            2,
+            &serde_json::json!({
+                "stasis": null, "turret": saved
+            }),
+            "shock2vr.ai_stasis",
+        )
+        .unwrap();
+        let mut base = BaseMonster::new();
+        base.restore_state(&outer, &ScriptRestoreContext::new(&HashMap::new()))
+            .unwrap();
+        let mut world = World::new();
+        let entity = world.add_entity((
+            dark::properties::PropAI("turret".into()),
+            device(),
+            RuntimePropTransform(Matrix4::identity()),
+            dark::properties::PropPosition {
+                position: cgmath::vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::from_angle_y(Deg(0.0)),
+            },
+        ));
+        base.initialize_after_hydration(entity, &world, true);
+        assert_eq!(base.save_state().unwrap(), outer);
     }
 }

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -12,12 +12,20 @@ use super::{
 pub struct BaseMonster {
     ai: Box<dyn Script>,
     stasis: Option<super::stasis::StasisState>,
+    restored_turret: bool,
 }
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BaseMonsterState {
+    stasis: Option<super::stasis::StasisState>,
+    turret: Option<super::ScriptState>,
+}
+
 impl BaseMonster {
     pub fn new() -> BaseMonster {
         BaseMonster {
             ai: Box::new(NoopScript {}),
             stasis: None,
+            restored_turret: false,
         }
     }
 }
@@ -30,14 +38,33 @@ impl Script for BaseMonster {
         Some("shock2vr.ai_stasis")
     }
     fn save_state(&self) -> Result<super::ScriptState, super::ScriptStateError> {
-        super::ScriptState::encode(1, &self.stasis, "shock2vr.ai_stasis")
+        let turret = if self.ai.script_state_key() == Some("shock2vr.turret") {
+            Some(self.ai.save_state()?)
+        } else {
+            None
+        };
+        super::ScriptState::encode(
+            2,
+            &BaseMonsterState {
+                stasis: self.stasis.clone(),
+                turret,
+            },
+            "shock2vr.ai_stasis",
+        )
     }
     fn restore_state(
         &mut self,
         state: &super::ScriptState,
-        _context: &super::ScriptRestoreContext<'_>,
+        context: &super::ScriptRestoreContext<'_>,
     ) -> Result<(), super::ScriptStateError> {
-        self.stasis = state.decode(1, "shock2vr.ai_stasis")?;
+        let restored: BaseMonsterState = state.decode(2, "shock2vr.ai_stasis")?;
+        self.stasis = restored.stasis;
+        if let Some(turret) = restored.turret {
+            let mut ai = TurretAI::new();
+            ai.restore_state(&turret, context)?;
+            self.ai = Box::new(ai);
+            self.restored_turret = true;
+        }
         // Reject malformed state through the same typed decoder error path.
         if self.stasis.as_ref().is_some_and(|state| !state.valid()) {
             return Err(super::ScriptStateError::InvalidPayload {
@@ -53,8 +80,7 @@ impl Script for BaseMonster {
         world: &World,
         _hydrated: bool,
     ) -> Effect {
-        // Only stasis is hydrated; the native AI must still be constructed.
-        // initialize() deliberately leaves the restored freeze state intact.
+        // initialize() preserves hydrated native turret state and stasis.
         self.initialize(entity, world)
     }
 
@@ -103,7 +129,9 @@ impl Script for BaseMonster {
                 }
             };
 
-        self.ai = ai;
+        if !self.restored_turret {
+            self.ai = ai;
+        }
 
         self.ai.initialize(entity_id, world)
     }
@@ -197,6 +225,7 @@ mod tests {
         let count = Rc::new(Cell::new(0));
         let mut script = BaseMonster {
             ai: Box::new(Counter(count.clone())),
+            restored_turret: false,
             stasis: None,
         };
         let physics = PhysicsWorld::new();

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -769,6 +769,11 @@ pub enum Effect {
         position: Vector3<f32>,
         rotation: Quaternion<f32>,
     },
+    /// LGMD parameter IDs, in degrees or Dark feet according to the model.
+    SetObjectParameters {
+        entity_id: EntityId,
+        parameters: Vec<(i32, f32)>,
+    },
     SetJointTransform {
         entity_id: EntityId,
         joint_id: u32,

--- a/tools/shock2-sdk/test/turret-articulation.e2e.test.ts
+++ b/tools/shock2-sdk/test/turret-articulation.e2e.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+for (const vr of [false, true]) {
+  test(`turret raises both moving parts and closes fully (${vr ? "VR" : "flat"})`,
+    { skip: !enabled, timeout: 300_000 }, async () => {
+      await using game = await GameServer.launch({
+        mission: "debug_turret", debugFlags: vr ? ["--vr"] : [],
+      });
+      const [turret] = await game.entities.byTemplate(-168);
+      assert.ok(turret);
+      const [x, y, z] = turret.position;
+      await game.player.teleport({ x, y, z: z + 8 });
+      await game.step({ frames: 2 });
+      const closed = await game.entities.animation(turret.id);
+      assert.ok(closed);
+
+      // The debug scene mounts this turret at 180 degrees. Its authored Dark
+      // +X forward therefore faces world +X. Old AI watched world -Z instead.
+      await game.player.teleport({ x: x + 12, y, z });
+      await game.step({ frames: 30 });
+      const open = await game.entities.animation(turret.id);
+      assert.ok(open);
+      for (const index of [1, 2]) {
+        const before = closed.joints[index];
+        const after = open.joints[index];
+        assert.ok(Math.abs(after[1] - before[1] - 0.8) < 0.001,
+          `part ${index} must rise the authored two Dark feet`);
+        assert.ok(Math.abs(after[0] - before[0]) < 0.001);
+        assert.ok(Math.abs(after[2] - before[2]) < 0.001);
+      }
+      assert.deepEqual(open.joints[0], closed.joints[0], "base stays fixed");
+
+      // Aim off-axis before withdrawing, exercising the return-home phase.
+      await game.player.teleport({ x: x + 12, y, z: z + 3 });
+      await game.step({ frames: 30 });
+      await game.player.teleport({ x: x - 12, y, z });
+      await game.step({ frames: 120 });
+      const returned = await game.entities.animation(turret.id);
+      assert.ok(returned);
+      for (const index of [0, 1, 2]) {
+        for (let axis = 0; axis < 3; axis++) {
+          assert.ok(Math.abs(returned.joints[index][axis] - closed.joints[index][axis]) < 0.001,
+            `part ${index} must return to its closed position`);
+        }
+      }
+    });
+}


### PR DESCRIPTION
25AE reordered the cap and gun in all three turret models. The old fixed bone indices now rotated the cap and translated the gun. This change resolves the models' stable articulation parameter IDs and evaluates motion in their authored axle frames.

Turrets now raise the cap and gun together using `AIDevice`, face targets at the authored turn rate, fire from the animated muzzle only when aligned, and return the gun home before closing. FOV follows the model's authored forward. Native turret pose, cooldown and alertness round-trip through script saves.

The original slide action applied `activateSpeed` per AI frame without using elapsed time. This implementation explicitly normalizes that increment to 60 Hz (the shipped 0.1/2-foot settings open in 20 simulation frames), then uses elapsed time in all presentations. [Implementation notes and source references](https://github.com/tommy-xr/shock2quest/blob/65dc4d22589cd85b81108afb760a5c81f12cf4e8/projects/turret-articulation.md) explain the coordinate and timing conventions.

Validation:
- `cargo test -p dark --lib`: 180 passed.
- `cargo test -p shock2vr --lib`: 1,726 passed, 2 ignored; final focused turret tests also passed.
- Before/after 25AE capture confirms straight cap travel, horizontal tracking, full closure and successful shots. Measured cap and gun travel: 0.8 world units each; base unchanged.
- SDK integration tests: all 23 missions loaded and stepped; turret articulation regression passed in flat and VR (25/25).
- Final flat/VR render verification and laser firing probe passed; before/after GIFs and stills below.
- Formatting check passed. GitHub platform builds are running.

## Visual verification

The same deterministic 25AE scene sequence approaches from south, tracks side to side, withdraws, then repeats from east. The corrected turret detects along its authored facing, raises its cap and gun, aims the gun independently, and returns home before closing.

| Before | After |
| --- | --- |
| ![Before: turret articulation](https://gist.githubusercontent.com/tommy-xr/d960136e0d393c271c45ba481b5f6207/raw/d5bcf2e8c6861c8a9783c040f2df52091a6ad10f/before.gif) | ![After: turret articulation](https://gist.githubusercontent.com/tommy-xr/d960136e0d393c271c45ba481b5f6207/raw/d5bcf2e8c6861c8a9783c040f2df52091a6ad10f/after.gif) |

![Before and after, same two target positions](https://gist.githubusercontent.com/tommy-xr/d960136e0d393c271c45ba481b5f6207/raw/d5bcf2e8c6861c8a9783c040f2df52091a6ad10f/before-after.png)

![Laser bolt leaving the articulated barrel](https://gist.githubusercontent.com/tommy-xr/d960136e0d393c271c45ba481b5f6207/raw/d5bcf2e8c6861c8a9783c040f2df52091a6ad10f/firing.png)

<details><summary>VR presentation</summary>

![Corrected turret open in VR](https://gist.githubusercontent.com/tommy-xr/d960136e0d393c271c45ba481b5f6207/raw/d5bcf2e8c6861c8a9783c040f2df52091a6ad10f/open.png)

</details>

<sub>Captured headlessly with the debug runtime and SDK; fixed 60 Hz simulation, four simulation frames per GIF frame.</sub>

