### PR TITLE
feat(ai): implement upright grubs with joint animation and segment hitboxes

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -29,6 +29,29 @@ fn flip_winding(winding: FrontFaceWinding) -> FrontFaceWinding {
 pub struct SubObject {
     pub name: String,
     pub transform: Matrix4<f32>,
+    pub articulation: u8,
+    pub parameter: i32,
+}
+
+impl SubObject {
+    /// LGMD articulates around/along local Dark X after the authored pivot
+    /// transform. Dark X maps to -X in the runtime. Parameters are degrees
+    /// for hinges and Dark distance units for sliders.
+    pub fn parameter_transform(&self, values: &[f32]) -> Option<Matrix4<f32>> {
+        let value = *values.get(usize::try_from(self.parameter).ok()?)?;
+        if !value.is_finite() {
+            return None;
+        }
+        match self.articulation {
+            1 => Some(Matrix4::from_angle_x(cgmath::Deg(-value))),
+            2 => Some(Matrix4::from_translation(cgmath::vec3(
+                -value / crate::SCALE_FACTOR,
+                0.0,
+                0.0,
+            ))),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -86,6 +109,8 @@ pub struct AnimatedModel {
     /// corpse lying flat would be bounded by the standing rest skeleton.
     posed_bounds: Option<Aabb3<f32>>,
     object_articulation: Option<std::sync::Arc<crate::object_articulation::ObjectArticulation>>,
+    /// Authored LGMD rest bounds, kept separate from posed skeletal bounds.
+    object_bounds: Option<Aabb3<f32>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -207,6 +232,7 @@ impl AnimatedModel {
             bind: self.bind.clone(),
             object_articulation: self.object_articulation.clone(),
             posed_bounds: joint_box_bounds(&animated_skeleton.get_transforms(), &self.hit_boxes),
+            object_bounds: self.object_bounds,
         }
     }
 
@@ -232,6 +258,7 @@ impl AnimatedModel {
             bind: model.bind.clone(),
             posed_bounds: model.posed_bounds,
             object_articulation: model.object_articulation.clone(),
+            object_bounds: model.object_bounds,
         }
     }
 
@@ -272,6 +299,8 @@ impl Model {
             .map(|(index, sub_object)| SubObject {
                 name: sub_object.name.clone(),
                 transform: skeleton.global_transform(&(index as u32)),
+                articulation: sub_object.articulation,
+                parameter: sub_object.parameter,
             })
             .collect::<Vec<SubObject>>();
 
@@ -291,6 +320,7 @@ impl Model {
                     object_articulation: Some(std::sync::Arc::new(
                         ss2_bin_obj_loader::object_articulation(&static_mesh),
                     )),
+                    object_bounds: Some(bounding_box),
                 }),
             }
         } else {
@@ -362,6 +392,7 @@ impl Model {
                 bind,
                 posed_bounds: None,
                 object_articulation: None,
+                object_bounds: None,
             }),
         }
     }
@@ -390,6 +421,7 @@ impl Model {
                     bind: None,
                     posed_bounds: None,
                     object_articulation: None,
+                    object_bounds: None,
                 }),
             }
         } else {
@@ -504,6 +536,15 @@ impl Model {
         match &self.inner {
             InnerModel::Animated(model) => model.to_posed_scene_objects(pose),
             InnerModel::Static(model) => model.to_scene_objects().clone(),
+        }
+    }
+
+    /// Rest bounds for physical support of articulated object actors. This
+    /// does not change the legacy interaction bounds of other jointed props.
+    pub fn object_model_bounds(&self) -> Option<Aabb3<f32>> {
+        match &self.inner {
+            InnerModel::Static(model) => Some(model.bounding_box),
+            InnerModel::Animated(model) => model.object_bounds,
         }
     }
 
@@ -721,6 +762,7 @@ mod tests {
                 bind: None,
                 posed_bounds,
                 object_articulation: None,
+                object_bounds: None,
             }),
         }
     }
@@ -824,5 +866,25 @@ mod tests {
         model.apply_local_transform(Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0));
         model.apply_local_transform(Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0));
         assert_eq!(winding(&model), Some(FrontFaceWinding::Clockwise));
+    }
+}
+
+#[cfg(test)]
+mod object_parameter_tests {
+    use super::*;
+    use cgmath::{SquareMatrix, Transform};
+    #[test]
+    fn object_parameters_are_not_sub_object_indices_and_rotate_about_dark_x() {
+        let part = SubObject {
+            name: "hinge".into(),
+            transform: Matrix4::identity(),
+            articulation: 1,
+            parameter: 2,
+        };
+        let transform = part.parameter_transform(&[0.0, 0.0, 90.0]).unwrap();
+        let point = transform.transform_point(cgmath::point3(0.0, 1.0, 0.0));
+        assert!(point.y.abs() < 0.0001);
+        assert!((point.z + 1.0).abs() < 0.0001);
+        assert!(part.parameter_transform(&[0.0]).is_none());
     }
 }

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -22,6 +22,33 @@ fn flip_winding(winding: FrontFaceWinding) -> FrontFaceWinding {
     }
 }
 
+/// Enclose the joint's geometry with a cylinder and rounded ends. The long
+/// axis comes from the mesh, so this also handles terminal parts without a child.
+fn object_part_capsule(bounds: Aabb3<f32>, padding: f32) -> HitBoxShape {
+    use cgmath::EuclideanSpace;
+    let half = bounds.dim() * 0.5;
+    let axis = if half.x >= half.y && half.x >= half.z {
+        0
+    } else if half.y >= half.z {
+        1
+    } else {
+        2
+    };
+    let mut a = bounds.center().to_vec();
+    let mut b = a;
+    a[axis] -= half[axis];
+    b[axis] += half[axis];
+    let radial_sq: f32 = (0..3)
+        .filter(|&i| i != axis)
+        .map(|i| half[i] * half[i])
+        .sum();
+    HitBoxShape::Capsule {
+        a,
+        b,
+        radius: radial_sq.sqrt() + padding.max(0.0),
+    }
+}
+
 /// One LGMD sub-object: a named part of a static `.bin` (the pieces an in-game
 /// tweq rotates or translates - a gun slide, a door leaf) and its pivot in
 /// model space. Empty for LGMM/AI and GLB models, which articulate via joints.
@@ -31,6 +58,8 @@ pub struct SubObject {
     pub transform: Matrix4<f32>,
     pub articulation: u8,
     pub parameter: i32,
+    /// Geometry bounds in this joint's local frame; absent for empty pivots.
+    pub local_bounds: Option<Aabb3<f32>>,
 }
 
 impl SubObject {
@@ -292,6 +321,10 @@ impl Model {
         // built from the sub-object tree is exactly that hierarchy resolved.
         // Same pairs as `ss2_bin_obj_loader::sub_object_transforms` - keep them
         // in step.
+        let local_bounds = ss2_bin_obj_loader::sub_object_bounds(
+            &static_mesh,
+            &[Matrix4::identity(); MAX_SKINNED_JOINTS],
+        );
         let sub_objects = static_mesh
             .sub_objects
             .iter()
@@ -301,6 +334,7 @@ impl Model {
                 transform: skeleton.global_transform(&(index as u32)),
                 articulation: sub_object.articulation,
                 parameter: sub_object.parameter,
+                local_bounds: local_bounds[index].1,
             })
             .collect::<Vec<SubObject>>();
 
@@ -501,13 +535,37 @@ impl Model {
     }
 
     /// Per-joint fitted collision shapes (capsule-toward-child / box), the shared
-    /// source of truth for the ragdoll and damage hitboxes. Empty for static or
-    /// non-AI-bin models.
+    /// source of truth for the ragdoll and damage hitboxes. Articulated object
+    /// models opt in through `enable_object_joint_hit_boxes`; static models are empty.
     pub fn hit_box_shapes(&self) -> Rc<HashMap<u32, HitBoxShape>> {
         match &self.inner {
             InnerModel::Animated(animated_model) => animated_model.hit_box_shapes.clone(),
             InnerModel::Static(_) => Rc::new(HashMap::new()),
         }
+    }
+
+    /// Opt an articulated object into per-part damage geometry. Physics support
+    /// remains separate. Empty pivots receive no collider.
+    pub fn enable_object_joint_hit_boxes(&mut self, padding: f32) {
+        let InnerModel::Animated(model) = &mut self.inner else {
+            return;
+        };
+        if model.object_bounds.is_none() {
+            return;
+        }
+        let bounds: HashMap<_, _> = model
+            .sub_objects
+            .iter()
+            .enumerate()
+            .filter_map(|(i, part)| part.local_bounds.map(|bounds| (i as u32, bounds)))
+            .collect();
+        model.hit_box_shapes = Rc::new(
+            bounds
+                .iter()
+                .map(|(&i, bounds)| (i, object_part_capsule(*bounds, padding)))
+                .collect(),
+        );
+        model.hit_boxes = Rc::new(bounds);
     }
 
     pub fn get_hit_boxes(&self) -> Rc<HashMap<u32, Aabb3<f32>>> {
@@ -874,12 +932,29 @@ mod object_parameter_tests {
     use super::*;
     use cgmath::{SquareMatrix, Transform};
     #[test]
+    fn object_capsule_covers_segment_ends_and_adds_radial_padding() {
+        use cgmath::point3;
+        let HitBoxShape::Capsule { a, b, radius } = object_part_capsule(
+            Aabb3::new(point3(-0.4, -0.03, -0.04), point3(0.2, 0.03, 0.04)),
+            0.025,
+        ) else {
+            panic!("joint parts must use capsules")
+        };
+        assert!((a.x + 0.4).abs() < 1e-6);
+        assert!((b.x - 0.2).abs() < 1e-6);
+        assert!((radius - 0.075).abs() < 1e-6);
+        assert_eq!(a.y, 0.0);
+        assert_eq!(b.z, 0.0);
+    }
+
+    #[test]
     fn object_parameters_are_not_sub_object_indices_and_rotate_about_dark_x() {
         let part = SubObject {
             name: "hinge".into(),
             transform: Matrix4::identity(),
             articulation: 1,
             parameter: 2,
+            local_bounds: None,
         };
         let transform = part.parameter_transform(&[0.0, 0.0, 90.0]).unwrap();
         let point = transform.transform_point(cgmath::point3(0.0, 1.0, 0.0));

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -56,31 +56,8 @@ fn object_part_capsule(bounds: Aabb3<f32>, padding: f32) -> HitBoxShape {
 pub struct SubObject {
     pub name: String,
     pub transform: Matrix4<f32>,
-    pub articulation: u8,
-    pub parameter: i32,
     /// Geometry bounds in this joint's local frame; absent for empty pivots.
     pub local_bounds: Option<Aabb3<f32>>,
-}
-
-impl SubObject {
-    /// LGMD articulates around/along local Dark X after the authored pivot
-    /// transform. Dark X maps to -X in the runtime. Parameters are degrees
-    /// for hinges and Dark distance units for sliders.
-    pub fn parameter_transform(&self, values: &[f32]) -> Option<Matrix4<f32>> {
-        let value = *values.get(usize::try_from(self.parameter).ok()?)?;
-        if !value.is_finite() {
-            return None;
-        }
-        match self.articulation {
-            1 => Some(Matrix4::from_angle_x(cgmath::Deg(-value))),
-            2 => Some(Matrix4::from_translation(cgmath::vec3(
-                -value / crate::SCALE_FACTOR,
-                0.0,
-                0.0,
-            ))),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone)]
@@ -137,9 +114,9 @@ pub struct AnimatedModel {
     /// there is no record of the pose the model is actually drawn in, and a
     /// corpse lying flat would be bounded by the standing rest skeleton.
     posed_bounds: Option<Aabb3<f32>>,
-    object_articulation: Option<std::sync::Arc<crate::object_articulation::ObjectArticulation>>,
     /// Authored LGMD rest bounds, kept separate from posed skeletal bounds.
     object_bounds: Option<Aabb3<f32>>,
+    object_articulation: Option<std::sync::Arc<crate::object_articulation::ObjectArticulation>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -286,8 +263,8 @@ impl AnimatedModel {
             sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
             posed_bounds: model.posed_bounds,
-            object_articulation: model.object_articulation.clone(),
             object_bounds: model.object_bounds,
+            object_articulation: model.object_articulation.clone(),
         }
     }
 
@@ -332,8 +309,6 @@ impl Model {
             .map(|(index, sub_object)| SubObject {
                 name: sub_object.name.clone(),
                 transform: skeleton.global_transform(&(index as u32)),
-                articulation: sub_object.articulation,
-                parameter: sub_object.parameter,
                 local_bounds: local_bounds[index].1,
             })
             .collect::<Vec<SubObject>>();
@@ -351,10 +326,10 @@ impl Model {
                     sub_objects,
                     bind: None,
                     posed_bounds: None,
+                    object_bounds: Some(bounding_box),
                     object_articulation: Some(std::sync::Arc::new(
                         ss2_bin_obj_loader::object_articulation(&static_mesh),
                     )),
-                    object_bounds: Some(bounding_box),
                 }),
             }
         } else {
@@ -425,8 +400,8 @@ impl Model {
                 sub_objects: vec![],
                 bind,
                 posed_bounds: None,
-                object_articulation: None,
                 object_bounds: None,
+                object_articulation: None,
             }),
         }
     }
@@ -454,8 +429,8 @@ impl Model {
                     sub_objects: vec![],
                     bind: None,
                     posed_bounds: None,
-                    object_articulation: None,
                     object_bounds: None,
+                    object_articulation: None,
                 }),
             }
         } else {
@@ -819,8 +794,8 @@ mod tests {
                 sub_objects: Vec::new(),
                 bind: None,
                 posed_bounds,
-                object_articulation: None,
                 object_bounds: None,
+                object_articulation: None,
             }),
         }
     }
