### PR TITLE
feat(vr): add hold-to-eject and carried ammo cycling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -166,14 +166,23 @@ that hand holds (`shock2vr/src/hand_buttons.rs`):
 | that hand holds | lower (`X`/`A`) | upper (`Y`/`B`) |
 | --- | --- | --- |
 | nothing, a melee weapon, or any other item | `Jump` | `ReadLastUnreadLog` |
-| a gun | `Jump` | `CycleGunSetting` - that hand's gun, so dual wielding switches the one pressed; a gun with one mode is a no-op |
+| a gun | `Jump` | tap/release switches that gun's fire mode; hold ~0.5 s drops its loaded clip, with progress on its cuff meter |
+| an ammo clip | `Jump` | swap with the next compatible carried ammo type, returning the original clip to the backpack |
 | the psi amp | `Jump` | `SelectPsiPower` - the power selection MFD, in the cyber interface |
 
 The lower button is jump unconditionally: it is the one control a player reaches
 for with both hands full, so a held weapon must not take it away. Only the upper
-button is contextual. `EjectClip` and `CyclePsiPower` therefore have no button
-any more - the settings MFD's UNLOAD and the psi MFD's stick navigation cover
-them - though both actions keep their flat keys and HTTP/SDK paths.
+button is contextual. The settings MFD's UNLOAD and `EjectClip` still return rounds to the backpack;
+upper-button holding drops a physical clip instead. `CyclePsiPower` stays on
+the psi MFD's stick navigation. Both actions keep their flat keys and HTTP/SDK paths.
+
+Gun taps fire on release, and a completed hold fires once and swallows release.
+Changing weapons, entering a panel, pausing, death, or a session interruption
+cancels a pending hold. Empty and energy weapons eject nothing. Ammo swaps
+preserve the actual clip entities and counts, skip unavailable or unrelated
+ammo, and refuse if the outgoing clip cannot fit in the backpack. The other
+hand's gun determines compatibility first, then carried guns, then authored
+ammo families when no gun is carried.
 
 Mode first: while the cyber interface is up the lower button keeps its close
 (rather than jumping) and the upper one the log reader, on both hands whatever

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
   strip with your free hand and bring it to the gun the other hand is holding -
   the clip goes in and the weapon is loaded. A clip of a different ammo type
-  swaps the type over, returning the rounds already loaded to your pack - that
-  insert is the only way to change ammo type in the headset, so the types you
-  can select are the ones you are carrying clips for. There is no reload or
-  ammo-swap button on the controllers; the gesture is the control.
+  swaps the type over, returning the rounds already loaded to your pack.
+  While holding a clip, tap that hand's upper button (`Y` / `B`) to exchange it
+  for the next compatible ammo type in your backpack; the original clip returns
+  to the pack with its rounds intact. Insert the new clip to load that type.
 - Quest VR: rearrange inventory by gripping an item, pointing at its new
   location, and releasing. Tall items slide up to fit the chosen column.
   The ghost footprint previews the destination: green for placement or merging,
@@ -75,8 +75,11 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - Quest VR: with that hand free, press an upper face button (left `Y` / right
   `B`) to open the newest unread audio log. Press it again to close it; after
   every log is read, it replays the most recently collected log. Holding a
-  weapon, that hand's upper button is the weapon's instead: a gun's fire mode,
-  the psi amp's power selector.
+  weapon, that hand's upper button is the weapon's instead: tap and release to
+  switch a gun's fire mode, or hold for half a second to drop its loaded clip
+  into the world. The cuff ammo meter fills a border and shows `EJECT` during
+  the hold. A completed hold does not also switch modes. The psi amp keeps
+  its power selector.
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,
   `6` EMP Rifle, `7` Electro Shock, `8` Grenade Launcher, `9` Stasis Field

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   every log is read, it replays the most recently collected log. Holding a
   weapon, that hand's upper button is the weapon's instead: tap and release to
   switch a gun's fire mode, or hold for half a second to drop its loaded clip
-  into the world. The cuff ammo meter fills a border and shows `EJECT` during
-  the hold. A completed hold does not also switch modes. The psi amp keeps
+  into the world. A thin line fills left to right along the bottom of the cuff
+  ammo meter, which shows `EJECT` during the hold. A completed hold does not
+  also switch modes. The psi amp keeps
   its power selector.
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,

--- a/shock2vr/src/hand_buttons.rs
+++ b/shock2vr/src/hand_buttons.rs
@@ -18,7 +18,9 @@
 //!
 //! Resolution is pure ([`resolve_hand_button`]) and the world lookup that
 //! feeds it is one function ([`held_kind_in_hand`]), so the whole table is
-//! host-testable. This is contextual input - it reads game state - so it lives
+//! host-testable. Gun taps are delayed until release by `weapon_button_hold`;
+//! its long press ejects instead, before this instantaneous table is dispatched.
+//! This is contextual input - it reads game state - so it lives
 //! beside `VirtualHand` rather than in `ActionDispatcher`, which only handles
 //! actions whose meaning never changes.
 
@@ -46,8 +48,10 @@ pub enum HeldKind {
     Gun,
     /// The psi amp, which owns its hand's buttons for power selection.
     PsiAmp,
-    /// Anything else carried: a clip, a log disc, a medkit.
+    /// Anything else carried: a log disc or a medkit.
     Other,
+    /// A physical ammunition clip.
+    Ammo,
 }
 
 /// Whether the player-owned interface (the cyber interface / use mode) is up.
