### PR TITLE
feat(difficulty): derive player pools from campaign parameters

### DIFF
--- a/dark/src/gamesys/difficulty.rs
+++ b/dark/src/gamesys/difficulty.rs
@@ -193,3 +193,72 @@ mod tests {
         assert!(serde_json::from_str::<Difficulty>("\"multiplayer\"").is_err());
     }
 }
+
+/// The first four STATPARAM fields, used when a DIFFPARAM coefficient is zero.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlayerPoolParams {
+    pub base_hp: i32,
+    pub hp_per_endurance: i32,
+    pub base_psi: i32,
+    pub psi_per_psionics: i32,
+}
+impl Default for PlayerPoolParams {
+    fn default() -> Self {
+        // Retail STATPARAM defaults, used only by synthetic/missing-data worlds.
+        Self {
+            base_hp: 30,
+            hp_per_endurance: 5,
+            base_psi: 20,
+            psi_per_psionics: 5,
+        }
+    }
+}
+impl PlayerPoolParams {
+    pub fn read<T: Read + Seek>(toc: &ChunkFileTableOfContents, reader: &mut T) -> Option<Self> {
+        let chunk = toc.get_chunk("STATPARAM".to_owned())?;
+        if chunk.length < 16 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset)).ok()?;
+        let mut values = [0; 4];
+        reader.read_i32_into::<LittleEndian>(&mut values).ok()?;
+        Some(Self {
+            base_hp: values[0],
+            hp_per_endurance: values[1],
+            base_psi: values[2],
+            psi_per_psionics: values[3],
+        })
+    }
+}
+
+#[cfg(test)]
+mod pool_param_tests {
+    use super::*;
+    #[test]
+    fn difficulty_pool_fallback_reads_statparam_header_not_hazard_floats() {
+        let mut bytes = vec![0; 424];
+        bytes[..4].copy_from_slice(&400_u32.to_le_bytes());
+        bytes[400..404].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[404..413].copy_from_slice(b"STATPARAM");
+        bytes[416..420].copy_from_slice(&280_u32.to_le_bytes());
+        bytes[420..424].copy_from_slice(&56_u32.to_le_bytes());
+        for (i, v) in [40_i32, 7, 12, 9].into_iter().enumerate() {
+            bytes[304 + 4 * i..308 + 4 * i].copy_from_slice(&v.to_le_bytes());
+        }
+        let mut reader = io::Cursor::new(bytes.clone());
+        let toc = crate::ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+        assert_eq!(
+            PlayerPoolParams::read(&toc, &mut reader),
+            Some(PlayerPoolParams {
+                base_hp: 40,
+                hp_per_endurance: 7,
+                base_psi: 12,
+                psi_per_psionics: 9,
+            })
+        );
+        bytes[420..424].copy_from_slice(&15_u32.to_le_bytes());
+        let mut reader = io::Cursor::new(bytes);
+        let toc = crate::ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+        assert!(PlayerPoolParams::read(&toc, &mut reader).is_none());
+    }
+}

--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -21,6 +21,7 @@ pub struct Gamesys {
     hrm_params: Option<HrmParams>,
     /// Skill-system tuning (`SKILLPARAM` file-var chunk).
     skill_params: Option<SkillParams>,
+    player_pool_params: Option<crate::gamesys::PlayerPoolParams>,
     hazard_params: Option<crate::gamesys::HazardParams>,
 }
 
@@ -75,6 +76,10 @@ impl Gamesys {
         self.hrm_params.as_ref()
     }
 
+    pub fn player_pool_params(&self) -> Option<&crate::gamesys::PlayerPoolParams> {
+        self.player_pool_params.as_ref()
+    }
+
     pub fn hazard_params(&self) -> Option<&crate::gamesys::HazardParams> {
         self.hazard_params.as_ref()
     }
@@ -108,6 +113,7 @@ pub fn read<T: io::Read + io::Seek>(
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
     let hrm_params = HrmParams::read(&table_of_contents, reader);
     let skill_params = SkillParams::read(&table_of_contents, reader);
+    let player_pool_params = crate::gamesys::PlayerPoolParams::read(&table_of_contents, reader);
     let hazard_params = crate::gamesys::HazardParams::read(&table_of_contents, reader);
 
     // Uncomment to output debug info for voices:
@@ -124,5 +130,6 @@ pub fn read<T: io::Read + io::Seek>(
         hrm_params,
         skill_params,
         hazard_params,
+        player_pool_params,
     }
 }