@@ -930,7 +905,6 @@ mod tests {
 #[cfg(test)]
 mod object_parameter_tests {
     use super::*;
-    use cgmath::{SquareMatrix, Transform};
     #[test]
     fn object_capsule_covers_segment_ends_and_adds_radial_padding() {
         use cgmath::point3;
@@ -945,21 +919,5 @@ mod object_parameter_tests {
         assert!((radius - 0.075).abs() < 1e-6);
         assert_eq!(a.y, 0.0);
         assert_eq!(b.z, 0.0);
-    }
-
-    #[test]
-    fn object_parameters_are_not_sub_object_indices_and_rotate_about_dark_x() {
-        let part = SubObject {
-            name: "hinge".into(),
-            transform: Matrix4::identity(),
-            articulation: 1,
-            parameter: 2,
-            local_bounds: None,
-        };
-        let transform = part.parameter_transform(&[0.0, 0.0, 90.0]).unwrap();
-        let point = transform.transform_point(cgmath::point3(0.0, 1.0, 0.0));
-        assert!(point.y.abs() < 0.0001);
-        assert!((point.z + 1.0).abs() < 0.0001);
-        assert!(part.parameter_transform(&[0.0]).is_none());
     }
 }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -2227,12 +2227,6 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             identity,
             accumulator::latest,
         ),
-        define_prop(
-            "P$AI_TurnRa",
-            PropAITurnRate::read,
-            identity,
-            accumulator::latest,
-        ),
         // Internal properties
         // These are not properties that are provided by shock2 game,
         // but are used internally for save/restore.

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -5,6 +5,7 @@ mod prop_ai_alertness;
 mod prop_ai_aware_delay;
 mod prop_ai_camera;
 mod prop_ai_device;
+mod prop_ai_grub;
 mod prop_ai_hearing;
 mod prop_ai_mode;
 mod prop_ambient_hacked;
@@ -54,6 +55,7 @@ pub use prop_ai_alertness::*;
 pub use prop_ai_aware_delay::*;
 pub use prop_ai_camera::*;
 pub use prop_ai_device::*;
+pub use prop_ai_grub::*;
 pub use prop_ai_hearing::*;
 pub use prop_ai_mode::*;
 pub use prop_ambient_hacked::*;
@@ -2192,6 +2194,42 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$StTweqMod",
             PropTweqModelState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$CfgTweqJo",
+            PropTweqJointsConfig::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$StTweqJoi",
+            PropTweqJointsState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$JointPos",
+            PropJointPositions::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_Grub_C",
+            PropAIGrubCombat::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_MoveSp",
+            PropAIMoveSpeed::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_TurnRa",
+            PropAITurnRate::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_ai_grub.rs
+++ b/dark/src/properties/prop_ai_grub.rs
@@ -1,0 +1,73 @@
+use crate::{SCALE_FACTOR, ss2_common::*};
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+use std::io::{Read, Seek};
+
+/// Dark's sAIGrubCombatParams (`P$AI_Grub_C`, 60 bytes).
+#[derive(Clone, Debug, Component, Serialize, Deserialize)]
+pub struct PropAIGrubCombat {
+    pub leap_distance: f32,
+    pub bite_distance: f32,
+    pub stimulus: String,
+    pub intensity: f32,
+    pub horizontal_speed: f32,
+    pub vertical_speed: f32,
+    pub min_leap_ms: u32,
+    pub max_leap_ms: u32,
+}
+impl PropAIGrubCombat {
+    pub fn read<T: Read + Seek>(reader: &mut T, _len: u32) -> Self {
+        Self {
+            leap_distance: read_single(reader) / SCALE_FACTOR,
+            bite_distance: read_single(reader) / SCALE_FACTOR,
+            stimulus: read_string_with_size(reader, 32),
+            intensity: read_single(reader),
+            horizontal_speed: read_single(reader) / SCALE_FACTOR,
+            vertical_speed: read_single(reader) / SCALE_FACTOR,
+            min_leap_ms: read_u32(reader),
+            max_leap_ms: read_u32(reader),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Component, Serialize, Deserialize)]
+pub struct PropAIMoveSpeed(pub f32);
+impl PropAIMoveSpeed {
+    pub fn read<T: Read + Seek>(reader: &mut T, _len: u32) -> Self {
+        Self(read_single(reader) / SCALE_FACTOR)
+    }
+}
+#[derive(Clone, Debug, Component, Serialize, Deserialize)]
+pub struct PropAITurnRate(pub f32);
+impl PropAITurnRate {
+    pub fn read<T: Read + Seek>(reader: &mut T, _len: u32) -> Self {
+        Self(read_single(reader))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn reads_retail_grub_combat_without_inventing_bite_damage() {
+        let mut bytes = Vec::new();
+        bytes.extend(15.0f32.to_le_bytes());
+        bytes.extend(0.0f32.to_le_bytes());
+        bytes.extend([0u8; 32]);
+        for value in [0.0f32, 12.0, 50.0] {
+            bytes.extend(value.to_le_bytes());
+        }
+        bytes.extend(0u32.to_le_bytes());
+        bytes.extend(1u32.to_le_bytes());
+        let mut reader = std::io::Cursor::new(bytes);
+        let config = PropAIGrubCombat::read(&mut reader, 60);
+        assert_eq!(reader.position(), 60);
+        assert_eq!(config.leap_distance, 15.0 / SCALE_FACTOR);
+        assert_eq!(config.horizontal_speed, 12.0 / SCALE_FACTOR);
+        assert_eq!(config.vertical_speed, 50.0 / SCALE_FACTOR);
+        assert_eq!(config.bite_distance, 0.0);
+        assert_eq!(config.intensity, 0.0);
+        assert!(config.stimulus.is_empty());
+        assert_eq!((config.min_leap_ms, config.max_leap_ms), (0, 1));
+    }
+}

--- a/dark/src/properties/prop_ai_grub.rs
+++ b/dark/src/properties/prop_ai_grub.rs
@@ -37,14 +37,6 @@ impl PropAIMoveSpeed {
         Self(read_single(reader) / SCALE_FACTOR)
     }
 }
-#[derive(Clone, Debug, Component, Serialize, Deserialize)]
-pub struct PropAITurnRate(pub f32);
-impl PropAITurnRate {
-    pub fn read<T: Read + Seek>(reader: &mut T, _len: u32) -> Self {
-        Self(read_single(reader))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dark/src/properties/prop_tweq.rs
+++ b/dark/src/properties/prop_tweq.rs
@@ -412,3 +412,116 @@ mod tests {
         assert_eq!(config.velocity, cgmath::vec3(25.0, 0.0, 0.0));
     }
 }
+
+/// One articulated object parameter. Joint tweq rates are units per 100 ms,
+/// unlike the rotate-tweq heading rate. See Dark processTweqAxis.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TweqJoint {
+    pub curve: u8,
+    pub animation_config: TweqAnimationConfig,
+    pub limits: TweqAxisLimits,
+}
+
+#[derive(Debug, Component, Clone, Deserialize, Serialize)]
+pub struct PropTweqJointsConfig {
+    pub halt: TweqHalt,
+    pub joints: [TweqJoint; 6],
+    /// One-based master parameter; zero means all parameters run independently.
+    pub primary_joint: u8,
+}
+
+impl PropTweqJointsConfig {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        let _type = read_u8(reader);
+        let _curve = read_u8(reader);
+        let _anim = read_u8(reader);
+        let halt = num_traits::FromPrimitive::from_u8(read_u8(reader)).unwrap();
+        let _misc = read_u16(reader);
+        let _rate = read_u16(reader);
+        let joints = std::array::from_fn(|_| {
+            let _type = read_u8(reader);
+            let curve = read_u8(reader);
+            let animation_config = TweqAnimationConfig::from_bits_truncate(read_u8(reader).into());
+            let _halt = read_u8(reader);
+            let _misc = read_u16(reader);
+            let _rate = read_u16(reader);
+            TweqJoint {
+                curve,
+                animation_config,
+                limits: TweqAxisLimits {
+                    rate: read_single(reader),
+                    low: read_single(reader),
+                    high: read_single(reader),
+                },
+            }
+        });
+        let primary_joint = read_u8(reader);
+        for _ in 0..3 {
+            let _pad = read_u8(reader);
+        }
+        Self {
+            halt,
+            joints,
+            primary_joint,
+        }
+    }
+}
+
+#[derive(Debug, Component, Clone, Deserialize, Serialize)]
+pub struct PropTweqJointsState {
+    pub animation_state: TweqAnimationState,
+    pub joints: [TweqAnimationState; 6],
+}
+
+impl PropTweqJointsState {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        let mut state = || {
+            let flags = TweqAnimationState::from_bits_truncate(read_u16(reader).into());
+            let _misc = read_u16(reader);
+            flags
+        };
+        Self {
+            animation_state: state(),
+            joints: std::array::from_fn(|_| state()),
+        }
+    }
+}
+
+#[derive(Debug, Component, Clone, Deserialize, Serialize)]
+pub struct PropJointPositions(pub [f32; 6]);
+impl PropJointPositions {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self(std::array::from_fn(|_| read_single(reader)))
+    }
+}
+
+#[cfg(test)]
+mod joint_tests {
+    use super::*;
+    #[test]
+    fn joint_config_and_state_keep_six_distinct_parameter_slots() {
+        let mut bytes = vec![0, 0, 0, 3, 0, 0, 0, 0];
+        for i in 0..6 {
+            bytes.extend([0, 0, 0, 3, 0, 0, 0, 0]);
+            for value in [10.0 + i as f32, -30.0, 30.0] {
+                bytes.extend(value.to_le_bytes());
+            }
+        }
+        bytes.extend([3, 0, 0, 0]);
+        let mut reader = std::io::Cursor::new(bytes);
+        let config = PropTweqJointsConfig::read(&mut reader, 132);
+        assert_eq!(reader.position(), 132);
+        assert_eq!(config.primary_joint, 3);
+        assert_eq!(config.joints[5].limits.rate, 15.0);
+        let mut reader = std::io::Cursor::new(
+            [1u32, 1, 3, 1, 0, 0, 0]
+                .into_iter()
+                .flat_map(u32::to_le_bytes)
+                .collect::<Vec<_>>(),
+        );
+        let state = PropTweqJointsState::read(&mut reader, 28);
+        assert_eq!(reader.position(), 28);
+        assert!(state.joints[1].contains(TweqAnimationState::REVERSE));
+        assert!(!state.joints[2].contains(TweqAnimationState::REVERSE));
+    }
+}

