### PR TITLE
feat(difficulty): persist campaign choice and parse authored parameters

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -221,6 +221,17 @@ Steps are edge-triggered, so a held stick moves one place, and they are the same
 `StepPsiSelection` the readout's four arrows emit - the selection applies live,
 and the panel pages to whatever tier it lands on.
 
+### Campaign difficulty in debug runs
+
+Start a fresh mission with `cargo dbgr --mission medsci1.mis --difficulty hard`.
+The choices are `easy`, `normal` (default), `hard`, and `impossible`; the SDK
+accepts the same strings as `GameServer.launch({ mission, difficulty })`.
+Difficulty is fixed for a campaign and reported by `/v1/info` as
+`player.difficulty`. Saves and deck transitions retain it, including when loading
+an existing campaign from a runtime launched with a different choice. The generic
+quest-bit API cannot change it. Gameplay consumers are being added in the
+subsequent difficulty stack layers.
+
 ### Developer options
 
 The **Developer** screen (from the main menu, or the pause overlay's Developer

--- a/dark/src/gamesys/difficulty.rs
+++ b/dark/src/gamesys/difficulty.rs
@@ -1,0 +1,195 @@
+//! Retail difficulty indices and the field-major, six-column DIFFPARAM file-var.
+use crate::ss2_chunk_file_reader::ChunkFileTableOfContents;
+use byteorder::{LittleEndian, ReadBytesExt};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{self, Read, Seek},
+    str::FromStr,
+};
+
+/// Only the four campaign choices are selectable. Retail reserves 0 for
+/// Playtest and 5 for Multiplayer; neither is a single-player difficulty.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Difficulty {
+    Easy,
+    #[default]
+    Normal,
+    Hard,
+    Impossible,
+}
+impl Difficulty {
+    pub const ALL: [Self; 4] = [Self::Easy, Self::Normal, Self::Hard, Self::Impossible];
+    pub const fn retail_index(self) -> usize {
+        match self {
+            Self::Easy => 1,
+            Self::Normal => 2,
+            Self::Hard => 3,
+            Self::Impossible => 4,
+        }
+    }
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Easy => "Easy",
+            Self::Normal => "Normal",
+            Self::Hard => "Hard",
+            Self::Impossible => "Impossible",
+        }
+    }
+}
+impl FromStr for Difficulty {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|d| d.label().eq_ignore_ascii_case(value))
+            .ok_or("expected easy, normal, hard, or impossible")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DifficultyParams {
+    pub trainer_multiplier: [f32; 6],
+    pub base_hp: [i32; 6],
+    pub hp_per_endurance: [i32; 6],
+    pub base_psi: [i32; 6],
+    pub psi_per_psionics: [i32; 6],
+    pub loot_discard_threshold: [i32; 6],
+    pub replicator_multiplier: [f32; 6],
+}
+impl DifficultyParams {
+    pub fn read<T: Read + Seek>(toc: &ChunkFileTableOfContents, reader: &mut T) -> Option<Self> {
+        let chunk = toc.get_chunk("DIFFPARAM".to_owned())?;
+        if chunk.length < 168 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset)).ok()?;
+        Self::read_record(reader)
+    }
+    fn read_record(reader: &mut impl Read) -> Option<Self> {
+        let mut value = Self {
+            trainer_multiplier: [0.0; 6],
+            base_hp: [0; 6],
+            hp_per_endurance: [0; 6],
+            base_psi: [0; 6],
+            psi_per_psionics: [0; 6],
+            loot_discard_threshold: [0; 6],
+            replicator_multiplier: [0.0; 6],
+        };
+        reader
+            .read_f32_into::<LittleEndian>(&mut value.trainer_multiplier)
+            .ok()?;
+        for row in [
+            &mut value.base_hp,
+            &mut value.hp_per_endurance,
+            &mut value.base_psi,
+            &mut value.psi_per_psionics,
+            &mut value.loot_discard_threshold,
+        ] {
+            reader.read_i32_into::<LittleEndian>(row).ok()?;
+        }
+        reader
+            .read_f32_into::<LittleEndian>(&mut value.replicator_multiplier)
+            .ok()?;
+        if value
+            .trainer_multiplier
+            .iter()
+            .chain(&value.replicator_multiplier)
+            .any(|v| !v.is_finite() || *v < 0.0)
+        {
+            return None;
+        }
+        Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    fn retail_record() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for v in [1.0_f32, 0.85, 1.0, 1.4, 1.8, 1.4] {
+            bytes.extend(v.to_le_bytes());
+        }
+        for row in [
+            [30_i32, 45, 30, 24, 7, 24],
+            [5, 10, 5, 3, 3, 3],
+            [5, 10, 5, 3, 1, 5],
+            [10, 16, 10, 8, 5, 10],
+            [0, 0, 0, 30, 75, 0],
+        ] {
+            for v in row {
+                bytes.extend(v.to_le_bytes());
+            }
+        }
+        for v in [1.0_f32, 0.85, 1.0, 1.25, 2.0, 1.0] {
+            bytes.extend(v.to_le_bytes());
+        }
+        bytes
+    }
+    #[test]
+    fn difficulty_decodes_retail_columns_and_rejects_partial_records() {
+        let bytes = retail_record();
+        assert_eq!(bytes.len(), 168);
+        let p = DifficultyParams::read_record(&mut Cursor::new(&bytes)).unwrap();
+        assert_eq!(p.base_hp, [30, 45, 30, 24, 7, 24]);
+        assert_eq!(p.hp_per_endurance, [5, 10, 5, 3, 3, 3]);
+        assert_eq!(p.base_psi, [5, 10, 5, 3, 1, 5]);
+        assert_eq!(p.psi_per_psionics, [10, 16, 10, 8, 5, 10]);
+        assert_eq!(p.loot_discard_threshold, [0, 0, 0, 30, 75, 0]);
+        assert_eq!(
+            p.trainer_multiplier[Difficulty::Impossible.retail_index()],
+            1.8
+        );
+        assert_eq!(
+            p.replicator_multiplier[Difficulty::Hard.retail_index()],
+            1.25
+        );
+        for len in 0..168 {
+            assert!(DifficultyParams::read_record(&mut Cursor::new(&bytes[..len])).is_none());
+        }
+    }
+    #[test]
+    fn difficulty_reader_honors_chunk_bounds_and_missing_chunk() {
+        let record = retail_record();
+        for (name, length, expected) in [
+            ("DIFFPARAM", 168_u32, true),
+            ("DIFFPARAM", 167, false),
+            ("OTHER", 168, false),
+        ] {
+            let toc_offset = 272 + 24 + record.len();
+            let mut bytes = vec![0; 272 + 24];
+            bytes[..4].copy_from_slice(&(toc_offset as u32).to_le_bytes());
+            bytes.extend(&record);
+            bytes.extend(1_u32.to_le_bytes());
+            let mut chunk_name = [0; 12];
+            chunk_name[..name.len()].copy_from_slice(name.as_bytes());
+            bytes.extend(chunk_name);
+            bytes.extend(272_u32.to_le_bytes());
+            bytes.extend(length.to_le_bytes());
+            let mut reader = Cursor::new(bytes);
+            let toc = crate::ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+            assert_eq!(
+                DifficultyParams::read(&toc, &mut reader).is_some(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn difficulty_names_cannot_select_reserved_columns() {
+        for (i, d) in Difficulty::ALL.into_iter().enumerate() {
+            assert_eq!(d.retail_index(), i + 1);
+            assert_eq!(d.label().parse(), Ok(d));
+            assert_eq!(
+                serde_json::from_str::<Difficulty>(&serde_json::to_string(&d).unwrap()).unwrap(),
+                d
+            );
+        }
+        for invalid in ["0", "5", "playtest", "multiplayer", "medium", ""] {
+            assert!(invalid.parse::<Difficulty>().is_err());
+        }
+        assert!(serde_json::from_str::<Difficulty>("\"multiplayer\"").is_err());
+    }
+}

--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -16,6 +16,7 @@ pub struct Gamesys {
     /// Trainer upgrade cost tables (`STATCOST`/`WTECHCOST`/`WSKILLCOST`/
     /// `PSICOST` file-var chunks); `None` if the gamesys lacks them.
     trainer_costs: Option<TrainerCostTables>,
+    difficulty_params: Option<crate::gamesys::DifficultyParams>,
     /// HRM hacking/repair/modify tuning (`HRM` file-var chunk).
     hrm_params: Option<HrmParams>,
     /// Skill-system tuning (`SKILLPARAM` file-var chunk).
@@ -66,6 +67,10 @@ impl Gamesys {
         self.trainer_costs.as_ref()
     }
 
+    pub fn difficulty_params(&self) -> Option<&crate::gamesys::DifficultyParams> {
+        self.difficulty_params.as_ref()
+    }
+
     pub fn hrm_params(&self) -> Option<&HrmParams> {
         self.hrm_params.as_ref()
     }
@@ -99,6 +104,7 @@ pub fn read<T: io::Read + io::Seek>(
 
     let env_tag_map = EnvMap::read(&table_of_contents, reader);
     let speech_db = SpeechDB::read(&table_of_contents, reader);
+    let difficulty_params = crate::gamesys::DifficultyParams::read(&table_of_contents, reader);
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
     let hrm_params = HrmParams::read(&table_of_contents, reader);
     let skill_params = SkillParams::read(&table_of_contents, reader);
@@ -114,6 +120,7 @@ pub fn read<T: io::Read + io::Seek>(
         env_tag_map,
         speech_db,
         trainer_costs,
+        difficulty_params,
         hrm_params,
         skill_params,
         hazard_params,

--- a/dark/src/gamesys/mod.rs
+++ b/dark/src/gamesys/mod.rs
@@ -1,3 +1,5 @@
+pub mod difficulty;
+pub use difficulty::*;
 pub mod env_map;
 pub mod env_sound_query;
 pub mod gamesys;

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -6,7 +6,7 @@
 //! `PSICOST` (5 tiers x 8 ints, first int of each tier row = the tier unlock
 //! cost, the remaining 7 = per-power costs within that tier). All values are
 //! little-endian `i32`, Normal difficulty (the per-difficulty multipliers live
-//! in `DIFFPARAM`, whose exact layout is unverified - Normal-only for now).
+//! in `DIFFPARAM`, parsed by `DifficultyParams`).
 //!
 //! Decoded from the shipped `shock2.gam` (projects/flat-ui-panels.md §3.2) and
 //! identical to the community-documented tables, so both sources corroborate.

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -863,6 +863,7 @@ pub struct TimeInfo {
 /// Player information
 #[derive(Debug, Serialize, Clone)]
 pub struct PlayerInfo {
+    pub difficulty: Option<dark::gamesys::Difficulty>,
     pub entity_id: Option<i32>,
     pub inventory_entity_id: Option<i32>,
     pub position: [f32; 3],

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -92,6 +92,10 @@ struct Args {
     #[arg(short, long, default_value = "main_menu")]
     mission: String,
 
+    /// Difficulty of a fresh campaign (saved campaigns retain their selection).
+    #[arg(long, default_value = "normal")]
+    difficulty: dark::gamesys::Difficulty,
+
     /// Port to bind the HTTP server to. Bound exactly as given: a taken port
     /// is a hard, loud failure rather than a silent move to another port,
     /// because a caller that then talks to the old port would be driving
@@ -588,6 +592,7 @@ fn run_game_blocking(
 
     let options = GameOptions {
         mission: mission.clone(),
+        difficulty: args.difficulty,
         presentation_mode,
         spawn_location,
         save_file: args.save_file,
@@ -1387,9 +1392,13 @@ fn process_command(
             }
         }
         RuntimeCommand::SetQuestBit { name, value, reply } => {
-            let result = match game.debug_scene_mut() {
-                Some(scene) => scene.set_quest_bit(&name, &value),
-                None => Err("no debuggable scene available".to_string()),
+            let result = if name.eq_ignore_ascii_case("difficulty") {
+                Err("difficulty is fixed when the campaign starts".to_string())
+            } else {
+                match game.debug_scene_mut() {
+                    Some(scene) => scene.set_quest_bit(&name, &value),
+                    None => Err("no debuggable scene available".to_string()),
+                }
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send set-quest-bit result - receiver dropped");
@@ -2394,6 +2403,7 @@ fn capture_frame_snapshot(
             // held/wielded entities), or zeros when the scene has no player.
             let state = game.player_state();
             PlayerInfo {
+                difficulty: state.as_ref().map(|s| s.difficulty),
                 entity_id: state.as_ref().map(|s| s.entity_id),
                 inventory_entity_id: state.as_ref().map(|s| s.inventory_entity_id),
                 position: state

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -473,6 +473,8 @@ pub enum PresentationMode {
 }
 
 pub struct GameOptions {
+    /// Used only when starting a fresh campaign; loaded campaigns retain theirs.
+    pub difficulty: dark::gamesys::Difficulty,
     pub mission: String,
     pub presentation_mode: PresentationMode,
     pub spawn_location: SpawnLocation,
@@ -491,6 +493,7 @@ pub struct GameOptions {
 impl Default for GameOptions {
     fn default() -> Self {
         Self {
+            difficulty: dark::gamesys::Difficulty::Normal,
             mission: "earth.mis".to_owned(),
             presentation_mode: PresentationMode::Vr,
             spawn_location: SpawnLocation::MapDefault,
@@ -677,6 +680,7 @@ pub struct Game {
 /// player's "left hand" slot); in VR the two hand slots hold whatever is grabbed.
 #[derive(Clone, Debug)]
 pub struct PlayerStateSnapshot {
+    pub difficulty: dark::gamesys::Difficulty,
     pub entity_id: i32,
     /// Runtime id of the player's backpack container. Exposed for deterministic
     /// inventory/link assertions; like every concrete id it must be rediscovered
@@ -819,6 +823,7 @@ impl Game {
         });
         let gun_setting = crate::hud::get_wielded_gun_setting(world);
         Some(PlayerStateSnapshot {
+            difficulty: world.borrow::<UniqueView<QuestInfo>>().ok()?.difficulty(),
             entity_id: info.entity_id.inner() as i32,
             inventory_entity_id: info.inventory_entity_id.inner() as i32,
             position: [info.pos.x, info.pos.y, info.pos.z],

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -14682,6 +14682,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn set_quest_bit(&mut self, name: &str, value: &str) -> Result<(), String> {
+        if name.eq_ignore_ascii_case("difficulty") {
+            return Err("difficulty is fixed when the campaign starts".to_string());
+        }
         use dark::properties::QuestBitValue;
         let quest_value = match value.to_ascii_lowercase().as_str() {
             "unknown" => QuestBitValue::UNKNOWN,

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -31,6 +31,9 @@ pub struct CollectedLog {
 
 #[derive(Deserialize, Serialize, Unique, Clone, Debug)]
 pub struct QuestInfo {
+    /// Fixed at campaign creation. A typed field keeps invalid quest-bit values
+    /// and generic quest mutations from changing the campaign rules.
+    difficulty: dark::gamesys::Difficulty,
     quest_bit_values: HashMap<String, QuestBitValue>,
     played_emails: HashSet<String>,
     key_cards: Vec<KeyCard>,
@@ -57,7 +60,12 @@ pub struct QuestInfo {
 
 impl QuestInfo {
     pub fn new() -> QuestInfo {
+        Self::with_difficulty(dark::gamesys::Difficulty::Normal)
+    }
+
+    pub fn with_difficulty(difficulty: dark::gamesys::Difficulty) -> Self {
         QuestInfo {
+            difficulty,
             quest_bit_values: HashMap::new(),
             played_emails: HashSet::new(),
             key_cards: Vec::new(),
@@ -66,6 +74,17 @@ impl QuestInfo {
             explored_maps: HashMap::new(),
             research: ResearchState::default(),
         }
+    }
+
+    /// Scene constructors seed their own test stats; retain those while selecting
+    /// the difficulty of the newly-created debug scene. Not a live setting.
+    pub(crate) fn for_debug_difficulty(mut self, difficulty: dark::gamesys::Difficulty) -> Self {
+        self.difficulty = difficulty;
+        self
+    }
+
+    pub fn difficulty(&self) -> dark::gamesys::Difficulty {
+        self.difficulty
     }
 
     pub fn research(&self) -> &ResearchState {
@@ -187,6 +206,9 @@ impl QuestInfo {
     }
 
     pub fn set_quest_bit_value(&mut self, quest_name: &str, quest_value: QuestBitValue) {
+        if quest_name.eq_ignore_ascii_case("difficulty") {
+            return;
+        }
         self.quest_bit_values
             .insert(quest_name.to_ascii_lowercase(), quest_value);
     }
@@ -331,5 +353,25 @@ mod log_tests {
                 read: false
             }
         );
+    }
+}
+
+#[cfg(test)]
+mod difficulty_tests {
+    use super::*;
+    #[test]
+    fn difficulty_is_sticky_and_round_trips_with_campaign() {
+        for difficulty in dark::gamesys::Difficulty::ALL {
+            let mut q = QuestInfo::with_difficulty(difficulty);
+            q.set_quest_bit_value("Difficulty", QuestBitValue::COMPLETE);
+            q.clear_quest_bit_value("difficulty");
+            let saved = serde_json::to_string(&q).unwrap();
+            let restored: QuestInfo = serde_json::from_str(&saved).unwrap();
+            assert_eq!(restored.difficulty(), difficulty);
+            assert_eq!(restored.clone().difficulty(), difficulty);
+        }
+        let mut value = serde_json::to_value(QuestInfo::new()).unwrap();
+        value["difficulty"] = serde_json::json!("multiplayer");
+        assert!(serde_json::from_value::<QuestInfo>(value).is_err());
     }
 }

--- a/shock2vr/src/scenes/debug_teleport.rs
+++ b/shock2vr/src/scenes/debug_teleport.rs
@@ -20,6 +20,7 @@ impl DebugTeleportScene {
         experimental_features.insert("teleport".to_string());
 
         let teleport_options = GameOptions {
+            difficulty: game_options.difficulty,
             mission: game_options.mission.clone(),
             presentation_mode: game_options.presentation_mode,
             spawn_location: game_options.spawn_location.clone(),

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -219,7 +219,18 @@ pub fn create_debug_scene(
     DEBUG_SCENES
         .iter()
         .find(|(scene_name, _)| name.eq_ignore_ascii_case(scene_name))
-        .map(|(_, create)| create(global_context, options, asset_cache, audio_context))
+        .map(|(_, create)| {
+            let scene = create(global_context, options, asset_cache, audio_context);
+            // Debug scenes are fresh campaigns, but retain their seeded test stats.
+            {
+                let mut quests = scene
+                    .world()
+                    .borrow::<shipyard::UniqueViewMut<QuestInfo>>()
+                    .unwrap();
+                *quests = quests.clone().for_debug_difficulty(options.difficulty);
+            }
+            scene
+        })
 }
 
 pub fn create_initial_scene(
@@ -284,7 +295,7 @@ pub fn create_initial_scene(
         audio_context,
         global_context,
         options.spawn_location.clone(),
-        QuestInfo::new(),
+        QuestInfo::with_difficulty(options.difficulty),
         Box::new(MissionEntityPopulator::create()),
         HeldItemSaveData::empty(),
         options,

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -9,6 +9,8 @@ import { Game } from "./game.js";
 export interface LaunchOptions {
   /** Mission file or debug scene, e.g. "medsci1.mis" or "debug_minimal". */
   mission: string;
+  /** Fixed for this fresh campaign; loading a save retains its difficulty. */
+  difficulty?: "easy" | "normal" | "hard" | "impossible";
   /**
    * Exact port for the debug runtime HTTP server. Omit it (the default) and
    * the runtime binds an OS-assigned ephemeral port, which the SDK learns
@@ -312,6 +314,7 @@ export class GameServer extends Game implements AsyncDisposable {
       ...(options.experimental?.length
         ? ["--experimental", options.experimental.join(",")]
         : []),
+      ...(options.difficulty ? ["--difficulty", options.difficulty] : []),
       ...(options.debugFlags ?? []),
     ];
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -585,6 +585,8 @@ export interface ClimbGripResult {
 }
 
 export interface PlayerSnapshot {
+  /** Read-only campaign choice; null when no player is available. */
+  difficulty: "easy" | "normal" | "hard" | "impossible" | null;
   entity_id: number | null;
   /** Runtime id of the backpack container; rediscover it after save/load. */
   inventory_entity_id?: number | null;

--- a/tools/shock2-sdk/test/difficulty.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty.e2e.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+for (const difficulty of ["easy", "normal", "hard", "impossible"] as const) {
+  test(`difficulty: ${difficulty} is retained across save/load and deck transitions`,
+    { skip: !enabled, timeout: 180_000 }, async () => {
+      await using game = await GameServer.launch({ mission: "medsci1.mis", difficulty });
+      await game.step({ frames: 2 });
+      assert.equal((await game.info()).player.difficulty, difficulty);
+      await assert.rejects(game.quests.set("Difficulty", "complete"), /fixed/);
+      const save = `difficulty-${difficulty}-${Date.now()}`;
+      await game.save(save);
+      await game.transitionLevel("medsci2.mis");
+      assert.equal((await game.info()).player.difficulty, difficulty);
+      await game.load(save);
+      assert.equal((await game.info()).player.difficulty, difficulty);
+      assert.equal((await game.info()).mission, "medsci1.mis");
+    });
+}
+
+test("difficulty: loading another campaign overrides the launch choice", {
+  skip: !enabled, timeout: 180_000,
+}, async () => {
+  const save = `difficulty-cross-campaign-${Date.now()}`;
+  {
+    await using game = await GameServer.launch({ mission: "medsci1.mis", difficulty: "impossible" });
+    await game.step({ frames: 2 });
+    await game.save(save);
+  }
+  await using game = await GameServer.launch({ mission: "medsci1.mis", difficulty: "easy" });
+  assert.equal((await game.info()).player.difficulty, "easy");
+  await game.load(save);
+  assert.equal((await game.info()).player.difficulty, "impossible");
+});


### PR DESCRIPTION
Fresh campaigns can select Easy, Normal, Hard, or Impossible through `--difficulty` or the SDK launch option. The choice is private campaign state: saves and deck transitions retain it, loading a save overrides the launch choice, and the quest API rejects attempts to change it. Normal is the default.

Parses the authored 168-byte, six-column `DIFFPARAM` table with explicit retail indices (the four choices are 1–4; 0 and 5 are reserved). `/v1/info` exposes the campaign choice. Gameplay consumers and the new-game selector follow in the stack.

Validation: three parser/index tests; campaign serialization and invalid-value tests; all five SDK difficulty scenarios (four modes across save/load/transitions plus cross-campaign loading); 63 SDK unit tests; debug runtime build; formatting and diff checks. No visible behavior changes in this foundation layer.