--- a/shock2vr/src/career.rs
+++ b/shock2vr/src/career.rs
@@ -9,10 +9,8 @@
 //! persisted quest bit so it survives every level transition, then it is applied
 //! to the player on each mission load.
 //!
-//! The per-career attribute table here is a faithful-in-spirit starting point,
-//! not the exact retail OS-unit numbers: it emphasises each branch (Marines are
-//! tanky, OSA are psionic) so the three careers arrive observably different.
-//! A full skill/stat/cyber-module system is deferred (issue #424).
+//! Career training grants character stats; player HP and psi pools are derived
+//! from those stats and the campaign difficulty (crate::difficulty).
 
 use dark::properties::QuestBitValue;
 
@@ -31,14 +29,9 @@ pub enum Career {
     Osa,
 }
 
-/// The starting attributes a career deploys with. Applied as absolute values
-/// (not deltas) so re-applying on every level load is idempotent.
+/// Career-specific starting equipment/powers; vitals follow character stats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CareerLoadout {
-    /// Current and maximum hit points on deployment.
-    pub max_hit_points: i32,
-    /// Current and maximum psi points on deployment.
-    pub max_psi_points: i32,
     /// An extra psi power the career starts trained in (beyond the default
     /// Cryokinesis), by template id. `None` for non-psi careers.
     pub extra_psi_power: Option<i32>,