--- a/projects/grub-ai.md
+++ b/projects/grub-ai.md
@@ -15,7 +15,7 @@ ground movement or skeletal motion clips.
   A failed/pending real route never falls back to chasing through a wall.
   Debug scenes without navigation can chase a visible target directly.
 - `P$AI_MoveSp` is the Dark move-speed input; the motor applies the original
-  `SetObjImpulse` factor of 7.5. `P$AI_TurnRa` is degrees per second.
+  `SetObjImpulse` factor of 7.5. `P$AI_TurnR` is degrees per second.
 - `P$AI_Grub_C` supplies leap range, speed limits and cooldown. The retail
   template has zero bite distance/intensity and an empty bite stimulus; its
   authored Anti-Human contact stim supplies damage. Contact is spent once per
@@ -34,7 +34,7 @@ values. The Grub enables three linear, bouncing parameters, each from -30 to
 +30 degrees at 10 degrees per 100 milliseconds.
 
 LGMD's field previously labeled `parent_idx` is actually the parameter index.
-The child/next links encode hierarchy. `SetObjectJointParameters` maps each
+The child/next links encode hierarchy. `SetObjectParameters` maps each
 parameter onto the appropriate sub-object, including parts sharing a parameter.
 Rotation occurs about local Dark X (runtime -X), after the authored pivot;
 sliding uses the same axis. This preserves the existing per-joint transform

--- a/projects/grub-ai.md
+++ b/projects/grub-ai.md
@@ -1,0 +1,97 @@
+# Grub object-model AI
+
+`GrubAI` is a sibling of `AnimatedMonsterAI` under `BaseMonster`. It reads
+awareness and navigation independently of animation, sets physical velocity,
+and advances the object's authored joint tweq. `SwarmerAI` remains a follow-up;
+its flight controller can reuse the awareness layer without adopting the grub's
+ground movement or skeletal motion clips.
+
+## Authored behavior and reused components
+
+- `MobileAwareness` uses the existing alertness state machine, caps, delays,
+  visibility, last-known target publication and noise messages.
+- Ground movement uses `PathFollowSteeringStrategy` for chase and wander,
+  including asynchronous route requests, waypoint progress and stall recovery.
+  A failed/pending real route never falls back to chasing through a wall.
+  Debug scenes without navigation can chase a visible target directly.
+- `P$AI_MoveSp` is the Dark move-speed input; the motor applies the original
+  `SetObjImpulse` factor of 7.5. `P$AI_TurnRa` is degrees per second.
+- `P$AI_Grub_C` supplies leap range, speed limits and cooldown. The retail
+  template has zero bite distance/intensity and an empty bite stimulus; its
+  authored Anti-Human contact stim supplies damage. Contact is spent once per
+  leap to prevent repeated collision messages from multiplying a strike.
+- Death uses the existing Slay/Flinderize path. BaseMonster forwards child AI
+  snapshots, including awareness, animation phase, leap cooldown and contact
+  latch. Stasis pauses both the controller and the wiggle and blocks contact
+  attacks. Routes are recomputed after loading.
+
+## Joint animation
+
+`CfgTweqJo` is a 132-byte configuration: an eight-byte header, six 20-byte
+parameter configurations, and a one-based primary parameter plus padding.
+`StTweqJoi` contains seven four-byte states. `JointPos` supplies six initial
+values. The Grub enables three linear, bouncing parameters, each from -30 to
++30 degrees at 10 degrees per 100 milliseconds.
+
+LGMD's field previously labeled `parent_idx` is actually the parameter index.
+The child/next links encode hierarchy. `SetObjectJointParameters` maps each
+parameter onto the appropriate sub-object, including parts sharing a parameter.
+Rotation occurs about local Dark X (runtime -X), after the authored pivot;
+sliding uses the same axis. This preserves the existing per-joint transform
+path for cameras and turrets. The helper is currently driven by GrubAI, not a
+new global tweq pass: other jointed props are not implicitly activated. Nonlinear
+jitter/multiply curves are not implemented by this helper.
+
+## Physics boundaries
+
+Hatched grubs previously became kinematic fixtures through inherited FrobInfo;
+emitted grubs became unconstrained dynamic props through the projectile path.
+Both now use the same dynamic sphere, with physical rotation locked. The motor
+owns yaw. Grub geometry faces -X while navigation uses +Z, so heading is converted
+at that boundary in both directions.
+
+The remaster's `grub3.bin` has a lower rest extent of approximately -.052, while
+its inherited sphere offset is .36 and radius .2. Applying the inherited offset
+unchanged buries the visible model .16 below support. Creation derives the
+sphere offset from the loaded model's lower bound plus radius (approximately
+.148), including model scale. This metadata is separate from existing model
+interaction bounds. Support and perception use the live sphere; resting solver
+contacts handle curved pod surfaces that a vertical probe can miss.
+
+## Damage volume
+
+The live sphere is also the damage target: radius .2 world units, with five
+authored hit points. There are no per-segment hitboxes. Its height is forgiving
+relative to the thin mesh, but the head and tail extend beyond its horizontal
+footprint. The lifecycle test injects damage directly; aimed weapon accuracy
+and shots-to-kill have not been playtested in this pass.
+
+## Deliberate limits of this first controller
+
+The hop is a motor approximation, not full original physics parity. Dark keeps
+applying velocity control after the leap. Our motor instead treats authored
+speeds as limits and bounds the apex to target height. Applying the raw retail
+50 ft/s upward speed as free ballistic motion sent the grub several storeys
+above the target in an open scene. Emitter launches remain ballistic until
+landing; they are not replaced by a chase velocity in midair.
+
+Ground following refuses unsupported steps. It does not add wall/ceiling
+crawling or humanoid door-frob behavior. Separate nonzero bite stimuli and the
+original random collision-escape charge are not implemented in this first pass;
+the existing path follower provides stall recovery.
+
+## Evidence and checks
+
+- Real `rec1.mis` pod 131 near the elevator: hatch, upright landing, natural
+  pursuit/hop and player damage.
+- `grub-ai.e2e.test.ts`: joint animation without a skeletal clip, natural pursuit,
+  bounded upright hops, contact/death lifecycle and isolated floor placement.
+- Existing annelid egg/goo volley and ops4 emitter/save tests.
+- Unit coverage for binary layouts, parameter mapping, animation phase restore,
+  support geometry, body creation, alert caps and committed leap state.
+
+Reference implementations examined:
+[Grub combat](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/SHOCK/SHKAIGRA.CPP),
+[joint tweqs](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/ENGFEAT/TWEQCTRL.CPP),
+[object articulation](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/DarkEngine/LIBSRC/MD/RENDER.C),
+and [AI velocity control](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/AI/AIUTILS.CPP).

--- a/projects/grub-ai.md
+++ b/projects/grub-ai.md
@@ -60,11 +60,20 @@ contacts handle curved pod surfaces that a vertical probe can miss.
 
 ## Damage volume
 
-The live sphere is also the damage target: radius .2 world units, with five
-authored hit points. There are no per-segment hitboxes. Its height is forgiving
-relative to the thin mesh, but the head and tail extend beyond its horizontal
-footprint. The lifecycle test injects damage directly; aimed weapon accuracy
-and shots-to-kill have not been playtested in this pass.
+Damage follows four padded capsules fitted to the joint-local geometry of the
+head, chest, abdomen and tail. Each capsule encloses its section along its longest
+axis with an extra .025 model units of radial padding and rounded ends. The
+existing hitbox manager places these non-solid proxies using the same animated
+joint transforms as the rendered mesh. All four count as normal body damage.
+The support sphere remains for movement and ordinary physical contacts; shot
+ray refinement, flat melee and held VR melee use the segment proxies when present.
+Slow physical projectiles retain the existing engine contact behavior.
+
+The grub retains five authored hit points. Tests verify hits beyond the old
+sphere, misses through its empty upper volume, proxy damage forwarding and
+cleanup on death. Weapon balance/skill-dependent shots-to-kill have not been
+playtested in this pass. Proxies are rebuilt after save/load, like skeletal
+creature hitboxes.
 
 ## Deliberate limits of this first controller
 
@@ -85,7 +94,7 @@ the existing path follower provides stall recovery.
 - Real `rec1.mis` pod 131 near the elevator: hatch, upright landing, natural
   pursuit/hop and player damage.
 - `grub-ai.e2e.test.ts`: joint animation without a skeletal clip, natural pursuit,
-  bounded upright hops, contact/death lifecycle and isolated floor placement.
+  bounded upright hops, segment ray hits, proxy death/cleanup and isolated floor placement.
 - Existing annelid egg/goo volley and ops4 emitter/save tests.
 - Unit coverage for binary layouts, parameter mapping, animation phase restore,
   support geometry, body creation, alert caps and committed leap state.

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -45,8 +45,17 @@ pub(crate) fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
 /// on the animal would make whole bands of it unshootable. That creature keeps
 /// its capsule; widening its definition is what would let it join the rule.
 pub(crate) fn hit_boxes_cover_body(world: &World, entity_id: EntityId) -> bool {
-    crate::creature::get_entity_creature(world, entity_id)
-        .is_some_and(|creature| creature.hit_boxes.len() > 1)
+    is_grub(world, entity_id)
+        || crate::creature::get_entity_creature(world, entity_id)
+            .is_some_and(|creature| creature.hit_boxes.len() > 1)
+}
+
+fn is_grub(world: &World, entity: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropAI>>()
+        .unwrap()
+        .get(entity)
+        .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("grub"))
 }
 
 /// Whether an entity is a creature with live hitbox proxies - i.e. whether a