@@ -65,7 +69,8 @@ pub enum HandButtonMode {
 /// | hand holds | lower (X/A) | upper (Y/B) |
 /// |---|---|---|
 /// | nothing, melee, or any other item | `Jump` | `ReadLastUnreadLog` |
-/// | a gun | `Jump` | `CycleGunSetting` (that hand's gun) |
+/// | a gun | `Jump` | `CycleGunSetting` (tap/release on that hand's gun) |
+/// | an ammo clip | `Jump` | `CycleAmmo` (swap carried clips) |
 /// | the psi amp | `Jump` | `SelectPsiPower` (the selection MFD) |
 ///
 /// **Lower is jump, on both hands, whatever they hold.** Jumping is the one
@@ -103,6 +108,7 @@ pub fn resolve_hand_button(
             HeldKind::Empty | HeldKind::Melee | HeldKind::Other => InputAction::ReadLastUnreadLog,
             // The gun hand's own handling control: its fire mode.
             HeldKind::Gun => InputAction::CycleGunSetting,
+            HeldKind::Ammo => InputAction::CycleAmmo,
             // The amp hand's own control: the power selection MFD, where a
             // power is *chosen* from a described grid. It names no hand -
             // there is one psi selection, not one per amp.
@@ -132,6 +138,8 @@ pub fn held_kind_in_hand(world: &World, hand: Handedness) -> HeldKind {
         .is_ok_and(|guns| guns.get(held).is_ok())
     {
         HeldKind::Gun
+    } else if crate::mission::reload::is_ammo_clip(world, held) {
+        HeldKind::Ammo
     } else {
         HeldKind::Other
     }
@@ -142,12 +150,13 @@ mod tests {
     use super::*;
 
     const HANDS: [Handedness; 2] = [Handedness::Left, Handedness::Right];
-    const HELD: [HeldKind; 5] = [
+    const HELD: [HeldKind; 6] = [
         HeldKind::Empty,
         HeldKind::Melee,
         HeldKind::Gun,
         HeldKind::PsiAmp,
         HeldKind::Other,
+        HeldKind::Ammo,
     ];
 
     fn resolve(held: HeldKind, hand: Handedness, button: HandButton) -> Option<InputAction> {
@@ -193,6 +202,16 @@ mod tests {
                 resolve(HeldKind::Gun, hand, HandButton::Upper),
                 Some(InputAction::CycleGunSetting),
                 "{hand:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ammo_upper_button_cycles_ammo_on_either_hand() {
+        for hand in HANDS {
+            assert_eq!(
+                resolve(HeldKind::Ammo, hand, HandButton::Upper),
+                Some(InputAction::CycleAmmo)
             );
         }
     }

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -443,48 +443,16 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
     }
 
     if let Some(progress) = readout.eject_progress {
-        // Shared canvas pixels: a clockwise border fills around the gauge.
-        let mut remaining = progress.clamp(0.0, 1.0) * 242.0;
-        for (edge, rect) in [
-            Rect::new(175.0, 11.0, 76.0, 2.0),
-            Rect::new(249.0, 13.0, 2.0, 45.0),
-            Rect::new(175.0, 56.0, 76.0, 2.0),
-            Rect::new(175.0, 11.0, 2.0, 45.0),
-        ]
-        .into_iter()
-        .enumerate()
-        {
-            let length = if rect.w > rect.h { rect.w } else { rect.h };
-            let fraction = (remaining / length).clamp(0.0, 1.0);
-            remaining -= length;
-            if fraction > 0.0 {
-                let filled = if rect.w > rect.h {
-                    Rect::new(
-                        rect.x
-                            + if edge == 2 {
-                                rect.w * (1.0 - fraction)
-                            } else {
-                                0.0
-                            },
-                        rect.y,
-                        rect.w * fraction,
-                        rect.h,
-                    )
-                } else {
-                    Rect::new(
-                        rect.x,
-                        rect.y
-                            + if edge == 3 {
-                                rect.h * (1.0 - fraction)
-                            } else {
-                                0.0
-                            },
-                        rect.w,
-                        rect.h * fraction,
-                    )
-                };
-                canvas.image(at(origin, filled), "HPBAR.PCX");
-            }
+        // One thin line along the gauge's bottom, filling left to right.
+        // Sample only a plain center texel so the health-bar art does not stretch.
+        let width = 76.0 * progress.clamp(0.0, 1.0);
+        if width > 0.0 {
+            canvas.cropped_image(
+                at(origin, Rect::new(175.0, 56.0, width, 1.0)),
+                "HPBAR.PCX",
+                Rect::new(40.0, 7.0, 1.0, 1.0),
+                vec2(80.0, 14.0),
+            );
         }
     }
 

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -204,6 +204,8 @@ pub(crate) struct AmmoReadout {
     pub psi_power: Option<(String, i32)>,
     /// Rounds in the wielded weapon's clip.
     pub ammo: Option<i32>,
+    /// Progress of this weapon hand's eject hold.
+    pub eject_progress: Option<f32>,
     /// The selected ammo type's object-icon bitmap.
     pub ammo_icon: Option<String>,
     /// The selected ammo type's class tag ("std", "he", "ap").
@@ -254,6 +256,8 @@ impl AmmoReadout {
         show_buttons: bool,
     ) -> Self {
         Self {
+            eject_progress: weapon
+                .and_then(|w| crate::weapon_button_hold::EjectProgress::for_weapon(world, w)),
             gun_condition: weapon.and_then(|w| wielded_gun_condition(world, w)),
             psi_power: super::get_weapon_psi_power(world, weapon),
             ammo: weapon
@@ -397,7 +401,16 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
         if let Some(badge) = readout.gun_condition {
             canvas.image(at(origin, CONDITION), badge);
         }
-        if compact {
+        if compact && readout.eject_progress.is_some() {
+            canvas.text_fit(
+                at(origin, COMPACT_DETAIL),
+                "EJECT",
+                FONT,
+                10.0,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        } else if compact {
             // Keep each label's space independent: a long authored ammo tag
             // must not push the current fire mode off the meter.
             let paired = readout.ammo_type.is_some() && readout.gun_setting_header.is_some();
@@ -427,6 +440,52 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
         }
     } else {
         return;
+    }
+
+    if let Some(progress) = readout.eject_progress {
+        // Shared canvas pixels: a clockwise border fills around the gauge.
+        let mut remaining = progress.clamp(0.0, 1.0) * 242.0;
+        for (edge, rect) in [
+            Rect::new(175.0, 11.0, 76.0, 2.0),
+            Rect::new(249.0, 13.0, 2.0, 45.0),
+            Rect::new(175.0, 56.0, 76.0, 2.0),
+            Rect::new(175.0, 11.0, 2.0, 45.0),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let length = if rect.w > rect.h { rect.w } else { rect.h };
+            let fraction = (remaining / length).clamp(0.0, 1.0);
+            remaining -= length;
+            if fraction > 0.0 {
+                let filled = if rect.w > rect.h {
+                    Rect::new(
+                        rect.x
+                            + if edge == 2 {
+                                rect.w * (1.0 - fraction)
+                            } else {
+                                0.0
+                            },
+                        rect.y,
+                        rect.w * fraction,
+                        rect.h,
+                    )
+                } else {
+                    Rect::new(
+                        rect.x,
+                        rect.y
+                            + if edge == 3 {
+                                rect.h * (1.0 - fraction)
+                            } else {
+                                0.0
+                            },
+                        rect.w,
+                        rect.h * fraction,
+                    )
+                };
+                canvas.image(at(origin, filled), "HPBAR.PCX");
+            }
+        }
     }
 
     for button in buttons(readout) {
@@ -476,24 +535,29 @@ mod tests {
 
     #[test]
     fn wrist_preserves_the_complete_compact_panel_and_shared_overlay_layout() {
-        let readout = full_gun();
-        let wrist = build_wrist_canvas(&readout);
-        assert_eq!(wrist.size(), vec2(94.0, 64.0));
-        assert!(
-            matches!(&wrist.elements()[0], crate::ui::UiElement::Image { texture, kind: crate::ui::ImageKind::Ui, .. } if texture == "AMMOBACK.PCX")
-        );
-        let passive = AmmoReadout {
-            show_buttons: false,
-            ..readout
-        };
-        let panel = build_readout_canvas(&passive);
-        assert_eq!(wrist.element_count(), panel.element_count() + 1);
-        for (cropped, full) in wrist.elements()[1..].iter().zip(panel.elements()) {
-            let (a, b) = (cropped.rect(), full.rect());
-            assert_eq!(
-                (a.x + WRIST_CROP.x, a.y + WRIST_CROP.y, a.w, a.h),
-                (b.x, b.y, b.w, b.h)
+        for eject_progress in [None, Some(0.0), Some(0.4), Some(0.8), Some(1.0)] {
+            let readout = AmmoReadout {
+                eject_progress,
+                ..full_gun()
+            };
+            let wrist = build_wrist_canvas(&readout);
+            assert_eq!(wrist.size(), vec2(94.0, 64.0));
+            assert!(
+                matches!(&wrist.elements()[0], crate::ui::UiElement::Image { texture, kind: crate::ui::ImageKind::Ui, .. } if texture == "AMMOBACK.PCX")
             );
+            let passive = AmmoReadout {
+                show_buttons: false,
+                ..readout
+            };
+            let panel = build_readout_canvas(&passive);
+            assert_eq!(wrist.element_count(), panel.element_count() + 1);
+            for (cropped, full) in wrist.elements()[1..].iter().zip(panel.elements()) {
+                let (a, b) = (cropped.rect(), full.rect());
+                assert_eq!(
+                    (a.x + WRIST_CROP.x, a.y + WRIST_CROP.y, a.w, a.h),
+                    (b.x, b.y, b.w, b.h)
+                );
+            }
         }
         assert_eq!(
             build_wrist_canvas(&AmmoReadout::default()).element_count(),

--- a/shock2vr/src/input/state.rs
+++ b/shock2vr/src/input/state.rs
@@ -42,6 +42,11 @@ impl InputActionState {
         self.triggered.clear();
     }
 
+    /// Consume an edge while retaining the runtime-owned held state.
+    pub fn consume_trigger(&mut self, action: InputAction) {
+        self.triggered.remove(&action);
+    }
+
     /// Release a held action
     pub fn release(&mut self, action: InputAction) {
         self.held.remove(&action);

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -14,6 +14,7 @@ pub mod save_load;
 pub mod scenes;
 pub mod teleport;
 pub mod time;
+mod weapon_button_hold;
 
 pub mod career;
 pub mod creature;
@@ -622,6 +623,7 @@ pub struct Game {
     /// same reason: it decides `Game`'s own overlay, and must keep running on
     /// a frame the scene is not updated at all.
     menu_hold: input::MenuHold,
+    weapon_buttons: weapon_button_hold::WeaponButtons,
     menu_hold_ring: scenes::cutscene_skip::RingArt,
 
     /// Wall-clock time spent with the simulation suspended, subtracted from the
@@ -1386,6 +1388,7 @@ impl Game {
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
             menu_hold: input::MenuHold::default(),
+            weapon_buttons: Default::default(),
             menu_hold_ring: scenes::cutscene_skip::RingArt::default(),
             time_suspended: std::time::Duration::ZERO,
             hit_feedback: hit_feedback::HitFeedback::new(),
@@ -1478,6 +1481,7 @@ impl Game {
         // close the menu again.
         self.update_pause_menu(time, input_context, actions);
         if self.pause_menu.suspends_scene() {
+            self.weapon_buttons.cancel(self.active_game_scene.world());
             // Paused: the scene is not updated (nothing simulates, and
             // `VirtualHand` is never advanced, so hands are inert but keep
             // whatever they were holding). It is still *rendered* every frame
@@ -1498,7 +1502,15 @@ impl Game {
         // Convert triggered actions into effects; triggered actions are
         // consumed here so injected actions (e.g. from the debug runtime)
         // apply exactly once.
-        let action_effects = input::ActionDispatcher::dispatch(actions, input_context);
+        let allowed = self.pause_is_allowed() && !self.active_game_scene.wants_pointer();
+        let mut action_effects = self.weapon_buttons.update(
+            self.active_game_scene.world(),
+            actions,
+            time.elapsed,
+            allowed,
+            free_camera::FreeCamera::is_enabled(),
+        );
+        action_effects.extend(input::ActionDispatcher::dispatch(actions, input_context));
         actions.clear_triggered();
 
         // Fly the detached camera, then withhold the channels it consumed from
@@ -1695,6 +1707,7 @@ impl Game {
     /// instead would mint the short press nobody made.
     pub fn cancel_menu_hold(&mut self) {
         self.menu_hold.cancel();
+        self.weapon_buttons.cancel(self.active_game_scene.world());
     }
 
     /// Apply the pause toggle and, while open, drive the overlay.
@@ -2102,6 +2115,7 @@ impl Game {
     /// what it owns beyond its own frame (see [`GameScene::on_exit`]). Every
     /// scene swap goes through here so that hook cannot be forgotten.
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
+        self.weapon_buttons.cancel(self.active_game_scene.world());
         self.active_game_scene.on_exit(&mut self.audio_context);
         self.audio_context.stop_ambient_sounds();
         self.last_env_sound = None;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7648,6 +7648,34 @@ impl MissionCore {
                 // and the physics controller wants a rising edge, not a level.
                 Effect::Jump => self.button_jump = true,
 
+                Effect::HeldGunButton {
+                    hand,
+                    weapon,
+                    long_press,
+                } => {
+                    let held = self.interaction.held_entities();
+                    let in_hand = if hand == crate::Handedness::Left {
+                        held.0
+                    } else {
+                        held.1
+                    };
+                    if !self.use_mode && in_hand == Some(weapon) {
+                        if long_press {
+                            if let Some(cue) = self.drop_loaded_clip(asset_cache, weapon) {
+                                effects.push_back(cue);
+                            }
+                        } else {
+                            let current = crate::scripts::script_util::current_gun_setting(
+                                &self.world,
+                                weapon,
+                            );
+                            effects.push_front(Effect::SetGunSetting {
+                                entity_id: weapon,
+                                setting: i32::from(current == 0),
+                            });
+                        }
+                    }
+                }
                 Effect::EjectClip { hand } => {
                     if let Some(weapon) =
                         crate::wielded_weapon::hand_weapon_target(&self.world, hand)
@@ -7684,6 +7712,9 @@ impl MissionCore {
                         // dual-wielding player switches the mode they meant.
                         Some(crate::input::InputAction::CycleGunSetting) => {
                             effects.push_front(Effect::CycleGunSetting { hand: Some(hand) })
+                        }
+                        Some(crate::input::InputAction::CycleAmmo) => {
+                            effects.extend(self.cycle_held_ammo(asset_cache, hand));
                         }
                         // The amp hand's upper button opens the selection MFD.
                         // It names no hand - there is one psi selection
@@ -10815,6 +10846,126 @@ impl MissionCore {
             name: "bset".to_owned(),
             spatial: false,
         })
+    }
+
+    /// Spawn the actual loaded rounds at the gun's magazine, retaining their type.
+    fn drop_loaded_clip(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        weapon: EntityId,
+    ) -> Option<Effect> {
+        let (template, rounds) = super::reload::world_clip_offer(&self.world, weapon)?;
+        let position = self.magazine_anchor_world(weapon)?;
+        let rotation = self
+            .world
+            .borrow::<View<PropPosition>>()
+            .ok()?
+            .get(weapon)
+            .ok()?
+            .rotation;
+        let clip = self
+            .create_entity_with_position(
+                asset_cache,
+                template,
+                vec3_to_point3(position),
+                rotation,
+                Matrix4::identity(),
+                CreateEntityOptions::default(),
+            )
+            .entity_id;
+        self.world
+            .add_component(clip, dark::properties::PropStackCount(rounds));
+        self.make_physical(clip);
+        super::reload::empty_magazine(&self.world, weapon);
+        Some(crate::scripts::script_util::play_environmental_sound(
+            &self.world,
+            weapon,
+            "reload",
+            vec![],
+            AudioHandle::new(),
+        ))
+    }
+
+    /// Swap actual clips, reserving the outgoing clip's space before changing hands.
+    fn cycle_held_ammo(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        hand: crate::Handedness,
+    ) -> Vec<Effect> {
+        let Some(held) = crate::wielded_weapon::held_by_hand(&self.world, hand) else {
+            return vec![];
+        };
+        if self.interaction.holding_hand(held) != Some(hand)
+            || !super::reload::is_ammo_clip(&self.world, held)
+        {
+            return vec![];
+        }
+        let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+        let inventory = player.inventory_entity_id;
+        let other = if hand == crate::Handedness::Left {
+            player.right_hand_entity_id
+        } else {
+            player.left_hand_entity_id
+        };
+        drop(player);
+        let carried =
+            crate::scripts::script_util::get_all_links_with_data(&self.world, inventory, |link| {
+                matches!(link, Link::Contains(_)).then_some(())
+            })
+            .into_iter()
+            .map(|(entity, ())| entity);
+        let candidate = other
+            .into_iter()
+            .chain(carried)
+            .find_map(|gun| super::reload::next_carried_clip(&self.world, gun, held));
+        let candidate = candidate.or_else(|| {
+            super::reload::next_carried_clip_without_gun(&self.world, held, &self.entity_info)
+        });
+        let Some(next) = candidate else {
+            return vec![];
+        };
+        // Removing the incoming clip frees its slot even in a full backpack.
+        // Candidates come only from this inventory, so these are the complete
+        // containment links to restore if the outgoing shape cannot fit.
+        let original_links = self
+            .world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(inventory)
+            .unwrap()
+            .clone();
+        self.detach_from_containers(next);
+        if !move_live_entity_into_container(&mut self.world, inventory, held) {
+            self.world.add_component(inventory, original_links);
+            return vec![backpack_full_feedback(held)];
+        }
+        self.interaction.on_entity_destroyed(held);
+        self.make_un_physical(held);
+        self.script_world.dispatch(Message {
+            to: held,
+            payload: MessagePayload::Drop,
+        });
+        let effects = self.grab_entity_into_hand(asset_cache, next, hand);
+        if self.interaction.holding_hand(next) != Some(hand) {
+            self.world.add_component(inventory, original_links);
+            let mut rollback = effects;
+            rollback.extend(self.grab_entity_into_hand(asset_cache, held, hand));
+            return rollback;
+        }
+        let (left, right) = self.interaction.held_entities();
+        {
+            let mut player = self.world.borrow::<UniqueViewMut<PlayerInfo>>().unwrap();
+            player.left_hand_entity_id = left;
+            player.right_hand_entity_id = right;
+        }
+        let mut effects = effects;
+        effects.push(Effect::PlaySound {
+            handle: AudioHandle::new(),
+            source: None,
+            name: "bset".to_owned(),
+            spatial: false,
+        });
+        effects
     }
 
     /// Return `weapon`'s loaded rounds to the backpack as clips of the ammo

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -487,6 +487,117 @@ pub(crate) fn unload_to_reserve(world: &World, weapon: EntityId) -> UnloadOutcom
     }
 }
 
+/// A physical ejection is an offer until the caller successfully spawns it.
+pub(crate) fn world_clip_offer(world: &World, weapon: EntityId) -> Option<(i32, i32)> {
+    let rounds = world
+        .borrow::<View<PropGunState>>()
+        .ok()?
+        .get(weapon)
+        .ok()?
+        .ammo;
+    if rounds <= 0 {
+        return None;
+    }
+    let templates = selected_clip_templates(world, weapon)?;
+    let clips = world.borrow::<UniqueView<GlobalProjectileClips>>().ok()?;
+    Some((
+        mint_clip_template(&templates, &clips.clip_sizes, rounds),
+        rounds,
+    ))
+}
+
+/// Next stocked type fitting the same gun. The held clip determines the start,
+/// independently of what that gun currently has loaded.
+pub(crate) fn next_carried_clip(
+    world: &World,
+    weapon: EntityId,
+    held: EntityId,
+) -> Option<EntityId> {
+    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect::<Vec<_>>();
+    next_carried_clip_in_family(world, held, &projectiles)
+}
+
+fn next_carried_clip_in_family(
+    world: &World,
+    held: EntityId,
+    projectiles: &[i32],
+) -> Option<EntityId> {
+    let class = crate::scripts::script_util::entity_class_template_id(world, held)?;
+    let hierarchy = world
+        .borrow::<UniqueView<crate::mission::GlobalTemplateHierarchy>>()
+        .ok()?;
+    let current = projectiles.iter().position(|projectile| {
+        clip_templates_for_projectile(world, *projectile).is_some_and(|templates| {
+            templates
+                .iter()
+                .any(|t| hierarchy.is_or_descends_from(class, *t))
+        })
+    })?;
+    for offset in 1..projectiles.len() {
+        let index = (current + offset) % projectiles.len();
+        let Some(templates) = clip_templates_for_projectile(world, projectiles[index]) else {
+            continue;
+        };
+        if let Some(item) = compatible_reserve_items(world, &templates)
+            .into_iter()
+            .find(|item| {
+                *item != held
+                    && crate::scripts::script_util::entity_class_template_id(world, *item)
+                        .is_some_and(|class| {
+                            !clip_templates_for_projectile(world, projectiles[current])
+                                .unwrap_or_default()
+                                .iter()
+                                .any(|t| hierarchy.is_or_descends_from(class, *t))
+                        })
+            })
+        {
+            return Some(item);
+        }
+    }
+    None
+}
+
+/// Ammo can be switched with no gun in hand or inventory. Infer its family
+/// from authored weapon projectile relations, never from arbitrary clip names.
+pub(crate) fn next_carried_clip_without_gun(
+    world: &World,
+    held: EntityId,
+    info: &SystemShock2EntityInfo,
+) -> Option<EntityId> {
+    let mut templates = info.template_to_links.iter().collect::<Vec<_>>();
+    templates.sort_by_key(|(id, _)| **id);
+    for (_, links) in templates {
+        for setting in 0..2 {
+            let mut projectiles = links
+                .to_links
+                .iter()
+                .filter_map(|link| match &link.link {
+                    Link::Projectile(options)
+                        if options.setting < 0 || options.setting == setting =>
+                    {
+                        Some((options.order, link.to_template_id))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            projectiles.sort_by_key(|(order, _)| *order);
+            let family = projectiles
+                .into_iter()
+                .map(|(_, id)| id)
+                .collect::<Vec<_>>();
+            if family.len() > 1
+                && let Some(next) = next_carried_clip_in_family(world, held, &family)
+            {
+                return Some(next);
+            }
+        }
+    }
+    None
+}
+
 /// The clip archetype to mint for `rounds` ejected rounds: the smallest
 /// authored box that holds them all, so the label matches the contents - an
 /// assault rifle's 30 rounds must not come back as a "Small Standard Clip"
@@ -585,6 +696,61 @@ mod tests {
         world: World,
         weapon: EntityId,
         inventory: EntityId,
+    }
+
+    #[test]
+    fn physical_ejection_offers_exact_rounds_without_touching_reserve() {
+        let mut f = Fixture::new(5, 1);
+        let reserve = f.reserve(HE_CLIP, 9);
+        assert_eq!(world_clip_offer(&f.world, f.weapon), Some((HE_CLIP, 5)));
+        assert_eq!(f.ammo(), 5);
+        assert_eq!(f.rounds(reserve), 9);
+        empty_magazine(&f.world, f.weapon);
+        assert_eq!(world_clip_offer(&f.world, f.weapon), None);
+    }
+
+    #[test]
+    fn ammo_family_without_a_gun_includes_all_setting_links() {
+        let mut f = Fixture::new(0, 0);
+        let held = f.held_clip(HE_CLIP, 3);
+        let reserve = f.reserve(STD_CLIP, 7);
+        let mut info = SystemShock2EntityInfo::empty();
+        info.template_to_links.insert(
+            PISTOL,
+            dark::properties::TemplateLinks {
+                to_links: [STD_PROJECTILE, HE_PROJECTILE]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(order, projectile)| dark::properties::ToTemplateLink {
+                        to_template_id: projectile,
+                        link: Link::Projectile(ProjectileOptions {
+                            order: order as i32,
+                            setting: -1,
+                        }),
+                    })
+                    .collect(),
+            },
+        );
+        assert_eq!(
+            next_carried_clip_without_gun(&f.world, held, &info),
+            Some(reserve)
+        );
+        assert_eq!(f.rounds(held), 3);
+        assert_eq!(f.rounds(reserve), 7);
+    }
+
+    #[test]
+    fn held_ammo_cycles_real_stock_relative_to_clip_not_loaded_type() {
+        let mut f = Fixture::new(5, 1);
+        let held = f.held_clip(STD_CLIP, 3);
+        f.reserve(STD_CLIP, 17);
+        f.reserve(HE_CLIP, 0);
+        assert_eq!(next_carried_clip(&f.world, f.weapon, held), None);
+        let alternate = f.reserve(HE_CLIP, 7);
+        assert_eq!(next_carried_clip(&f.world, f.weapon, held), Some(alternate));
+        assert_eq!(f.rounds(held), 3);
+        assert_eq!(f.rounds(alternate), 7);
+        assert_eq!(f.ammo(), 5);
     }
 
     impl Fixture {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -349,6 +349,13 @@ pub enum Effect {
     /// rotation sampled at the input edge.
     ReadLastUnreadLog,
 
+    /// Apply a completed tap/hold only while this exact gun remains in this hand.
+    HeldGunButton {
+        hand: Handedness,
+        weapon: EntityId,
+        long_press: bool,
+    },
+
     /// Return a gun's loaded magazine to the backpack reserve, as clips of the
     /// ammo type the rounds already are (`reload::unload_to_reserve`). No
     /// physical clip is dropped into the world.

--- a/shock2vr/src/weapon_button_hold.rs
+++ b/shock2vr/src/weapon_button_hold.rs
@@ -1,0 +1,193 @@
+//! Per-hand tap/hold disambiguation, reusing the Menu button's timing policy.
+use crate::{
+    Handedness,
+    hand_buttons::HeldKind,
+    input::{InputAction, InputActionState, MenuHold, MenuPress},
+    scripts::Effect,
+};
+use shipyard::{EntityId, Unique, UniqueView, UniqueViewMut, World};
+use std::time::Duration;
+
+#[derive(Unique, Default)]
+pub(crate) struct EjectProgress(pub Vec<(EntityId, f32)>);
+impl EjectProgress {
+    fn publish(world: &World, progress: Self) {
+        if let Ok(mut current) = world.borrow::<UniqueViewMut<Self>>() {
+            *current = progress;
+        } else {
+            world.add_unique(progress);
+        }
+    }
+    pub fn for_weapon(world: &World, weapon: EntityId) -> Option<f32> {
+        world
+            .borrow::<UniqueView<Self>>()
+            .ok()?
+            .0
+            .iter()
+            .find_map(|(w, p)| (*w == weapon).then_some(*p))
+    }
+}
+
+#[derive(Default)]
+struct Press {
+    weapon: Option<EntityId>,
+    timer: MenuHold,
+}
+impl Press {
+    fn update(
+        &mut self,
+        weapon: Option<EntityId>,
+        pressed: bool,
+        held: bool,
+        dt: Duration,
+    ) -> MenuPress {
+        if weapon != self.weapon {
+            self.timer.cancel();
+            self.weapon = weapon;
+        }
+        if weapon.is_none() {
+            self.timer.cancel();
+            return MenuPress::None;
+        }
+        if pressed {
+            self.timer.press();
+        }
+        if held {
+            self.timer.tick(dt)
+        } else {
+            self.timer.release()
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct WeaponButtons {
+    presses: [Press; 2],
+}
+impl WeaponButtons {
+    pub fn cancel(&mut self, world: &World) {
+        for press in &mut self.presses {
+            press.timer.cancel();
+            press.weapon = None;
+        }
+        EjectProgress::publish(world, EjectProgress::default());
+    }
+    pub fn update(
+        &mut self,
+        world: &World,
+        actions: &mut InputActionState,
+        dt: Duration,
+        allowed: bool,
+        free_camera: bool,
+    ) -> Vec<Effect> {
+        let mut effects = Vec::new();
+        let mut progress = Vec::new();
+        for (i, (hand, action)) in [
+            (Handedness::Left, InputAction::LeftHandUpperButton),
+            (Handedness::Right, InputAction::RightHandUpperButton),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let gun = (allowed
+                && !(free_camera && i == 1)
+                && crate::hand_buttons::held_kind_in_hand(world, hand) == HeldKind::Gun)
+                .then(|| crate::wielded_weapon::weapon_in_hand(world, hand))
+                .flatten();
+            let result = self.presses[i].update(
+                gun,
+                actions.just_triggered(action),
+                actions.is_held(action),
+                dt,
+            );
+            if let Some(weapon) = gun {
+                actions.consume_trigger(action);
+                match result {
+                    MenuPress::Short | MenuPress::Long => effects.push(Effect::HeldGunButton {
+                        hand,
+                        weapon,
+                        long_press: result == MenuPress::Long,
+                    }),
+                    MenuPress::None => {}
+                }
+                if crate::mission::reload::world_clip_offer(world, weapon).is_some()
+                    && let Some(p) = self.presses[i].timer.progress()
+                {
+                    progress.push((weapon, p));
+                }
+            }
+        }
+        EjectProgress::publish(world, EjectProgress(progress));
+        effects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn tap_and_hold_are_exclusive_and_hold_fires_once() {
+        let mut world = World::new();
+        let gun = Some(world.add_entity(()));
+        let mut p = Press::default();
+        assert_eq!(p.update(gun, true, true, Duration::ZERO), MenuPress::None);
+        assert_eq!(
+            p.update(gun, false, false, Duration::ZERO),
+            MenuPress::Short
+        );
+        for i in 0..7 {
+            assert_eq!(
+                p.update(gun, i == 0, true, Duration::from_millis(100)),
+                if i == 4 {
+                    MenuPress::Long
+                } else {
+                    MenuPress::None
+                }
+            );
+        }
+        assert_eq!(p.update(gun, false, false, Duration::ZERO), MenuPress::None);
+    }
+    #[test]
+    fn cancellation_clears_both_hands_even_if_the_next_scene_reuses_ids() {
+        let mut world = World::new();
+        let gun = world.add_entity(());
+        let mut buttons = WeaponButtons::default();
+        for press in &mut buttons.presses {
+            press.update(Some(gun), true, true, Duration::from_millis(100));
+        }
+        EjectProgress::publish(&world, EjectProgress(vec![(gun, 0.2)]));
+        buttons.cancel(&world);
+        assert_eq!(EjectProgress::for_weapon(&world, gun), None);
+        for press in &mut buttons.presses {
+            for _ in 0..8 {
+                assert_eq!(
+                    press.update(Some(gun), false, true, Duration::from_millis(100)),
+                    MenuPress::None
+                );
+            }
+            assert_eq!(
+                press.update(Some(gun), false, false, Duration::ZERO),
+                MenuPress::None
+            );
+        }
+    }
+
+    #[test]
+    fn changing_weapon_or_context_cancels_without_rearming() {
+        let mut world = World::new();
+        let a = Some(world.add_entity(()));
+        let b = Some(world.add_entity(()));
+        let mut p = Press::default();
+        p.update(a, true, true, Duration::from_millis(100));
+        for _ in 0..8 {
+            assert_eq!(
+                p.update(b, false, true, Duration::from_millis(100)),
+                MenuPress::None
+            );
+        }
+        assert_eq!(p.update(b, false, false, Duration::ZERO), MenuPress::None);
+        p.update(a, true, true, Duration::ZERO);
+        p.update(None, false, true, Duration::ZERO);
+        assert_eq!(p.update(a, false, false, Duration::ZERO), MenuPress::None);
+    }
+}

--- a/tools/shock2-sdk/test/vr-weapon-buttons.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-buttons.e2e.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt, quatConjugate, quatRotate, sub } from "./helpers/vr-hand.js";
+import { stackCount } from "./helpers/nanites.js";
+import { ammoOf } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+
+for (const hand of ["left", "right"] as const) {
+  test(`${hand} upper button swaps carried clips with exact identity and rounds`, { skip: !enabled, timeout: 180_000 }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const gunHand = hand === "left" ? "right" : "left";
+    const owner = hand === "left" ? "wielded_entity_id" : "right_hand_entity_id";
+    const button = hand === "left" ? "LeftHandUpperButton" : "RightHandUpperButton";
+    const pistol = (await game.entities.list()).entities.find(e => e.template_id === -17);
+    assert.ok(pistol);
+    await aimVrHandAt(game, pistol.position, 0.2, 1, 0, { hand: gunHand });
+    await game.step({ frames: 5 });
+    const standard = await game.player.spawnItem(-31);
+    const highExplosive = await game.player.spawnItem(-32);
+    const unrelated = await game.player.spawnItem(-42);
+    const original = [standard, highExplosive, unrelated];
+    const rounds = await Promise.all(original.map(async item => stackCount((await game.entities.detail(item.entity_id)).properties)));
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    await game.step({ frames: 5 });
+    const player = (await game.info()).player;
+    const center = player.hand_feedback?.ammo_pouch?.center;
+    assert.ok(center);
+    await game.input.set(`${hand}_hand.position`, quatRotate(quatConjugate(player.rotation), sub(center, player.position)));
+    await game.input.set(`${hand}_hand.rotation`, [0, 0, 0, 1]);
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+    await game.step({ frames: 3 });
+    await game.input.set(`${hand}_hand.squeeze`, 1);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player[owner], standard.entity_id);
+    // Leave the body pouch and the gun's insertion zone before changing type.
+    await game.input.set(`${hand}_hand.position`, [hand === "left" ? -1.4 : 1.4, 1.5, -0.5]);
+    await game.step({ frames: 5 });
+    if (hand === "right") {
+      let full = false;
+      for (let i = 0; i < 50; i++) {
+        try { await game.player.spawnItem(-1221); }
+        catch { full = true; break; }
+      }
+      assert.ok(full, "exercise a full backpack");
+    }
+    await game.input.hold(button);
+    await game.step({ frames: 45 });
+    assert.equal((await game.info()).player[owner], highExplosive.entity_id, "holding ammo cycles only once");
+    await game.input.release(button);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player[owner], highExplosive.entity_id, "release does not cycle a second time");
+    let inventory = (await game.player.inventory()).items;
+    assert.equal(inventory.find(i => i.entity_id === standard.entity_id)?.location, "inventory");
+    assert.equal(inventory.find(i => i.entity_id === highExplosive.entity_id)?.location, `${hand}_hand`);
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), loaded);
+    for (let i = 0; i < original.length; i++) assert.equal(stackCount((await game.entities.detail(original[i].entity_id)).properties), rounds[i]);
+    assert.equal((await game.physics.bodies({ entityId: standard.entity_id })).bodies.length, 0, "stored clip has no physics");
+    // Let go of the gun. Ammo families must still work when no gun is carried.
+    await game.input.set(`${gunHand}_hand.squeeze`, 0);
+    await game.step({ frames: 5 });
+    await game.input.trigger(button);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player[owner], standard.entity_id);
+    inventory = (await game.player.inventory()).items;
+    assert.equal(inventory.find(i => i.entity_id === highExplosive.entity_id)?.location, "inventory");
+    for (let i = 0; i < original.length; i++) assert.equal(stackCount((await game.entities.detail(original[i].entity_id)).properties), rounds[i]);
+  });
+}
+
+test("gun tap fires on release and simultaneous grip release cancels it", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const pistol = (await game.entities.list()).entities.find(e => e.template_id === -17);
+  assert.ok(pistol);
+  await aimVrHandAt(game, pistol.position, 0.2, 1, 0, { hand: "left" });
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.wielded_entity_id, pistol.id);
+  const initial = (await game.info()).player.wielded_gun_setting;
+  const before = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+  await game.input.hold("LeftHandUpperButton");
+  await game.step({ frames: 12 });
+  assert.equal((await game.info()).player.wielded_gun_setting, initial, "press alone does not change mode");
+  await game.input.release("LeftHandUpperButton");
+  await game.step({ frames: 2 });
+  const changed = (await game.info()).player.wielded_gun_setting;
+  assert.notEqual(changed, initial);
+  assert.ok((await game.audio.recent()).sounds.some(s => s.sequence > before && s.sample.toLowerCase().startsWith("bset")));
+  await game.input.hold("LeftHandUpperButton");
+  await game.step({ frames: 12 });
+  await game.input.set("left_hand.squeeze", 0);
+  await game.input.release("LeftHandUpperButton");
+  await game.step({ frames: 3 });
+  assert.notEqual((await game.info()).player.wielded_entity_id, pistol.id);
+  const dropped = (await game.entities.list()).entities.find(e => e.id === pistol.id);
+  assert.ok(dropped);
+  await aimVrHandAt(game, dropped.position, 0.2, 1, 0, { hand: "left" });
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.wielded_entity_id, pistol.id);
+  assert.equal((await game.info()).player.wielded_gun_setting, changed, "dropped gun did not receive the tap");
+  await game.input.hold("LeftHandUpperButton");
+  await game.step({ frames: 12 });
+  await game.input.trigger("TogglePauseMenu");
+  await game.step({ frames: 3 });
+  await game.input.trigger("TogglePauseMenu");
+  await game.step({ frames: 40 });
+  await game.input.release("LeftHandUpperButton");
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.wielded_gun_setting, changed, "pause canceled the tap");
+  assert.ok(ammoOf(await game.entities.detail(pistol.id)) > 0, "resuming a held button did not eject");
+});


### PR DESCRIPTION
Upper face buttons now distinguish gun taps from holds: release a short press to switch fire mode with the existing `bset` cue, or hold ~0.5 seconds to drop a physical clip containing exactly the loaded rounds. The gun's cuff meter fills a thin bottom line from left to right and shows EJECT during the hold. Completing the hold never also changes mode.

While holding ammo, tap that hand's upper button to exchange the clip with another compatible type in the backpack. The original item returns to inventory with its rounds intact; unavailable and unrelated types are skipped. This works on either hand, with a full backpack when the exchanged clip fits, and without a gun carried. Existing UNLOAD still returns rounds to the backpack.

Pending holds cancel on item changes, panels, pause, death, session interruption, and scene replacement. Completed actions recheck the exact gun against live hand ownership, including simultaneous button/grip release.

Validation:

- 1,741 Rust library tests pass (2 ignored); debug runtime build, CI `-D warnings` checks for core/desktop/debug, and workspace formatting pass.
- All 8 focused SDK scenarios pass, covering existing unload/fire-mode behavior plus both-hand swaps, exact clip identities/counts, full-backpack exchange, no-gun cycling, tap sound, simultaneous grip release, and pause cancellation.
- Deterministic before/after captures verify shared flat/VR layout, physical falling, 12 loaded rounds becoming one 12-round world clip, and unchanged fire mode after hold/release.
- Full SDK suite is still running; failures observed in ammo-readout control lists, creature loot, and Earth keypad scenarios, not yet fully triaged.
- Headset timing/comfort remains to be checked in hand.

![VR hold-to-eject](https://gist.githubusercontent.com/tommy-xr/7222012a967d83a82cfd1ced0a740364/raw/d5b299def73f821470d589fef70352d1088ce679/eject-vr.gif)

![VR before and after](https://gist.githubusercontent.com/tommy-xr/7222012a967d83a82cfd1ced0a740364/raw/d5b299def73f821470d589fef70352d1088ce679/before-after-vr.png)

![Flatscreen hold-to-eject](https://gist.githubusercontent.com/tommy-xr/7222012a967d83a82cfd1ced0a740364/raw/d5b299def73f821470d589fef70352d1088ce679/eject-flat.gif)

![Flatscreen before and after](https://gist.githubusercontent.com/tommy-xr/7222012a967d83a82cfd1ced0a740364/raw/d5b299def73f821470d589fef70352d1088ce679/before-after-flat.png)