@@ -89,23 +82,15 @@ impl Career {
     /// The career-appropriate starting attributes applied on deployment.
     pub fn loadout(&self) -> CareerLoadout {
         match self {
-            // Marines: front-line combat - tanky, minimal psi.
+            // Marines and Navy gain their stats through training tours.
             Career::Marine => CareerLoadout {
-                max_hit_points: 45,
-                max_psi_points: 20,
                 extra_psi_power: None,
             },
-            // Navy: technical - balanced (tech/repair skills are deferred).
             Career::Navy => CareerLoadout {
-                max_hit_points: 35,
-                max_psi_points: 35,
                 extra_psi_power: None,
             },
-            // OSA: psi operative - frail but psionically potent, deploys with an
-            // extra offensive power.
+            // OSA deploys with an extra offensive power.
             Career::Osa => CareerLoadout {
-                max_hit_points: 30,
-                max_psi_points: 60,
                 extra_psi_power: Some(PSIPULL_TEMPLATE_ID),
             },
         }
@@ -150,17 +135,9 @@ mod tests {
     }
 
     #[test]
-    fn careers_arrive_observably_different() {
+    fn osa_keeps_its_extra_starting_power() {
         let marine = Career::Marine.loadout();
-        let navy = Career::Navy.loadout();
         let osa = Career::Osa.loadout();
-
-        // Hit points and psi points differ across all three branches.
-        assert_ne!(marine.max_hit_points, navy.max_hit_points);
-        assert_ne!(navy.max_hit_points, osa.max_hit_points);
-        assert_ne!(marine.max_hit_points, osa.max_hit_points);
-        assert_ne!(marine.max_psi_points, navy.max_psi_points);
-        assert_ne!(navy.max_psi_points, osa.max_psi_points);
 
         // Only OSA deploys with an extra psi power.
         assert!(marine.extra_psi_power.is_none());

--- a/shock2vr/src/difficulty.rs
+++ b/shock2vr/src/difficulty.rs
@@ -1,0 +1,170 @@
+//! Authored campaign difficulty consumers. The campaign choice lives in QuestInfo.
+use crate::{mission::PlayerInfo, player_stats::PlayerStats, quest_info::QuestInfo};
+use dark::gamesys::{Difficulty, DifficultyParams, Gamesys, PlayerPoolParams};
+use shipyard::{Get, Unique, UniqueView, ViewMut, World};
+
+#[derive(Clone, Debug, Default, Unique)]
+pub struct GlobalDifficultyParams {
+    pub difficulty: Option<DifficultyParams>,
+    pub player_pools: PlayerPoolParams,
+}
+impl GlobalDifficultyParams {
+    pub fn from_gamesys(gamesys: &Gamesys) -> Self {
+        Self {
+            difficulty: gamesys.difficulty_params().cloned(),
+            player_pools: gamesys.player_pool_params().copied().unwrap_or_default(),
+        }
+    }
+    pub fn coefficients(&self, difficulty: Difficulty) -> PlayerPoolParams {
+        let Some(p) = &self.difficulty else {
+            return self.player_pools;
+        };
+        let i = difficulty.retail_index();
+        let fallback = |value, default| if value == 0 { default } else { value };
+        PlayerPoolParams {
+            base_hp: fallback(p.base_hp[i], self.player_pools.base_hp),
+            hp_per_endurance: fallback(p.hp_per_endurance[i], self.player_pools.hp_per_endurance),
+            base_psi: fallback(p.base_psi[i], self.player_pools.base_psi),
+            psi_per_psionics: fallback(p.psi_per_psionics[i], self.player_pools.psi_per_psionics),
+        }
+    }
+    pub fn limits(&self, difficulty: Difficulty, stats: &PlayerStats) -> (i32, i32) {
+        let p = self.coefficients(difficulty);
+        // The current sheet contains base stats; when temporary stat modifiers
+        // gain a consumer, only HP should use effective Endurance. Psi uses base PSI.
+        let tank = if stats.has_os_trait(crate::scripts::gui::TRAIT_TANK) {
+            crate::scripts::gui::TANK_HP_BONUS
+        } else {
+            0
+        };
+        let tier = stats.psi_tier.clamp(0, crate::player_stats::PSI_TIER_CAP);
+        let hp = p
+            .base_hp
+            .saturating_add(
+                p.hp_per_endurance
+                    .saturating_mul(stats.endurance.clamp(1, 8)),
+            )
+            .saturating_add(tank)
+            .max(1);
+        let psi = p
+            .base_psi
+            .saturating_add(
+                p.psi_per_psionics
+                    .saturating_mul(stats.psionic_ability.clamp(1, 8)),
+            )
+            .saturating_add(tier * (tier + 1))
+            .max(0);
+        (hp, psi)
+    }
+}
+
+/// Recompute after a stat/tier/trait change, preserving the deficit from the old
+/// maximum. `fill` is only for construction of a fresh player; saved vitals are
+/// restored afterwards. Repeating a recalculation with the same sheet is inert.
+pub fn refresh_player_pools(world: &World, fill: bool) {
+    let Ok(player) = world.borrow::<UniqueView<PlayerInfo>>() else {
+        return;
+    };
+    let Ok(quests) = world.borrow::<UniqueView<QuestInfo>>() else {
+        return;
+    };
+    let Ok(params) = world.borrow::<UniqueView<GlobalDifficultyParams>>() else {
+        return;
+    };
+    let (max_hp, max_psi) = params.limits(quests.difficulty(), quests.player_stats());
+    world.run(
+        |mut hp: ViewMut<dark::properties::PropHitPoints>,
+         mut maximum: ViewMut<dark::properties::PropMaxHitPoints>,
+         mut psi: ViewMut<dark::properties::PropPsiState>| {
+            if let (Ok(hp), Ok(maximum)) = (
+                (&mut hp).get(player.entity_id),
+                (&mut maximum).get(player.entity_id),
+            ) {
+                let old = maximum.hit_points.min(i32::MAX as u32) as i32;
+                hp.hit_points = shifted_pool(hp.hit_points, old, max_hp, fill, true);
+                maximum.hit_points = max_hp as u32;
+            }
+            if let Ok(psi) = (&mut psi).get(player.entity_id) {
+                psi.psi_points =
+                    shifted_pool(psi.psi_points, psi.max_psi_points, max_psi, fill, false);
+                psi.max_psi_points = max_psi;
+            }
+        },
+    );
+}
+fn shifted_pool(current: i32, old_max: i32, new_max: i32, fill: bool, health: bool) -> i32 {
+    if fill {
+        return new_max;
+    }
+    // An already-dead player must not be resurrected by a queued upgrade.
+    if health && current <= 0 {
+        return 0;
+    }
+    current
+        .saturating_add(new_max.saturating_sub(old_max))
+        .clamp(if health { 1 } else { 0 }, new_max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn retail() -> GlobalDifficultyParams {
+        GlobalDifficultyParams {
+            difficulty: Some(DifficultyParams {
+                trainer_multiplier: [1.0, 0.85, 1.0, 1.4, 1.8, 1.4],
+                base_hp: [30, 45, 30, 24, 7, 24],
+                hp_per_endurance: [5, 10, 5, 3, 3, 3],
+                base_psi: [5, 10, 5, 3, 1, 5],
+                psi_per_psionics: [10, 16, 10, 8, 5, 10],
+                loot_discard_threshold: [0, 0, 0, 30, 75, 0],
+                replicator_multiplier: [1.0, 0.85, 1.0, 1.25, 2.0, 1.0],
+            }),
+            ..Default::default()
+        }
+    }
+    #[test]
+    fn difficulty_pools_follow_stats_traits_and_unlocked_tiers() {
+        let params = retail();
+        let mut stats = PlayerStats::new();
+        for (d, expected) in
+            Difficulty::ALL
+                .into_iter()
+                .zip([(55, 26), (35, 15), (27, 11), (10, 6)])
+        {
+            assert_eq!(params.limits(d, &stats), expected);
+        }
+        stats.endurance = 3;
+        stats.psionic_ability = 2;
+        stats.psi_tier = 3;
+        stats.add_os_trait(crate::scripts::gui::TRAIT_TANK);
+        assert_eq!(params.limits(Difficulty::Impossible, &stats), (21, 23));
+    }
+    #[test]
+    fn difficulty_zero_coefficients_use_authored_statparam() {
+        let mut params = retail();
+        let p = params.difficulty.as_mut().unwrap();
+        p.base_hp[2] = 0;
+        p.hp_per_endurance[2] = 0;
+        p.base_psi[2] = 0;
+        p.psi_per_psionics[2] = 0;
+        params.player_pools = PlayerPoolParams {
+            base_hp: 40,
+            hp_per_endurance: 7,
+            base_psi: 12,
+            psi_per_psionics: 9,
+        };
+        assert_eq!(
+            params.limits(Difficulty::Normal, &PlayerStats::new()),
+            (47, 21)
+        );
+    }
+    #[test]
+    fn difficulty_recalculation_keeps_deficits_and_does_not_revive() {
+        assert_eq!(shifted_pool(25, 35, 40, false, true), 30);
+        assert_eq!(shifted_pool(30, 40, 40, false, true), 30);
+        assert_eq!(shifted_pool(0, 35, 40, false, true), 0);
+        assert_eq!(shifted_pool(1, 40, 10, false, true), 1);
+        assert_eq!(shifted_pool(2, 15, 6, false, false), 0);
+        assert_eq!(shifted_pool(2, 15, 6, true, false), 6);
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -21,6 +21,7 @@ pub mod damage_overlay;
 pub mod data_files;
 pub mod death_camera;
 pub mod dev_params;
+pub mod difficulty;
 mod flat_player_controller;
 pub mod free_camera;
 mod gui;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1726,60 +1726,6 @@ fn apply_comestible_use(
     ComestibleUseOutcome::Consumed
 }
 
-/// Raise only the live maximum HP pool. Buying Endurance is not healing: the
-/// original stat promises more maximum hit points, while Tank's separate O/S
-/// effect deliberately raises both current and maximum HP.
-fn increase_player_max_hit_points(world: &World, player: EntityId, amount: u32) -> bool {
-    let mut maximums = world
-        .borrow::<ViewMut<dark::properties::PropMaxHitPoints>>()
-        .unwrap();
-    if let Ok(maximum) = (&mut maximums).get(player) {
-        maximum.hit_points = maximum.hit_points.saturating_add(amount);
-        true
-    } else {
-        false
-    }
-}
-
-#[cfg(test)]
-mod endurance_upgrade_tests {
-    use super::*;
-
-    #[test]
-    fn endurance_raises_maximum_hp_without_healing() {
-        let mut world = World::new();
-        let player = world.add_entity((
-            PropHitPoints { hit_points: 25 },
-            dark::properties::PropMaxHitPoints { hit_points: 30 },
-        ));
-
-        assert!(increase_player_max_hit_points(
-            &world,
-            player,
-            crate::scripts::gui::ENDURANCE_HP_PER_LEVEL,
-        ));
-        assert_eq!(
-            world
-                .borrow::<View<dark::properties::PropMaxHitPoints>>()
-                .unwrap()
-                .get(player)
-                .unwrap()
-                .hit_points,
-            35
-        );
-        assert_eq!(
-            world
-                .borrow::<View<PropHitPoints>>()
-                .unwrap()
-                .get(player)
-                .unwrap()
-                .hit_points,
-            25,
-            "an Endurance upgrade must not double as a heal"
-        );
-    }
-}
-
 /// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
 /// used to pose the flat melee viewmodel in its ready stance.
 const MELEE_IDLE_CLIP: &str = "ph212203";
@@ -2495,11 +2441,9 @@ impl MissionCore {
         // Create player
         let player_entity = world.add_entity((PropLocalPlayer {}, RuntimePropDoNotSerialize {}));
 
-        // Seed the player's psi pool and hit points from `The Player`
-        // template, where the gamesys authors the starting/maximum values
-        // (P$PsiState, P$HitPoints/P$MAX_HP). The HP pool is what psi
-        // burnout (and later, real damage handling) drains; nothing yet
-        // reacts to it reaching zero.
+        // Instantiate the player's pool components from The Player. Once the
+        // character sheet is installed below, authored difficulty/stat parameters
+        // derive the maxima. Save/transition restoration then replaces current pools.
         {
             use crate::scripts::script_util::hydrate_template_component;
             if let Some(psi_state) = hydrate_template_component::<dark::properties::PropPsiState>(
@@ -2610,58 +2554,12 @@ impl MissionCore {
             mission.starts_with("debug_"),
         );
 
-        // Apply the career (Marine/Navy/OSA) chosen at the station recruit deck.
-        // The choice is persisted as a quest bit, so it re-applies on every
-        // deployment; with no career selected the player template defaults
-        // (30 HP, 40/50 psi) stand. Absolute values keep re-application
-        // idempotent across level loads. These are the deliberate first-career
-        // and legacy-save defaults; ordinary transitions and current-format
-        // saves restore their exact persisted pools after mission construction.
+        // Career powers remain authored separately; HP/psi maxima are derived
+        // from the character sheet and campaign difficulty below.
         if let Some(career) = crate::career::Career::from_quest_info(&quest_info) {
-            let loadout = career.loadout();
-            world.run(
-                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
-                 mut v_max_hp: ViewMut<dark::properties::PropMaxHitPoints>,
-                 mut v_psi: ViewMut<dark::properties::PropPsiState>| {
-                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
-                        hp.hit_points = loadout.max_hit_points;
-                    }
-                    if let Ok(max_hp) = (&mut v_max_hp).get(player_entity) {
-                        max_hp.hit_points = loadout.max_hit_points as u32;
-                    }
-                    if let Ok(psi) = (&mut v_psi).get(player_entity) {
-                        psi.psi_points = loadout.max_psi_points;
-                        psi.max_psi_points = loadout.max_psi_points;
-                    }
-                },
-            );
-            if let Some(power) = loadout.extra_psi_power {
+            if let Some(power) = career.loadout().extra_psi_power {
                 known_powers.0.insert(power);
             }
-            info!("Applied {:?} career loadout to player", career);
-        }
-
-        // O/S trait bonuses re-derive on every load, like the career loadout
-        // (the player entity is rebuilt each mission load; the traits
-        // themselves persist on the character sheet in QuestInfo). Applied
-        // after the career block so Tank adds on top of the career pool.
-        if quest_info
-            .player_stats()
-            .has_os_trait(crate::scripts::gui::TRAIT_TANK)
-        {
-            use crate::scripts::gui::TANK_HP_BONUS;
-            world.run(
-                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
-                 mut v_max_hp: ViewMut<dark::properties::PropMaxHitPoints>| {
-                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
-                        hp.hit_points += TANK_HP_BONUS;
-                    }
-                    if let Ok(max_hp) = (&mut v_max_hp).get(player_entity) {
-                        max_hp.hit_points += TANK_HP_BONUS as u32;
-                    }
-                },
-            );
-            info!("Applied Tank O/S trait: +{} max hit points", TANK_HP_BONUS);
         }
 
         let default_browsed_tier = psi_powers
@@ -2995,6 +2893,10 @@ impl MissionCore {
         world.add_unique(PlayerLifeState::Alive);
 
         world.add_unique(quest_info);
+        world.add_unique(crate::difficulty::GlobalDifficultyParams::from_gamesys(
+            game_entity_info,
+        ));
+        crate::difficulty::refresh_player_pools(&world, true);
         world.add_unique(crate::haptics::HapticFeedback::default());
 
         // Current saves record the width that encoded their backpack link
@@ -10023,6 +9925,7 @@ impl MissionCore {
                     drop(quests);
                     if applied {
                         self.resize_player_backpack(old_width, new_width);
+                        crate::difficulty::refresh_player_pools(&self.world, false);
                     }
                 }
 
@@ -10088,13 +9991,7 @@ impl MissionCore {
                         };
                         if purchased {
                             self.resize_player_backpack(old_width, new_width);
-                        }
-                        if purchased && endurance_target {
-                            increase_player_max_hit_points(
-                                &self.world,
-                                player_entity,
-                                crate::scripts::gui::ENDURANCE_HP_PER_LEVEL,
-                            );
+                            crate::difficulty::refresh_player_pools(&self.world, false);
                         }
                     } else {
                         warn!("TrainerPurchase dropped: gamesys has no cost tables");
@@ -10159,8 +10056,8 @@ impl MissionCore {
 
                 Effect::AcquireOsTrait { trait_id, machine } => {
                     use crate::scripts::gui::{
-                        NATURALLY_ABLE_MODULES, TANK_HP_BONUS, TRAIT_NATURALLY_ABLE, TRAIT_TANK,
-                        live_effect_note, trait_name, used_bit_name,
+                        NATURALLY_ABLE_MODULES, TRAIT_NATURALLY_ABLE, live_effect_note, trait_name,
+                        used_bit_name,
                     };
                     // The machine's stable mission object id keys its used bit.
                     let machine_template_id = self
@@ -10204,35 +10101,7 @@ impl MissionCore {
 
                     if acquired {
                         self.resize_player_backpack(old_width, new_width);
-                        if trait_id == TRAIT_TANK {
-                            // Tank (Trait8): the original raises the ceiling
-                            // AND current HP by the bonus. Loads first re-derive
-                            // the trait-adjusted default, so this live grant
-                            // cannot double-apply.
-                            let player_entity = self
-                                .world
-                                .borrow::<UniqueView<PlayerInfo>>()
-                                .unwrap()
-                                .entity_id;
-                            self.world.run(
-                                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
-                                 mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
-                                    let new_max = (&mut v_max)
-                                        .get(player_entity)
-                                        .map(|max| {
-                                            max.hit_points += TANK_HP_BONUS as u32;
-                                            max.hit_points
-                                        })
-                                        .ok();
-                                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
-                                        hp.hit_points += TANK_HP_BONUS;
-                                        if let Some(new_max) = new_max {
-                                            hp.hit_points = hp.hit_points.min(new_max as i32);
-                                        }
-                                    }
-                                },
-                            );
-                        }
+                        crate::difficulty::refresh_player_pools(&self.world, false);
                         info!(
                             "O/S trait acquired: {} ({}){}",
                             trait_id,
@@ -15040,6 +14909,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         let result = stats.clone();
         drop(quests);
         self.resize_player_backpack(old_backpack_width, new_backpack_width);
+        crate::difficulty::refresh_player_pools(&self.world, false);
         info!("Debug provisioning set player stats: {:?}", result);
         Ok(result)
     }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -229,6 +229,7 @@ pub fn create_debug_scene(
                     .unwrap();
                 *quests = quests.clone().for_debug_difficulty(options.difficulty);
             }
+            crate::difficulty::refresh_player_pools(scene.world(), true);
             scene
         })
 }

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -56,12 +56,6 @@ pub enum TrainerMode {
     Psi,
 }
 
-/// Normal difficulty grants five maximum hit points per Endurance level. The
-/// original manual documents the stat as raising maximum HP; the retail Normal
-/// table is `30 + 5 * END`. shock2quest has no difficulty setting yet, matching
-/// the Normal-only trainer prices above.
-pub const ENDURANCE_HP_PER_LEVEL: u32 = 5;
-
 /// Whether a stat has a real gameplay consumer and is therefore safe to sell.
 /// Keep this gate shared by display, immediate feedback, and authoritative
 /// effect handling so a future caller cannot bypass the module-loss guard.
@@ -414,16 +408,23 @@ impl Gui<TrainerGuiState, TrainerGuiMsg> for TrainerGui {
                 },
                 Effect::NoEffect,
             ),
-            Some(cost) => (
-                TrainerGuiState {
-                    message: Some(if matches!(target, TrainerTarget::Stat(Stat::Endurance)) {
-                        format!("Max HP +{} (-{} cm)", ENDURANCE_HP_PER_LEVEL, cost)
-                    } else {
-                        format!("Upgrade complete (-{} cm)", cost)
-                    }),
-                },
-                Effect::TrainerPurchase { target: *target },
-            ),
+            Some(cost) => {
+                let message = if matches!(target, TrainerTarget::Stat(Stat::Endurance)) {
+                    let hp_bonus = world
+                        .borrow::<UniqueView<crate::difficulty::GlobalDifficultyParams>>()
+                        .map(|p| p.coefficients(quests.difficulty()).hp_per_endurance)
+                        .unwrap_or(5);
+                    format!("Max HP +{} (-{} cm)", hp_bonus, cost)
+                } else {
+                    format!("Upgrade complete (-{} cm)", cost)
+                };
+                (
+                    TrainerGuiState {
+                        message: Some(message),
+                    },
+                    Effect::TrainerPurchase { target: *target },
+                )
+            }
         }
     }
 }

--- a/tools/shock2-sdk/test/difficulty.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty.e2e.test.ts
@@ -9,7 +9,17 @@ for (const difficulty of ["easy", "normal", "hard", "impossible"] as const) {
     { skip: !enabled, timeout: 180_000 }, async () => {
       await using game = await GameServer.launch({ mission: "medsci1.mis", difficulty });
       await game.step({ frames: 2 });
-      assert.equal((await game.info()).player.difficulty, difficulty);
+      const initial = (await game.info()).player;
+      assert.equal(initial.difficulty, difficulty);
+      const pools = { easy: [55, 26], normal: [35, 15], hard: [27, 11], impossible: [10, 6] }[difficulty];
+      assert.equal(initial.hit_points, pools[0]);
+      assert.equal(initial.max_hit_points, pools[0]);
+      assert.equal(initial.psi_points, pools[1]);
+      assert.equal(initial.max_psi_points, pools[1]);
+      await game.entities.sendMessage(initial.entity_id!, { type: "Damage", amount: 2 });
+      await game.step({ frames: 1 });
+      const wounded = (await game.info()).player.hit_points;
+      assert.equal(wounded, pools[0] - 2);
       await assert.rejects(game.quests.set("Difficulty", "complete"), /fixed/);
       const save = `difficulty-${difficulty}-${Date.now()}`;
       await game.save(save);
@@ -18,6 +28,7 @@ for (const difficulty of ["easy", "normal", "hard", "impossible"] as const) {
       await game.load(save);
       assert.equal((await game.info()).player.difficulty, difficulty);
       assert.equal((await game.info()).mission, "medsci1.mis");
+      assert.equal((await game.info()).player.hit_points, wounded, "load does not refill the pool");
     });
 }
 
@@ -34,4 +45,23 @@ test("difficulty: loading another campaign overrides the launch choice", {
   assert.equal((await game.info()).player.difficulty, "easy");
   await game.load(save);
   assert.equal((await game.info()).player.difficulty, "impossible");
+});
+
+test("difficulty: stat and psi-tier upgrades adjust current pools by the maximum delta", {
+  skip: !enabled, timeout: 120_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", difficulty: "normal" });
+  await game.step({ frames: 2 });
+  await game.entities.sendMessage((await game.info()).player.entity_id!, { type: "Damage", amount: 2 });
+  await game.step({ frames: 1 });
+  await game.player.setStats({ endurance: 2, psionic_ability: 2, psi_tier: 2 });
+  await game.step({ frames: 1 });
+  const player = (await game.info()).player;
+  assert.equal(player.max_hit_points, 40);
+  assert.equal(player.hit_points, 38);
+  assert.equal(player.max_psi_points, 31);
+  assert.equal(player.psi_points, 31);
+  await game.player.setStats({ cyber_modules: 100 });
+  await game.step({ frames: 1 });
+  assert.equal((await game.info()).player.hit_points, 38, "unrelated provisioning cannot heal");
 });

--- a/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
@@ -12,17 +12,9 @@ import { stepPastCutscenes } from "./helpers/cutscenes.js";
 //
 // The career is chosen by *playing the recruitment intro* (earth.mis): three
 // ChooseService markers there carry a P$Service value (0=Marine, 1=Navy, 2=OSA)
-// and a transition to the recruit station. TurnOn'ing one (as its tripwire does
-// when the player walks through that career door) persists the chosen career as
-// a quest bit and ships the player to the station; the career loadout is then
-// applied to the player on every subsequent mission load. Marines arrive tanky
-// (45 HP / 20 psi), Navy balanced (35 / 35), OSA psionic (30 / 60).
-//
-// Negative-first: with the loadout neutralized (or the career never registered),
-// all three branches deploy with the identical default player-template
-// attributes (30 HP, 40/50 psi) and the "should differ" asserts fail. The test
-// also guards that selection is the *station flow*, not the removed debug
-// SelectCareer* input actions.
+// and a transition to the recruit station. Career selection alone does not
+// grant different health/psi pools: those follow difficulty and earned stats.
+// Training rewards change the pools when the corresponding stats are awarded.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // The ChooseService career markers in earth.mis, keyed by their P$Service value,
@@ -104,28 +96,16 @@ async function playCareer(
 }
 
 test(
-  "career: branches chosen at the recruitment intro deploy with distinct attributes",
+  "career: choosing a branch alone preserves stat-derived player pools",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     const marine = await playCareer("marine");
     const navy = await playCareer("navy");
     const osa = await playCareer("osa");
 
-    // Hit points differ across all three branches (Marines tankiest, OSA least).
-    assert.notEqual(marine.maxHp, navy.maxHp, "Marine vs Navy HP should differ");
-    assert.notEqual(navy.maxHp, osa.maxHp, "Navy vs OSA HP should differ");
-    assert.notEqual(marine.maxHp, osa.maxHp, "Marine vs OSA HP should differ");
-    assert.ok(
-      marine.maxHp > osa.maxHp,
-      `Marines should be tankier than OSA (got ${marine.maxHp} vs ${osa.maxHp})`,
-    );
-
-    // Psi points differ too (OSA the strongest psion, Marines the weakest).
-    assert.notEqual(marine.maxPsi, navy.maxPsi, "Marine vs Navy psi should differ");
-    assert.notEqual(navy.maxPsi, osa.maxPsi, "Navy vs OSA psi should differ");
-    assert.ok(
-      osa.maxPsi > marine.maxPsi,
-      `OSA should out-psi Marines (got ${osa.maxPsi} vs ${marine.maxPsi})`,
-    );
+    for (const pools of [marine, navy, osa]) {
+      assert.deepEqual(pools, { maxHp: 35, maxPsi: 15 },
+        "Normal starting stats determine pools independently of career name");
+    }
   },
 );

--- a/tools/shock2-sdk/test/trainer.e2e.test.ts
+++ b/tools/shock2-sdk/test/trainer.e2e.test.ts
@@ -171,7 +171,7 @@ test(
     }
     const afterPurchases = (await game.info()).player;
     assert.equal(afterPurchases.max_hit_points, baseMaxHp + 15, "three levels grant +15 max HP");
-    assert.equal(afterPurchases.hit_points, beforePlayer.hit_points, "Endurance does not heal");
+    assert.equal(afterPurchases.hit_points, beforePlayer.hit_points! + 15, "Endurance preserves the health deficit");
     await game.screenshot("trainer-after-endurance-4.png");
 
     // --- Persistence: save/load, then a level transition. ---


### PR DESCRIPTION
Player health and psi pools now use the campaign's DIFFPARAM coefficients and earned character stats. At starting stats, Easy/Normal/Hard/Impossible start at 55/35/27/10 HP and 26/15/11/6 psi. Career selection no longer substitutes invented fixed pool values.

STATPARAM supplies the reference fallback for zero or absent coefficients. Tank adds five HP; learned psi tiers each contribute their tier bonus. Training rewards, purchases and debug stat provisioning recompute maxima and shift current values by the change, preserving existing damage. Fresh players start full; saved and transitioning players retain their saved vitals. Difficulty remains fixed for the campaign.

Validation: parser and pool arithmetic unit tests; six SDK runtime scenarios covering all four modes, save/load, deck transitions, cross-campaign loads and stat/tier upgrades; existing trainer purchase/persistence scenario. Flat and VR before/after visual evidence follows below.

## Visual verification

The same fresh MedSci1 sequence applies 5 HP of damage, waits 60 fixed simulation frames for the damage overlay to clear, then captures a small head pan. Both settings previously left 25/30 HP and 40/50 psi. This change leaves Normal at 30/35 HP and 15/15 psi, and Impossible at 5/10 HP and 6/6 psi. The game readouts show percentages; captions report the corresponding `/v1/info` pools. Each comparison places before on the left, after on the right, Normal above Impossible.

### Flatscreen

![Difficulty pool comparison in flatscreen](https://gist.githubusercontent.com/tommy-xr/712c9dcf0ddffe9c533414e239f886a4/raw/pr2-pools-flat.gif)

![Before and after difficulty pools in flatscreen](https://gist.githubusercontent.com/tommy-xr/712c9dcf0ddffe9c533414e239f886a4/raw/pr2-pools-flat.png)

### VR

![Difficulty pool comparison on both VR wrists](https://gist.githubusercontent.com/tommy-xr/712c9dcf0ddffe9c533414e239f886a4/raw/pr2-pools-vr.gif)

![Before and after difficulty pools on both VR wrists](https://gist.githubusercontent.com/tommy-xr/712c9dcf0ddffe9c533414e239f886a4/raw/pr2-pools-vr.png)

<sub>Captured headlessly from immutable before/after binaries with identical `/v1/step` and `/v1/screenshot` requests. Wrist poses are fixed to expose the shared readouts; both presentations were visually inspected.</sub>