@@ -249,7 +258,8 @@ impl HitBoxManager {
                     .with_id()
             {
                 let maybe_creature_type = get_entity_creature(world, parent_entity_id);
-                if maybe_creature_type.is_none() {
+                let object_grub = is_grub(world, parent_entity_id);
+                if maybe_creature_type.is_none() && !object_grub {
                     continue;
                 }
 
@@ -265,14 +275,24 @@ impl HitBoxManager {
                 // the authoritative key set for which joints get a proxy.
                 let fitted_shapes = maybe_model.unwrap().hit_box_shapes();
                 let joint_aabbs = maybe_model.unwrap().get_hit_boxes();
-                let creature_type = maybe_creature_type.unwrap();
+                // Every grub segment deals normal body damage: the padding
+                // makes small moving targets forgiving without a tail penalty.
+                let hitbox_type_for = |joint| {
+                    if object_grub {
+                        Some(HitBoxType::Body)
+                    } else {
+                        maybe_creature_type
+                            .as_ref()
+                            .and_then(|c| c.get_hitbox_type(joint))
+                    }
+                };
 
                 let mut built_hit_boxes = false;
                 let hit_box_map = self.hit_boxes.entry(parent_entity_id).or_insert_with(|| {
                     let mut out_hit_boxes = HashMap::new();
 
                     for joint_id in joint_aabbs.keys() {
-                        let maybe_hitbox_type = creature_type.get_hitbox_type(*joint_id);
+                        let maybe_hitbox_type = hitbox_type_for(*joint_id);
                         if maybe_hitbox_type.is_none() {
                             continue;
                         }
@@ -332,7 +352,7 @@ impl HitBoxManager {
 
                 let mut joint_index = 0;
                 for joint_xform in joint_xforms.0 {
-                    let maybe_hitbox_type = creature_type.get_hitbox_type(joint_index);
+                    let maybe_hitbox_type = hitbox_type_for(joint_index);
 
                     if maybe_hitbox_type.is_none() {
                         joint_index += 1;

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1207,6 +1207,44 @@ fn create_physics_representation_with_options(
     // that explicit creation mode here: frobbable emitted objects (Ops4's Grub
     // is one) would otherwise take the selectable-fixture branch below and
     // replace their authored moving sphere with a kinematic model-bounds box.
+    // Grubs are object models, not skeletal PropCreature actors. FrobInfo
+    // would make a hatched grub a kinematic fixture, while the launch path
+    // would make an emitted one a freely tumbling prop. Both are live actors:
+    // use the authored sphere and let the AI, not contact torque, own facing.
+    let is_grub = world
+        .borrow::<View<PropAI>>()
+        .unwrap()
+        .get(entity_id)
+        .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("grub"));
+    if is_grub && !launched_object_is_immobile {
+        if let (Ok(pos), Ok(dimensions)) = (v_pos.get(entity_id), v_phys_dimensions.get(entity_id))
+        {
+            let radius = dimensions.radius0.abs().max(dimensions.radius1.abs());
+            // The 25AE object model lies around its origin, while the legacy
+            // PhysDims centre is raised .36 above it. Match the sphere's
+            // support plane to the loaded art rather than burying the mesh.
+            let mut offset = dimensions.offset0;
+            if let Some(bounds) = maybe_model
+                .as_ref()
+                .and_then(|model| model.object_model_bounds())
+            {
+                offset.y = bounds.min.y * model_scale.y + radius;
+            }
+            let body = physics.add_dynamic(
+                entity_id,
+                pos.position,
+                pos.rotation,
+                offset,
+                PhysicsShape::Sphere(radius),
+                CollisionGroup::actor(),
+                false,
+                dynamics_options,
+            );
+            physics.set_enabled_rotations(entity_id, false, false, false);
+            return Some(body);
+        }
+    }
+
     let launched_projectile = launch_projectile
         || world
             .borrow::<View<RuntimePropLaunchedProjectile>>()
@@ -2036,6 +2074,50 @@ mod tests {
         assert_eq!(body.body_type, "dynamic");
         assert!(body.blocks_player && body.blocks_actor);
         assert!(body.collision_groups.iter().any(|group| group == "actor"));
+    }
+
+    #[test]
+    fn hatched_and_emitted_grubs_use_the_same_live_actor_body() {
+        for launched in [false, true] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity = world.add_entity((
+                PropAI("grub".into()),
+                PropPosition {
+                    position: vec3(0.0, 2.0, 0.0),
+                    rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                    cell: 0,
+                },
+                PropFrobInfo {
+                    world_action: FrobFlag::SCRIPT,
+                    inventory_action: FrobFlag::empty(),
+                    tool_action: FrobFlag::empty(),
+                },
+                PropPhysDimensions {
+                    radius0: 0.2,
+                    radius1: 0.0,
+                    offset0: vec3(0.0, 0.36, 0.0),
+                    offset1: Vector3::zero(),
+                    size: Vector3::zero(),
+                    point_vs_terrain: 0,
+                    point_vs_not_special: 0,
+                },
+            ));
+            create_physics_representation_with_options(
+                &mut world,
+                &mut physics,
+                &None,
+                entity,
+                launched,
+                false,
+            )
+            .unwrap();
+            let body = physics.debug_list_bodies().remove(0);
+            assert_eq!(body.body_type, "dynamic");
+            assert!(body.blocks_actor && body.blocks_player);
+            assert!(body.collision_groups.iter().any(|g| g == "actor"));
+            assert_eq!(physics.actor_sphere(entity).unwrap().1, 0.2);
+        }
     }
 
     fn capsule(shape: PhysicsShape) -> (f32, f32) {

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -817,6 +817,17 @@ fn create_model(
             }
         };
 
+        if world
+            .borrow::<View<PropAI>>()
+            .unwrap()
+            .get(entity_id)
+            .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("grub"))
+        {
+            // Small forgiving margin around each animated segment, independent
+            // of the sphere that supports and moves the grub.
+            model.enable_object_joint_hit_boxes(0.025);
+        }
+
         // The raw, signed scale - matching `RuntimePropTransform`, which is what
         // the renderer composes the local offset with (note the model bake
         // above deliberately uses the absolute value instead).

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5737,7 +5737,16 @@ impl MissionCore {
                         .borrow::<View<RuntimePropLaunchedProjectile>>()
                         .unwrap()
                         .contains(*id);
-                if !holds_terminal_death_pose && !launched_with_no_root_motion {
+                // Object-model AI owns its velocity even though its jointed
+                // render model has an AnimationPlayer for the tweq pose.
+                let physics_driven_ai = self
+                    .world
+                    .borrow::<View<dark::properties::PropAI>>()
+                    .unwrap()
+                    .get(*id)
+                    .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("grub"));
+                if !holds_terminal_death_pose && !launched_with_no_root_motion && !physics_driven_ai
+                {
                     self.physics.set_velocity(*id, scaled);
                 }
             }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4212,6 +4212,49 @@ impl PhysicsWorld {
         })
     }
 
+    /// A resting actor can be supported by a curved prop even when a ray
+    /// through its centre misses the contact. Use the solver's normal.
+    pub fn actor_has_support(&self, entity: EntityId) -> bool {
+        let Some(body) = self
+            .entity_id_to_body
+            .get(&entity)
+            .and_then(|h| self.rigid_body_set.get(*h))
+        else {
+            return false;
+        };
+        body.colliders().iter().any(|own| {
+            self.narrow_phase.contact_pairs_with(*own).any(|pair| {
+                pair.has_any_active_contact
+                    && pair.manifolds.iter().any(|manifold| {
+                        let normal = manifold.data.normal;
+                        let support_y = if pair.collider1 == *own {
+                            -normal.y
+                        } else {
+                            normal.y
+                        };
+                        support_y > 0.55 && !manifold.data.solver_contacts.is_empty()
+                    })
+            })
+        })
+    }
+
+    /// World-space support geometry of an object's live sphere, including
+    /// model-dependent offsets applied at creation. Sensors are not support.
+    pub fn actor_sphere(&self, entity: EntityId) -> Option<(Vector3<f32>, f32)> {
+        let body = self
+            .rigid_body_set
+            .get(*self.entity_id_to_body.get(&entity)?)?;
+        body.colliders().iter().find_map(|handle| {
+            let collider = self.collider_set.get(*handle)?;
+            if collider.is_sensor() {
+                return None;
+            }
+            let radius = collider.shape().as_ball()?.radius;
+            let center = collider.position().translation.vector;
+            Some((vec3(center.x, center.y, center.z), radius))
+        })
+    }
+
     pub fn get_velocity(&self, entity_id: EntityId) -> Option<Vector3<f32>> {
         if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
             let maybe_rigid_body = self.rigid_body_set.get(*handle);
@@ -8491,6 +8534,43 @@ mod tests {
         for _ in 0..frames {
             world.update(Vector3::new(0.0, 0.0, 0.0), player);
         }
+    }
+
+    #[test]
+    fn object_actor_support_uses_the_live_offset_and_rejects_airborne_contacts() {
+        let (mut world, mut player) = world_with_floor();
+        let actor = EntityId::from_inner(42).unwrap();
+        world.add_dynamic(
+            actor,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.148, 0.0),
+            PhysicsShape::Sphere(0.2),
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions {
+                restitution: 0.0,
+                ..DynamicPhysicsOptions::default()
+            },
+        );
+        world.set_enabled_rotations(actor, false, false, false);
+        assert!(!world.actor_has_support(actor));
+        step(&mut world, &mut player, 120);
+        assert!(world.actor_has_support(actor));
+        let (center, radius) = world.actor_sphere(actor).unwrap();
+        assert!((center.y - radius).abs() < 0.01);
+        let origin = world
+            .get_position(*world.entity_id_to_body.get(&actor).unwrap())
+            .unwrap();
+        assert!((origin.y - 0.052).abs() < 0.01);
+        world.set_velocity(actor, vec3(2.0, 4.0, 0.0));
+        step(&mut world, &mut player, 10);
+        assert!(!world.actor_has_support(actor));
+        assert!(
+            world.get_velocity(actor).unwrap().x > 1.9,
+            "airborne launch is preserved"
+        );
+        assert_eq!(world.get_rotation2(actor).unwrap(), identity_quat());
     }
 
     fn add_ramp(world: &mut PhysicsWorld, start: (f32, f32), end: (f32, f32), half_width: f32) {

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -83,7 +83,25 @@ fn creature_definition(
 pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
     creature_definition(world, entity_id)
         .map(|definition| definition.bounding_size.y)
+        .or_else(|| object_actor_radius(world, entity_id).map(|radius| radius * 2.0))
         .unwrap_or(CREATURE_DEFAULT_HEIGHT)
+}
+
+fn object_actor_radius(world: &World, entity: EntityId) -> Option<f32> {
+    if !world
+        .borrow::<View<dark::properties::PropAI>>()
+        .ok()?
+        .get(entity)
+        .ok()?
+        .0
+        .eq_ignore_ascii_case("grub")
+    {
+        return None;
+    }
+    let dimensions = world.borrow::<View<PropPhysDimensions>>().ok()?;
+    let dimensions = dimensions.get(entity).ok()?;
+    let radius = dimensions.radius0.abs().max(dimensions.radius1.abs());
+    (radius > 0.0 && radius.is_finite()).then_some(radius)
 }
 
 /// The radius of the capsule this creature actually collides with - the same
@@ -92,7 +110,7 @@ pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
 /// bounding box it may be much narrower than.
 pub fn creature_radius(world: &World, entity_id: EntityId) -> f32 {
     let Some(definition) = creature_definition(world, entity_id) else {
-        return CREATURE_DEFAULT_RADIUS;
+        return object_actor_radius(world, entity_id).unwrap_or(CREATURE_DEFAULT_RADIUS);
     };
     let v_phys_type = world.borrow::<View<PropPhysType>>().ok();
     let v_dimensions = world.borrow::<View<PropPhysDimensions>>().ok();
@@ -1198,8 +1216,17 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
     if let Ok(ent_pos) = v_current_pos.get(from_entity) {
-        let start_point =
-            point3(0.0, 0.0, 0.0) + ent_pos.position + creature::sense_offset(world, from_entity);
+        // Object-model crawlers can have their origin below the collider's
+        // support plane. Sense from the actual live sphere, including the
+        // model-dependent offset resolved by entity creation.
+        let start_point = if object_actor_radius(world, from_entity).is_some() {
+            physics
+                .actor_sphere(from_entity)
+                .map(|(center, _)| Point3::from_vec(center))
+                .unwrap_or_else(|| Point3::from_vec(ent_pos.position))
+        } else {
+            Point3::from_vec(ent_pos.position + creature::sense_offset(world, from_entity))
+        };
         let end_point = point3(0.0, 0.0, 0.0) + u_player.pos;
         return has_clear_sight_between(
             from_entity,

--- a/shock2vr/src/scripts/ai/grub_ai.rs
+++ b/shock2vr/src/scripts/ai/grub_ai.rs
@@ -1,0 +1,339 @@
+//! An object-model actor: navigation chooses a heading, physics supplies the
+//! travel, and the authored joint tweq supplies the pose. No motion clips.
+use super::{
+    ai_util,
+    joint_tweq::JointTweq,
+    mobile_awareness::MobileAwareness,
+    steering::{PathFollowSteeringStrategy, Steering, SteeringStrategy},
+};
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    scripts::{
+        AIPropertyUpdate, Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState,
+        ScriptStateError,
+    },
+    time::Time,
+};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Quaternion, Rotation3, Vector3, Zero, vec3};
+use dark::{
+    SCALE_FACTOR,
+    properties::{AIAlertLevel, PropAIGrubCombat, PropAIMoveSpeed, PropAITurnRate},
+};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+const KEY: &str = "shock2vr.grub_ai";
+#[derive(Default, Clone, Serialize, Deserialize)]
+struct GrubState {
+    awareness: MobileAwareness,
+    joints: JointTweq,
+    leap_remaining: f32,
+    leaping: bool,
+    contact_spent: bool,
+    dead: bool,
+}
+
+pub struct GrubAI {
+    state: GrubState,
+    chase: PathFollowSteeringStrategy,
+    wander: PathFollowSteeringStrategy,
+}
+impl GrubAI {
+    pub fn new() -> Self {
+        Self {
+            state: GrubState::default(),
+            chase: PathFollowSteeringStrategy::chase_player(),
+            wander: PathFollowSteeringStrategy::wander(3.0),
+        }
+    }
+    fn die(&mut self, entity_id: EntityId) -> Effect {
+        if self.state.dead {
+            return Effect::NoEffect;
+        }
+        self.state.dead = true;
+        Effect::SlayEntity { entity_id }
+    }
+}
+
+/// Sample support below the actual authored sphere (not the model origin).
+/// Keeping this independent of the player's controller preserves projectile
+/// launches and gravity while an actor is airborne.
+fn supported(physics: &PhysicsWorld, entity: EntityId, center: Vector3<f32>, radius: f32) -> bool {
+    physics
+        .ray_cast2_as_actor(
+            cgmath::Point3::from_vec(center),
+            -Vector3::unit_y(),
+            radius + 0.06,
+            InternalCollisionGroups::WORLD | InternalCollisionGroups::ENTITY,
+            Some(entity),
+            true,
+        )
+        .is_some_and(|hit| hit.hit_normal.y > 0.55)
+}
+
+/// Our motor has no Dark vertical velocity-control loop after the launch.
+/// Treat the authored leap speeds as limits and aim the hop at the target's
+/// body height. Applying the raw 50 ft/s as an uncontrolled ballistic launch
+/// sends a grub several storeys above its target in an open scene.
+fn leap_velocity(
+    forward: Vector3<f32>,
+    target_height: f32,
+    radius: f32,
+    horizontal: f32,
+    vertical: f32,
+) -> Vector3<f32> {
+    let rise = (target_height + radius).max(radius * 2.0);
+    let up = vertical.min((2.0 * 9.81 * rise).sqrt());
+    forward * horizontal + Vector3::unit_y() * up
+}
+
+impl Script for GrubAI {
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(KEY)
+    }
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, &self.state, KEY)
+    }
+    fn restore_state(
+        &mut self,
+        saved: &ScriptState,
+        _: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        self.state = saved.decode(1, KEY)?;
+        Ok(())
+    }
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        self.state.joints = JointTweq::from_world(world, entity_id);
+        self.state.awareness = MobileAwareness::from_world(world, entity_id);
+        self.state.joints.pose(entity_id)
+    }
+    fn initialize_after_hydration(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        hydrated: bool,
+    ) -> Effect {
+        if hydrated {
+            self.state.joints.pose(entity_id)
+        } else {
+            self.initialize(entity_id, world)
+        }
+    }
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if ai_util::is_killed(entity_id, world) {
+            return self.die(entity_id);
+        }
+        if self.state.dead {
+            return Effect::NoEffect;
+        }
+        let dt = time.elapsed.as_secs_f32();
+        if dt <= 0.0 {
+            return Effect::NoEffect;
+        }
+        self.state.leap_remaining = (self.state.leap_remaining - dt).max(0.0);
+        let (visible, awareness) = self.state.awareness.update(world, physics, entity_id, dt);
+        let mut effects = vec![awareness, self.state.joints.update(entity_id, world, dt)];
+        let (position, _) = ai_util::get_position_and_forward(world, entity_id);
+        let velocity = physics
+            .get_velocity(entity_id)
+            .unwrap_or_else(Vector3::zero);
+        let Some((center, radius)) = physics.actor_sphere(entity_id) else {
+            return Effect::combine(effects);
+        };
+        let grounded = velocity.y <= 0.1
+            && (physics.actor_has_support(entity_id)
+                || supported(physics, entity_id, center, radius));
+        // Do not overwrite any part of an emitter launch or a committed leap.
+        if !grounded {
+            effects.push(Effect::SetAIProperty {
+                entity_id,
+                update: AIPropertyUpdate::Behavior {
+                    name: "Airborne".into(),
+                },
+            });
+            return Effect::combine(effects);
+        }
+        self.state.leaping = false;
+        let chasing = self.state.awareness.target.is_some()
+            && matches!(
+                self.state.awareness.alertness.current_level,
+                AIAlertLevel::Moderate | AIAlertLevel::High
+            );
+        // The LGMD grub faces Dark +X (runtime -X); navigation headings
+        // use +Z. Convert once at the movement boundary, in both directions.
+        let heading = ai_util::current_yaw(entity_id, world) - Deg(90.0);
+        let route = if chasing {
+            &mut self.chase
+        } else {
+            &mut self.wander
+        };
+        let steering = route.steer(heading, world, physics, entity_id, time);
+        // A scene without a navigation service can still exercise the actor.
+        // A failed/pending real route must never become a straight-line chase.
+        let no_navigation = world
+            .borrow::<shipyard::UniqueView<crate::mission::GlobalPathfinding>>()
+            .ok()
+            .is_none_or(|service| service.0.is_none());
+        let steering = steering.or_else(|| {
+            (no_navigation && chasing && visible).then(|| {
+                (
+                    Steering::turn_to_point(
+                        position,
+                        cgmath::Point3::from_vec(self.state.awareness.target.unwrap()),
+                    ),
+                    Effect::NoEffect,
+                )
+            })
+        });
+        let mut desired_velocity = vec3(0.0, velocity.y.min(0.0), 0.0);
+        if let Some((steering, effect)) = steering {
+            effects.push(effect);
+            let delta = ai_util::clamp_to_minimal_delta_angle(steering.desired_heading - heading).0;
+            let rate = world
+                .borrow::<View<PropAITurnRate>>()
+                .unwrap()
+                .get(entity_id)
+                .map(|p| p.0)
+                .unwrap_or(380.0);
+            let facing = heading + Deg(delta.clamp(-rate * dt, rate * dt));
+            let rotation = Quaternion::from_angle_y(facing);
+            let forward = rotation * Vector3::unit_z();
+            let speed = world
+                .borrow::<View<PropAIMoveSpeed>>()
+                .unwrap()
+                .get(entity_id)
+                .map(|p| p.0)
+                .unwrap_or(1.4 / SCALE_FACTOR)
+                * 7.5; // Dark SetObjImpulse's move-speed multiplier.
+            // Crawl only into supported ground. Airborne leaps are a separate
+            // deliberate action; ground navigation must not walk off an edge.
+            if supported(
+                physics,
+                entity_id,
+                center + forward * radius.max(speed * dt),
+                radius,
+            ) {
+                desired_velocity += forward * speed * delta.to_radians().cos().max(0.0);
+            }
+            effects.push(Effect::SetRotation {
+                entity_id,
+                rotation: Quaternion::from_angle_y(facing + Deg(90.0)),
+            });
+            if chasing && visible && delta.abs() < 30.0 && self.state.leap_remaining <= 0.0 {
+                if let Ok(config) = world
+                    .borrow::<View<PropAIGrubCombat>>()
+                    .unwrap()
+                    .get(entity_id)
+                {
+                    let distance =
+                        (self.state.awareness.target.unwrap() - position.to_vec()).magnitude();
+                    if distance <= config.leap_distance && config.vertical_speed > 0.0 {
+                        desired_velocity = leap_velocity(
+                            forward,
+                            self.state.awareness.target.unwrap().y - center.y,
+                            radius,
+                            config.horizontal_speed,
+                            config.vertical_speed,
+                        );
+                        self.state.leaping = true;
+                        self.state.contact_spent = false;
+                        // Retain the selected delay in the script snapshot. It
+                        // must not re-roll or re-launch when a save is loaded.
+                        use rand::Rng;
+                        self.state.leap_remaining = rand::thread_rng().gen_range(
+                            config.min_leap_ms..=config.max_leap_ms.max(config.min_leap_ms),
+                        ) as f32
+                            / 1000.0;
+                    }
+                }
+            }
+        }
+        effects.push(Effect::SetLinearVelocity {
+            entity_id,
+            velocity: desired_velocity,
+        });
+        effects.push(Effect::SetAIProperty {
+            entity_id,
+            update: AIPropertyUpdate::Behavior {
+                name: if self.state.leaping {
+                    "Leap"
+                } else if chasing {
+                    "Chase"
+                } else {
+                    "Wander"
+                }
+                .into(),
+            },
+        });
+        Effect::combine(effects)
+    }
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Slay => self.die(entity_id),
+            MessagePayload::SetAlertness { level, pin } => self
+                .state
+                .awareness
+                .set_alertness(world, entity_id, *level, *pin),
+            MessagePayload::HeardNoise { origin } => {
+                self.state.awareness.hear(world, entity_id, *origin)
+            }
+            MessagePayload::Collided { with, .. }
+                if !self.state.dead && !self.state.contact_spent =>
+            {
+                let effect = crate::scripts::script_util::projectile_contact_effects(
+                    world, entity_id, *with, None,
+                );
+                if !matches!(effect, Effect::NoEffect) {
+                    self.state.contact_spent = true;
+                }
+                effect
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn hop_uses_authored_speed_limits_without_ballistic_overshoot() {
+        let v = leap_velocity(Vector3::unit_z(), 1.0, 0.2, 4.8, 20.0);
+        assert!((v.y * v.y / (2.0 * 9.81) - 1.2).abs() < 0.0001);
+        assert_eq!(v.z, 4.8);
+        assert_eq!(leap_velocity(Vector3::unit_z(), 1.0, 0.2, 2.0, 1.0).y, 1.0);
+    }
+    #[test]
+    fn a_saved_committed_leap_and_contact_latch_are_not_restarted() {
+        let mut grub = GrubAI::new();
+        grub.state.leaping = true;
+        grub.state.contact_spent = true;
+        grub.state.leap_remaining = 0.75;
+        grub.state.awareness.target = Some(vec3(1.0, 2.0, 3.0));
+        let saved = grub.save_state().unwrap();
+        let map = std::collections::HashMap::new();
+        let mut restored = GrubAI::new();
+        restored
+            .restore_state(
+                &saved,
+                &ScriptRestoreContext {
+                    entity_id_map: &map,
+                },
+            )
+            .unwrap();
+        assert_eq!(restored.save_state().unwrap(), saved);
+        assert!(restored.state.leaping && restored.state.contact_spent);
+    }
+}

--- a/shock2vr/src/scripts/ai/joint_tweq.rs
+++ b/shock2vr/src/scripts/ai/joint_tweq.rs
@@ -1,0 +1,159 @@
+//! Articulated-object animation independent of AI decisions or skeletal clips.
+//! The caller owns this state so animation phase freezes and saves with it.
+use crate::scripts::Effect;
+use dark::properties::{
+    PropJointPositions, PropTweqJointsConfig, PropTweqJointsState, TweqAnimationConfig as Config,
+    TweqAnimationState as State, TweqHalt,
+};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct JointTweq {
+    values: [f32; 6],
+    state: Option<PropTweqJointsState>,
+}
+impl JointTweq {
+    pub fn from_world(world: &World, entity: EntityId) -> Self {
+        Self {
+            values: world
+                .borrow::<View<PropJointPositions>>()
+                .unwrap()
+                .get(entity)
+                .map(|v| v.0)
+                .unwrap_or([0.0; 6]),
+            state: world
+                .borrow::<View<PropTweqJointsState>>()
+                .unwrap()
+                .get(entity)
+                .ok()
+                .cloned(),
+        }
+    }
+    pub fn pose(&self, entity_id: EntityId) -> Effect {
+        Effect::SetObjectJointParameters {
+            entity_id,
+            values: self.values,
+        }
+    }
+    pub fn update(&mut self, entity_id: EntityId, world: &World, seconds: f32) -> Effect {
+        let configs = world.borrow::<View<PropTweqJointsConfig>>().unwrap();
+        let (Some(state), Ok(config)) = (self.state.as_mut(), configs.get(entity_id)) else {
+            return Effect::NoEffect;
+        };
+        if !state.animation_state.contains(State::ON) || seconds <= 0.0 {
+            return self.pose(entity_id);
+        }
+        let primary = config
+            .primary_joint
+            .checked_sub(1)
+            .map(usize::from)
+            .filter(|i| *i < 6);
+        if let Some(i) = primary {
+            state.joints[i] = state.animation_state;
+        }
+        for (i, joint) in config.joints.iter().enumerate() {
+            if !state.joints[i].contains(State::ON) || joint.limits.rate == 0.0 {
+                continue;
+            }
+            // Grub authors linear curves. Jitter/multiply need their own
+            // reproducible curve implementation, not an invented sine wave.
+            if joint.curve != 0 {
+                continue;
+            }
+            let reverse = state.joints[i].contains(State::REVERSE);
+            let rate = joint.limits.rate * if reverse { -1.0 } else { 1.0 };
+            self.values[i] += rate * seconds * 10.0;
+            if joint.animation_config.contains(Config::NOLIMT) {
+                continue;
+            }
+            let low = self.values[i] < joint.limits.low;
+            let high = self.values[i] > joint.limits.high;
+            if !low && !high {
+                continue;
+            }
+            if joint.animation_config.contains(Config::WRAP) {
+                self.values[i] = if low {
+                    joint.limits.high
+                } else {
+                    joint.limits.low
+                };
+            } else {
+                self.values[i] = self.values[i].clamp(joint.limits.low, joint.limits.high);
+                state.joints[i].toggle(State::REVERSE);
+            }
+            let completed = !joint.animation_config.contains(Config::ONEBOUNCE) || reverse;
+            if completed && !matches!(config.halt, TweqHalt::Continue) {
+                state.joints[i].remove(State::ON);
+                if primary == Some(i) {
+                    state.animation_state = state.joints[i];
+                    match config.halt {
+                        TweqHalt::DestroyObject => return Effect::DestroyEntity { entity_id },
+                        TweqHalt::SlayObj => return Effect::SlayEntity { entity_id },
+                        _ => {}
+                    }
+                }
+            }
+        }
+        if let Some(i) = primary {
+            state.animation_state = state.joints[i];
+        }
+        self.pose(entity_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{TweqAxisLimits, TweqJoint};
+    fn fixture() -> (World, EntityId, JointTweq) {
+        let mut world = World::new();
+        let entity = world.add_entity((
+            PropTweqJointsConfig {
+                halt: TweqHalt::Continue,
+                primary_joint: 0,
+                joints: std::array::from_fn(|_| TweqJoint {
+                    curve: 0,
+                    animation_config: Config::empty(),
+                    limits: TweqAxisLimits {
+                        rate: 10.0,
+                        low: -30.0,
+                        high: 30.0,
+                    },
+                }),
+            },
+            PropTweqJointsState {
+                animation_state: State::ON,
+                joints: [State::ON; 6],
+            },
+        ));
+        let tween = JointTweq::from_world(&world, entity);
+        (world, entity, tween)
+    }
+    #[test]
+    fn authored_rate_is_per_100ms_and_bounces_at_the_limits() {
+        let (world, entity, mut tween) = fixture();
+        tween.update(entity, &world, 0.1);
+        assert_eq!(tween.values, [10.0; 6]);
+        tween.update(entity, &world, 0.25);
+        assert_eq!(tween.values, [30.0; 6]);
+        tween.update(entity, &world, 0.1);
+        assert_eq!(tween.values, [20.0; 6]);
+    }
+    #[test]
+    fn saved_reversing_joint_resumes_its_phase_and_paused_ticks_do_not_advance() {
+        let (world, entity, mut tween) = fixture();
+        tween.update(entity, &world, 0.35);
+        let saved = serde_json::to_value(&tween).unwrap();
+        let mut restored: JointTweq = serde_json::from_value(saved.clone()).unwrap();
+        restored.update(entity, &world, 0.0);
+        assert_eq!(serde_json::to_value(&restored).unwrap(), saved);
+        tween.update(entity, &world, 0.12);
+        restored.update(entity, &world, 0.12);
+        assert_eq!(
+            serde_json::to_value(&restored).unwrap(),
+            serde_json::to_value(&tween).unwrap()
+        );
+        assert_eq!(restored.values, [18.0; 6]);
+    }
+}

--- a/shock2vr/src/scripts/ai/joint_tweq.rs
+++ b/shock2vr/src/scripts/ai/joint_tweq.rs
@@ -31,9 +31,14 @@ impl JointTweq {
         }
     }
     pub fn pose(&self, entity_id: EntityId) -> Effect {
-        Effect::SetObjectJointParameters {
+        Effect::SetObjectParameters {
             entity_id,
-            values: self.values,
+            parameters: self
+                .values
+                .iter()
+                .enumerate()
+                .map(|(i, &value)| (i as i32, value))
+                .collect(),
         }
     }
     pub fn update(&mut self, entity_id: EntityId, world: &World, seconds: f32) -> Effect {

--- a/shock2vr/src/scripts/ai/mobile_awareness.rs
+++ b/shock2vr/src/scripts/ai/mobile_awareness.rs
@@ -1,0 +1,141 @@
+//! Awareness shared by actors whose motion is not driven by skeletal clips.
+use super::{
+    ai_util,
+    alertness::{self, AlertnessState, AlertnessTimings},
+};
+use crate::{
+    mission::PlayerInfo,
+    physics::PhysicsWorld,
+    scripts::{AIPropertyUpdate, Effect},
+};
+use cgmath::Vector3;
+use dark::properties::{AIAlertLevel, PropAIAlertCap, PropAIAlertness, PropAIAwareDelay};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct MobileAwareness {
+    pub alertness: AlertnessState,
+    pub target: Option<Vector3<f32>>,
+    pub pinned: bool,
+}
+impl MobileAwareness {
+    fn cap(world: &World, entity: EntityId) -> PropAIAlertCap {
+        world
+            .borrow::<View<PropAIAlertCap>>()
+            .unwrap()
+            .get(entity)
+            .cloned()
+            .unwrap_or(PropAIAlertCap {
+                min_level: AIAlertLevel::Lowest,
+                max_level: AIAlertLevel::High,
+                min_relax: AIAlertLevel::Low,
+            })
+    }
+    pub fn set_alertness(
+        &mut self,
+        world: &World,
+        entity: EntityId,
+        level: AIAlertLevel,
+        pinned: bool,
+    ) -> Effect {
+        self.pinned = pinned;
+        alertness::set_level(&mut self.alertness, level, &Self::cap(world, entity));
+        if self.alertness.current_level == AIAlertLevel::Lowest {
+            self.target = None;
+        }
+        alertness::sync_alertness_effect(entity, &self.alertness)
+    }
+    pub fn hear(&mut self, world: &World, entity: EntityId, origin: Vector3<f32>) -> Effect {
+        self.target = Some(origin);
+        alertness::set_level(
+            &mut self.alertness,
+            AIAlertLevel::High,
+            &Self::cap(world, entity),
+        );
+        Effect::combine(vec![
+            alertness::sync_alertness_effect(entity, &self.alertness),
+            Effect::SetAIProperty {
+                entity_id: entity,
+                update: AIPropertyUpdate::TargetAwareness {
+                    last_known_pos: origin,
+                    has_line_of_sight: false,
+                },
+            },
+        ])
+    }
+    pub fn from_world(world: &World, entity: EntityId) -> Self {
+        let mut state = Self::default();
+        if let Ok(prop) = world.borrow::<View<PropAIAlertness>>().unwrap().get(entity) {
+            state.alertness.current_level = prop.level;
+            state.alertness.peak_level = prop.peak;
+        }
+        state
+    }
+    pub fn update(
+        &mut self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity: EntityId,
+        dt: f32,
+    ) -> (bool, Effect) {
+        let visible = self.pinned || ai_util::is_player_visible(entity, world, physics);
+        let cap = Self::cap(world, entity);
+        let timings = world
+            .borrow::<View<PropAIAwareDelay>>()
+            .unwrap()
+            .get(entity)
+            .map(AlertnessTimings::from_aware_delay)
+            .unwrap_or_default();
+        if !self.pinned {
+            alertness::process_alertness_update(&mut self.alertness, visible, dt, &timings, &cap);
+        }
+        if visible {
+            self.target = world.borrow::<UniqueView<PlayerInfo>>().ok().map(|p| p.pos);
+        } else if self.alertness.current_level == AIAlertLevel::Lowest {
+            self.target = None;
+        }
+        let awareness = match self.target {
+            Some(pos) => AIPropertyUpdate::TargetAwareness {
+                last_known_pos: pos,
+                has_line_of_sight: visible,
+            },
+            None => AIPropertyUpdate::ClearTargetAwareness,
+        };
+        (
+            visible,
+            Effect::combine(vec![
+                alertness::sync_alertness_effect(entity, &self.alertness),
+                Effect::SetAIProperty {
+                    entity_id: entity,
+                    update: awareness,
+                },
+            ]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn noise_retains_its_origin_and_forced_alertness_respects_authored_caps() {
+        let mut world = World::new();
+        let entity = world.add_entity((PropAIAlertCap {
+            min_level: AIAlertLevel::Lowest,
+            max_level: AIAlertLevel::Moderate,
+            min_relax: AIAlertLevel::Lowest,
+        },));
+        let mut state = MobileAwareness::default();
+        let origin = cgmath::vec3(2.0, 3.0, 4.0);
+        state.hear(&world, entity, origin);
+        assert_eq!(state.target, Some(origin));
+        assert_eq!(state.alertness.current_level, AIAlertLevel::Moderate);
+        state.set_alertness(&world, entity, AIAlertLevel::High, true);
+        assert_eq!(state.alertness.current_level, AIAlertLevel::Moderate);
+        assert!(state.pinned);
+        state.set_alertness(&world, entity, AIAlertLevel::Lowest, false);
+        assert_eq!(state.target, None);
+        assert!(!state.pinned);
+    }
+}

--- a/shock2vr/src/scripts/ai/mod.rs
+++ b/shock2vr/src/scripts/ai/mod.rs
@@ -6,10 +6,14 @@ pub mod steering;
 mod animated_monster_ai;
 mod behavior;
 mod camera_ai;
+mod grub_ai;
+mod joint_tweq;
+mod mobile_awareness;
 mod turret_ai;
 
 pub use animated_monster_ai::*;
 pub use camera_ai::*;
+pub use grub_ai::*;
 pub use turret_ai::*;
 
 use super::{Effect, Message, MessagePayload, Script};

--- a/shock2vr/src/scripts/ai/turret_ai.rs
+++ b/shock2vr/src/scripts/ai/turret_ai.rs
@@ -203,6 +203,17 @@ impl TurretAI {
 }
 
 impl Script for TurretAI {
+    fn initialize_after_hydration(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _hydrated: bool,
+    ) -> Effect {
+        // Rebuild authored configuration and reapply the restored pose;
+        // initialize preserves alertness and activation when `restored` is set.
+        self.initialize(entity_id, world)
+    }
+
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         self.config = Self::build_config(world, entity_id);
         if !self.restored {
@@ -455,10 +466,8 @@ mod tests {
         turret.alertness.hidden_time = 1.25;
         let saved = turret.save_state().unwrap();
         let outer = super::super::super::ScriptState::encode(
-            2,
-            &serde_json::json!({
-                "stasis": null, "turret": saved
-            }),
+            3,
+            &serde_json::json!([null, ["shock2vr.turret", saved]]),
             "shock2vr.ai_stasis",
         )
         .unwrap();

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -5,19 +5,14 @@ use crate::{physics::PhysicsWorld, time::Time};
 
 use super::{
     Effect, MessagePayload, NoopScript, Script,
-    ai::{AnimatedMonsterAI, CameraAI, TurretAI},
+    ai::{AnimatedMonsterAI, CameraAI, GrubAI, TurretAI},
     script_util,
 };
 
 pub struct BaseMonster {
     ai: Box<dyn Script>,
     stasis: Option<super::stasis::StasisState>,
-    restored_turret: bool,
-}
-#[derive(serde::Serialize, serde::Deserialize)]
-struct BaseMonsterState {
-    stasis: Option<super::stasis::StasisState>,
-    turret: Option<super::ScriptState>,
+    hydrated_ai: bool,
 }
 
 impl BaseMonster {
@@ -25,7 +20,7 @@ impl BaseMonster {
         BaseMonster {
             ai: Box::new(NoopScript {}),
             stasis: None,
-            restored_turret: false,
+            hydrated_ai: false,
         }
     }
 }
@@ -38,32 +33,37 @@ impl Script for BaseMonster {
         Some("shock2vr.ai_stasis")
     }
     fn save_state(&self) -> Result<super::ScriptState, super::ScriptStateError> {
-        let turret = if self.ai.script_state_key() == Some("shock2vr.turret") {
-            Some(self.ai.save_state()?)
-        } else {
-            None
-        };
-        super::ScriptState::encode(
-            2,
-            &BaseMonsterState {
-                stasis: self.stasis.clone(),
-                turret,
-            },
-            "shock2vr.ai_stasis",
-        )
+        let child = self
+            .ai
+            .script_state_key()
+            .map(|key| self.ai.save_state().map(|state| (key.to_owned(), state)))
+            .transpose()?;
+        super::ScriptState::encode(3, &(&self.stasis, child), "shock2vr.ai_stasis")
     }
     fn restore_state(
         &mut self,
         state: &super::ScriptState,
         context: &super::ScriptRestoreContext<'_>,
     ) -> Result<(), super::ScriptStateError> {
-        let restored: BaseMonsterState = state.decode(2, "shock2vr.ai_stasis")?;
-        self.stasis = restored.stasis;
-        if let Some(turret) = restored.turret {
-            let mut ai = TurretAI::new();
-            ai.restore_state(&turret, context)?;
-            self.ai = Box::new(ai);
-            self.restored_turret = true;
+        let (stasis, child): (
+            Option<super::stasis::StasisState>,
+            Option<(String, super::ScriptState)>,
+        ) = state.decode(3, "shock2vr.ai_stasis")?;
+        self.stasis = stasis;
+        self.hydrated_ai = false;
+        if let Some((key, saved)) = child {
+            self.ai = match key.as_str() {
+                "shock2vr.grub_ai" => Box::new(GrubAI::new()),
+                "shock2vr.turret" => Box::new(TurretAI::new()),
+                _ => {
+                    return Err(super::ScriptStateError::InvalidPayload {
+                        script_key: "shock2vr.ai_stasis".into(),
+                        message: format!("unknown AI state {key}"),
+                    });
+                }
+            };
+            self.ai.restore_state(&saved, context)?;
+            self.hydrated_ai = true;
         }
         // Reject malformed state through the same typed decoder error path.
         if self.stasis.as_ref().is_some_and(|state| !state.valid()) {
@@ -80,8 +80,11 @@ impl Script for BaseMonster {
         world: &World,
         _hydrated: bool,
     ) -> Effect {
-        // initialize() preserves hydrated native turret state and stasis.
-        self.initialize(entity, world)
+        if self.hydrated_ai {
+            self.ai.initialize_after_hydration(entity, world, true)
+        } else {
+            self.initialize(entity, world)
+        }
     }
 
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
@@ -121,15 +124,15 @@ impl Script for BaseMonster {
                     "protocol" => Box::new(AnimatedMonsterAI::new()),
                     "shockdefault" => Box::new(AnimatedMonsterAI::new()),
                     "turret" => Box::new(TurretAI::new()),
-                    //TODO:
-                    "grub" => Box::new(NoopScript {}),
+                    "grub" => Box::new(GrubAI::new()),
+                    // TODO: flying object-model controller.
                     "swarmer" => Box::new(NoopScript {}),
 
                     _ => Box::new(AnimatedMonsterAI::idle()),
                 }
             };
 
-        if !self.restored_turret {
+        if !self.hydrated_ai {
             self.ai = ai;
         }
 
@@ -185,7 +188,12 @@ impl Script for BaseMonster {
         // Dropping a queued completion strands PlayOnce actions; delaying it
         // can apply an old completion to a newer scripted behavior. Animation
         // advancement remains paused centrally, and attack flags are suppressed.
-        if self.stasis.is_some() && matches!(msg, MessagePayload::AnimationFlagTriggered { .. }) {
+        if self.stasis.is_some()
+            && matches!(
+                msg,
+                MessagePayload::AnimationFlagTriggered { .. } | MessagePayload::Collided { .. }
+            )
+        {
             return Effect::NoEffect;
         }
         self.ai.handle_message(entity_id, world, physics, msg)
@@ -225,8 +233,8 @@ mod tests {
         let count = Rc::new(Cell::new(0));
         let mut script = BaseMonster {
             ai: Box::new(Counter(count.clone())),
-            restored_turret: false,
             stasis: None,
+            hydrated_ai: false,
         };
         let physics = PhysicsWorld::new();
         script.handle_message(
@@ -247,6 +255,16 @@ mod tests {
             },
         );
         assert_eq!(count.get(), 0);
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::Collided {
+                with: entity,
+                contact: None,
+            },
+        );
+        assert_eq!(count.get(), 0, "frozen actors cannot deal contact attacks");
         assert_eq!(script.stasis().unwrap().remaining_seconds, 5.0);
         // A shorter replacement is intentionally shorter, never max/add.
         script.handle_message(

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -799,7 +799,7 @@ pub enum Effect {
         entity_id: EntityId,
         rotation: Quaternion<f32>,
     },
-    /// Change a live projectile's flight velocity without changing its pose.
+    /// Set a physics-driven actor or projectile's velocity without changing its pose.
     SetLinearVelocity {
         entity_id: EntityId,
         velocity: Vector3<f32>,
@@ -818,6 +818,12 @@ pub enum Effect {
         entity_id: EntityId,
         joint_id: u32,
         transform: Matrix4<f32>,
+    },
+    /// LGMD parameter indices are independent of the sub-object hierarchy.
+    /// The model maps these authored joint values onto its render joints.
+    SetObjectJointParameters {
+        entity_id: EntityId,
+        values: [f32; 6],
     },
     SetPlayerPosition {
         position: Vector3<f32>,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -819,12 +819,6 @@ pub enum Effect {
         joint_id: u32,
         transform: Matrix4<f32>,
     },
-    /// LGMD parameter indices are independent of the sub-object hierarchy.
-    /// The model maps these authored joint values onto its render joints.
-    SetObjectJointParameters {
-        entity_id: EntityId,
-        values: [f32; 6],
-    },
     SetPlayerPosition {
         position: Vector3<f32>,
         is_teleport: bool,

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -319,6 +319,65 @@ mod tests {
     use dark::properties::PropCreature;
     use shipyard::{EntityId, World};
 
+    #[test]
+    fn grub_shots_hit_segments_beyond_support_and_miss_empty_support_volume() {
+        use crate::physics::CollisionGroup;
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let grub = world.add_entity((
+            dark::properties::PropAI("Grub".into()),
+            crate::creature::RuntimePropHasHitBoxes,
+        ));
+        physics.add_kinematic(
+            grub,
+            vec3(0.0, 0.2, 1.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.4, 0.4),
+            CollisionGroup::actor(),
+            false,
+        );
+        let segment = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: grub,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 1,
+        });
+        physics.add_kinematic_shared_shape(
+            segment,
+            vec3(0.0, 0.0, 1.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            rapier3d::prelude::SharedShape::capsule_x(0.45, 0.075),
+            vec3(0.0, 0.0, 0.0),
+            CollisionGroup::hitbox(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(10.0, 10.0, 10.0), EntityId::from_inner(1000).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        let cast = |x, y| {
+            projectile_ray_cast(
+                point3(x, y, 0.0),
+                vec3(0.0, 0.0, 1.0),
+                &physics,
+                2.0,
+                &world,
+                false,
+            )
+            .and_then(|hit| hit.maybe_entity_id)
+        };
+        assert_eq!(
+            cast(0.4, 0.0),
+            Some(segment),
+            "tail outside sphere is hittable"
+        );
+        assert_eq!(
+            cast(0.0, 0.3),
+            None,
+            "empty upper sphere cannot absorb a shot"
+        );
+        assert_eq!(cast(0.4, 0.12), None, "padding must remain bounded");
+    }
+
     fn shooter_and_target_fixture() -> (PhysicsWorld, World, EntityId, EntityId) {
         let mut physics = PhysicsWorld::new();
         // Put the player's capsule between the ray origin and the target so

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -667,7 +667,7 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
     // `ray_cast` normalizes its direction and casts a fixed 100 units, so the
     // reach has to be passed as `ray_cast2`'s max_toi - scaling the direction
     // bounds nothing.
-    let hit = physics.ray_cast2(
+    let hit = physics.ray_cast2_with_entity_filter(
         aim.origin,
         aim.forward.normalize(),
         MELEE_RANGE,
@@ -676,6 +676,10 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
             | InternalCollisionGroups::SELECTABLE,
         None,
         true,
+        &|entity| {
+            !(crate::creature::has_live_hit_boxes(world, entity)
+                && crate::creature::hit_boxes_cover_body(world, entity))
+        },
     );
     if let Some(RayCastResult {
         maybe_entity_id: Some(target),
@@ -1023,6 +1027,61 @@ mod tests {
     use crate::physics::{CollisionGroup, PhysicsWorld};
 
     use super::*;
+
+    #[test]
+    fn flat_melee_uses_grub_segments_instead_of_the_support_body() {
+        use crate::creature::{HitBoxType, RuntimePropHasHitBoxes, RuntimePropHitBox};
+        use crate::physics::CollisionGroup;
+        use crate::runtime_props::RuntimePropProxyEntity;
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let grub = world.add_entity((
+            dark::properties::PropAI("Grub".into()),
+            RuntimePropHasHitBoxes,
+        ));
+        let z = -MELEE_RANGE * 0.5;
+        physics.add_kinematic(
+            grub,
+            vec3(0.0, 0.2, z),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.4, 0.4),
+            CollisionGroup::actor(),
+            false,
+        );
+        let segment = world.add_entity((
+            RuntimePropHitBox {
+                parent_entity_id: grub,
+                hit_box_type: HitBoxType::Body,
+                joint_id: 1,
+            },
+            RuntimePropProxyEntity(grub),
+        ));
+        physics.add_kinematic_shared_shape(
+            segment,
+            vec3(0.0, 0.0, z),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            rapier3d::prelude::SharedShape::capsule_x(0.45, 0.075),
+            vec3(0.0, 0.0, 0.0),
+            CollisionGroup::hitbox(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(10.0, 10.0, 10.0), EntityId::from_inner(1000).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        let strike = |x, y| {
+            flat_melee_hit(
+                &physics,
+                RuntimePropFlatAim {
+                    origin: point3(x, y, 0.0),
+                    forward: vec3(0.0, 0.0, -1.0),
+                },
+                &world,
+            )
+        };
+        assert!(matches!(strike(0.0, 0.3), Effect::NoEffect));
+        assert!(matches!(strike(0.4, 0.0), Effect::Send { msg: Message { to, .. } } if to == grub));
+    }
 
     fn flat_melee_fixture() -> (World, PhysicsWorld, EntityId, EntityId) {
         let mut world = World::new();

--- a/tools/shock2-sdk/test/grub-ai.e2e.test.ts
+++ b/tools/shock2-sdk/test/grub-ai.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("a hatched grub animates, leaves its pod and pursues upright", {
+  skip: !enabled, timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  await game.player.teleport({ x: -6, y: 1, z: 0 });
+  await game.step({ frames: 30 });
+  const [grub] = await game.entities.byTemplate(-182);
+  assert.ok(grub, "approaching the pod must hatch a grub");
+  const start = await game.entities.detail(grub.id);
+  const before = await game.entities.animation(grub.id);
+  assert.ok(before, "the object model must have a joint pose");
+  await game.step({ frames: 10 });
+  const after = await game.entities.animation(grub.id);
+  assert.ok(after);
+  const relative = (pose: typeof before) => pose.joints.slice(0, 4).map(joint =>
+    joint.map((value, axis) => value - pose.position[axis]!));
+  assert.notDeepEqual(relative(before), relative(after), "joint tweqs must animate without motion clips");
+  assert.equal(after.clip, null, "a grub does not use skeletal locomotion clips");
+
+  let moved = false;
+  for (let i = 0; i < 24; i++) {
+    await game.step({ frames: 10 });
+    const [body] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+    assert.ok(body);
+    assert.equal(body.body_type, "dynamic");
+    assert.ok(body.angular_velocity.every(v => Math.abs(v) < 0.001), "live grub must not tumble");
+    assert.ok(Math.abs(body.rotation[0]!) < 0.001 && Math.abs(body.rotation[2]!) < 0.001,
+      "facing changes must preserve upright pitch and roll");
+    assert.ok(body.position[1]! < 4, "controlled hop must stay near its target's height");
+    moved ||= Math.hypot(body.position[0]! - start.position[0]!, body.position[2]! - start.position[2]!) > 0.5;
+  }
+  assert.ok(moved, "the grub must leave its pod and pursue without an injected alert or impulse");
+  await game.entities.sendMessage(grub.id, { type: "Damage", amount: 100 });
+  await game.step({ frames: 3 });
+  assert.equal((await game.entities.byTemplate(-182)).length, 0, "death must remove the live actor");
+  assert.equal((await game.entities.byTemplate(-2666)).length, 1, "death must use the authored grub flinders");
+});
+
+
+test("a launched grub settles with its visible model above the floor", {
+  skip: !enabled, timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(-1335);
+  assert.ok(pod);
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 30 });
+  const [grub] = await game.entities.byTemplate(-182);
+  assert.ok(grub);
+  // Hold calm to isolate physical landing from a new attack at the player.
+  await game.entities.sendMessage(grub.id, { type: "SetAlertness", level: "Lowest" });
+  await game.step({ frames: 1 });
+  const [body] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+  assert.ok(body && body.mass);
+  const response = await fetch(`${game.baseUrl}/v1/physics/bodies/${body.body_id}/impulse`, {
+    method: "POST", body: JSON.stringify({ impulse: [0, body.mass * 0.9, body.mass * 3] }),
+  });
+  assert.equal(response.ok, true);
+  await game.step({ frames: 180 });
+  const [landed] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+  assert.ok(landed);
+  assert.ok(Math.abs(landed.velocity[1]!) < 0.05, "the actor should have landed");
+  // This station's kerb is at y=.1; grub3's lower extent is -.052.
+  assert.ok(landed.position[1]! > 0.14 && landed.position[1]! < 0.17,
+    `the model must rest on the kerb, not below it: ${landed.position}`);
+  assert.ok(landed.angular_velocity.every(v => Math.abs(v) < 0.001));
+});

--- a/tools/shock2-sdk/test/grub-ai.e2e.test.ts
+++ b/tools/shock2-sdk/test/grub-ai.e2e.test.ts
@@ -14,6 +14,19 @@ test("a hatched grub animates, leaves its pod and pursues upright", {
   const [grub] = await game.entities.byTemplate(-182);
   assert.ok(grub, "approaching the pod must hatch a grub");
   const start = await game.entities.detail(grub.id);
+  const segments = start.aim_points ?? [];
+  assert.equal(segments.length, 4, "head, chest, abdomen and tail must have damage proxies");
+  for (const segment of segments) {
+    const body = await game.physics.body(segment.body_id);
+    assert.ok(body.collision_groups.includes("hitbox"));
+    assert.equal(body.blocks_actor, false, "damage proxies must not push the actor");
+    const hit = await game.raycast({
+      start: [segment.position[0]!, segment.position[1]! + 0.5, segment.position[2]!],
+      end: segment.position,
+      collision_groups: ["hitbox"],
+    });
+    assert.ok(segments.some(p => p.proxy_entity_id === hit.entity_id), "segment geometry must be ray-hittable");
+  }
   const before = await game.entities.animation(grub.id);
   assert.ok(before, "the object model must have a joint pose");
   await game.step({ frames: 10 });
@@ -37,9 +50,16 @@ test("a hatched grub animates, leaves its pod and pursues upright", {
     moved ||= Math.hypot(body.position[0]! - start.position[0]!, body.position[2]! - start.position[2]!) > 0.5;
   }
   assert.ok(moved, "the grub must leave its pod and pursue without an injected alert or impulse");
-  await game.entities.sendMessage(grub.id, { type: "Damage", amount: 100 });
+  const current = await game.entities.detail(grub.id);
+  const proxy = current.aim_points?.[0];
+  assert.ok(proxy);
+  await game.entities.sendMessage(proxy.proxy_entity_id, { type: "Damage", amount: 5 });
   await game.step({ frames: 3 });
   assert.equal((await game.entities.byTemplate(-182)).length, 0, "death must remove the live actor");
+  for (const segment of segments) {
+    assert.equal((await game.physics.bodies({ entityId: segment.proxy_entity_id })).bodies.length, 0,
+      "death must remove the joint collision proxies");
+  }
   assert.equal((await game.entities.byTemplate(-2666)).length, 1, "death must use the authored grub flinders");
 });
 


### PR DESCRIPTION
Grubs previously selected a no-op AI: hatched grubs could remain kinematic in their pods, while emitted grubs rolled freely. This adds `GrubAI` as a sibling of `AnimatedMonsterAI`, with authored joint wiggle, upright ground movement, pursuit, bounded hops, contact damage and padded segment hitboxes. Verified against the rec1 pod near the elevator.

Grubs reuse the shared object-articulation path, the existing alertness machinery and the chase/wander path follower. Four capsules fit the head, chest, abdomen and tail with .025 model units of radial padding. Child AI state survives save/load and respects stasis; the save wrapper handles both grubs and turrets. Sphere placement is fitted to the loaded model so the visible grub lands on the floor.

## Scope and limitations

- SwarmerAI remains a follow-up; this establishes a reusable awareness layer without requiring skeletal animation.
- Hops use authored speeds as caps with a bounded apex, approximating the original continuous velocity controller. Emitter launches remain ballistic until landing.
- Damage uses four animated segment capsules; the old sphere supports movement and ordinary physical contacts. Slow physical projectiles retain the existing engine contact behavior. All segments take normal damage, with 5 authored HP. Shot and flat-melee tests cover extremity hits and misses through empty sphere space; runtime tests cover proxy ray hits, damage forwarding and cleanup. Weapon balance/skill-dependent shots-to-kill are not yet playtested.
- Nonlinear joint tweq curves, nonzero bite stimuli and the original random collision-escape charge remain outside this first pass.

## Validation

- Merged-main Rust suites: dark 186 passed; shock2vr 1748 passed, 2 ignored, with one turret fixture still encoding the old save envelope. Updated that fixture to the current envelope and its round-trip regression passed. The pre-merge full suites also passed.
- Final grub E2E: 2 passed (natural hatch/pursuit/animation, segment ray hits/death cleanup, and isolated upright landing).
- Existing annelid egg/goo checks passed. After merging main, all 5 grub, ops4 emitter/save and flat/VR turret-articulation E2E cases passed.
- All 23 mission-load smoke tests and all 4 timed-stasis scenarios passed. An earlier combined run failed an overly coupled pursuit/landing assertion; splitting those checks produced the final passing grub tests above.
- `cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, SDK build, formatting and diff checks passed.
- Headless visual verification in flat and VR, plus the real rec1 elevator-area pod. All capture runtimes shut down.

## Before and after

![Grub behavior before and after](https://gist.githubusercontent.com/tommy-xr/3cadd7af85c5f7924d98d1b3dadd2b76/raw/grub-before-after.gif)

Identical headless runtime sequences: stationary grub before; authored joint animation, upright movement, pursuit and hopping after.

![Grub before and after still](https://gist.githubusercontent.com/tommy-xr/3cadd7af85c5f7924d98d1b3dadd2b76/raw/grub-before-after.png)

## Animated damage capsules

![Grub segment hitboxes](https://gist.githubusercontent.com/tommy-xr/3cadd7af85c5f7924d98d1b3dadd2b76/raw/grub-segment-hitboxes.gif)

![Grub segment hitbox still](https://gist.githubusercontent.com/tommy-xr/3cadd7af85c5f7924d98d1b3dadd2b76/raw/grub-segment-hitboxes.png)

Four padded, non-solid damage proxies follow the rendered joints. Verified with the physics overlay in flat and VR; the movement sphere stays separate.

See [implementation notes](projects/grub-ai.md) for authored data, physics boundaries and original-source references. Related context: #1492, #1497.
