### PR TITLE
feat(ai): implement swarmer flight, backoff and proximity damage

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -8,6 +8,7 @@ mod prop_ai_device;
 mod prop_ai_grub;
 mod prop_ai_hearing;
 mod prop_ai_mode;
+mod prop_ai_swarm;
 mod prop_ambient_hacked;
 mod prop_anim_light;
 mod prop_anim_tex;
@@ -58,6 +59,7 @@ pub use prop_ai_device::*;
 pub use prop_ai_grub::*;
 pub use prop_ai_hearing::*;
 pub use prop_ai_mode::*;
+pub use prop_ai_swarm::*;
 pub use prop_ambient_hacked::*;
 pub use prop_anim_light::*;
 pub use prop_anim_tex::*;
@@ -2224,6 +2226,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$AI_MoveSp",
             PropAIMoveSpeed::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_Swarm",
+            PropAISwarm::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_MoveZO",
+            PropAIMoveZOffset::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_ai_swarm.rs
+++ b/dark/src/properties/prop_ai_swarm.rs
@@ -1,0 +1,50 @@
+use crate::{SCALE_FACTOR, ss2_common::read_single};
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+use std::io::{Read, Seek};
+
+#[derive(Clone, Debug, Component, Serialize, Deserialize)]
+pub struct PropAISwarm {
+    pub close_distance: f32,
+    pub backoff_distance: f32,
+}
+impl Default for PropAISwarm {
+    fn default() -> Self {
+        Self {
+            close_distance: 1.0 / SCALE_FACTOR,
+            backoff_distance: 10.0 / SCALE_FACTOR,
+        }
+    }
+}
+impl PropAISwarm {
+    pub fn read<T: Read + Seek>(reader: &mut T, _: u32) -> Self {
+        Self {
+            close_distance: read_single(reader) / SCALE_FACTOR,
+            backoff_distance: read_single(reader) / SCALE_FACTOR,
+        }
+    }
+}
+#[derive(Clone, Debug, Component, Serialize, Deserialize)]
+pub struct PropAIMoveZOffset(pub f32);
+impl PropAIMoveZOffset {
+    pub fn read<T: Read + Seek>(reader: &mut T, _: u32) -> Self {
+        Self(read_single(reader) / SCALE_FACTOR)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn swarm_distances_and_hover_offset_convert_dark_units() {
+        let mut bytes =
+            std::io::Cursor::new([1.0f32.to_le_bytes(), 10.0f32.to_le_bytes()].concat());
+        let prop = PropAISwarm::read(&mut bytes, 8);
+        assert_eq!(prop.close_distance, 0.4);
+        assert_eq!(prop.backoff_distance, 4.0);
+        assert_eq!(
+            PropAIMoveZOffset::read(&mut std::io::Cursor::new(3.0f32.to_le_bytes()), 4).0,
+            1.2
+        );
+    }
+}

--- a/projects/swarmer-ai.md
+++ b/projects/swarmer-ai.md
@@ -1,0 +1,65 @@
+# Swarmer particle-cloud AI
+
+This layer builds on GrubAI's shared awareness and BaseMonster save envelope.
+`SwarmerAI` is another sibling of `AnimatedMonsterAI`: it drives the position of
+the existing authored particle group, not skeletal clips or individual bug bodies.
+
+## Original data and behavior
+
+The shipped Swarm (-183) has 36 HP, zero gravity, a zero-radius physical point,
+70 particles using the `bug` model, and an Anti-Human radius stimulus. Its parsed
+movement speed is 1.0 (the move enactor applies Dark's 7.5 multiplier) and its
+`AI_MoveZO` hover offset is 2.0 world units. `AI_Swarm` supplies close/backoff
+ranges when authored; the original defaults are one and ten Dark feet.
+
+The original `cAISwarmer` adds a four-second sine wave with half a Dark foot of
+amplitude to the ground offset. Its combat ability closes on the target, then
+chooses a clear retreat direction. The separate `Swarm` object script slays it
+after twenty seconds. These are separate responsibilities here too.
+
+## Implementation
+
+- `MobileAwareness` handles sight, noise, alertness caps and target memory.
+- The existing chase/wander/fixed-point path followers supply horizontal
+  navigation. Real navigation failures never become direct wall-crossing chase;
+  scenes without navigation may steer directly toward a visible target.
+- The hover motor tracks floor height and sweeps a finite core through the
+  intended flight volume. Nearby headings allow local avoidance, and Rapier
+  handles the remaining physical contacts. It does not open doors.
+- The particle emitter moves with the cloud; particle animation is unchanged.
+- Radius stimuli use the existing receptron, falloff and obstruction handling
+  without blast force. The effect now carries its source identity so its own
+  body cannot block the exposure ray. Existing ambient radiation keeps its
+  previous source-less behavior.
+- The AI snapshot preserves bob phase, retreat destination, action budget,
+  awareness and pulse timing. Paths are recomputed on loading. The object
+  script preserves its remaining lifetime and sends Slay once at expiry.
+  Stasis pauses flight and damage through BaseMonster; the independent lifetime
+  timer continues, like the original script timer.
+
+## Explicit approximations
+
+The authored zero-radius body is unsuitable as a stable, aimable Rapier body.
+A radius-.3 core represents the cloud; individual visual bugs have no hitboxes.
+The close threshold has a 1.0-unit minimum to account for the core and player
+collision volumes. The action retry budget is a fixed four seconds within the
+original three-to-five-second range. Proximity damage pulses every .5 seconds;
+the generic Dark stimulus-source timing records are not implemented here.
+Navigation remains ground routes plus hover, rather than a new volumetric flight
+navigation system. These choices are local to the swarmer controller.
+
+## Verification
+
+- Unit checks cover authored distance conversion, hover period/amplitude,
+  saved retreat/pulse state, wall/ceiling clearance and lifetime expiry/restore.
+- `swarmer-ai.e2e.test.ts` checks natural hatch, hover/pursuit/backoff, player
+  damage, expiry, and the real rec1 pod's save/load lifetime.
+- Visual capture uses the debug_annelid station and rec1 swarmer pod264, with
+  before/after sequences and both flat and VR presentations.
+
+## References
+
+- [Original swarmer behavior](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/SHOCK/SHKAISWM.CPP)
+- [Original close/backoff combat](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/SHOCK/SHKAISWA.CPP)
+- [Original swarm property defaults](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/SHOCK/SHKAIPR.CPP)
+- [Telliamed's Swarm script reference](https://thiefmissions.com/telliamed/allscripts.html)

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1214,6 +1214,36 @@ fn create_physics_representation_with_options(
         }
     }
 
+    // Retail swarms author a zero-radius point body and render a particle
+    // cloud. Give Rapier a finite core for collision/aiming, before inherited
+    // FrobInfo can turn the cloud into a stationary fixture.
+    if world
+        .borrow::<View<PropAI>>()
+        .unwrap()
+        .get(entity_id)
+        .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("swarmer"))
+        && !launched_object_is_immobile
+    {
+        if let Ok(pos) = v_pos.get(entity_id) {
+            let body = physics.add_dynamic(
+                entity_id,
+                pos.position,
+                pos.rotation,
+                vec3(0.0, 0.0, 0.0),
+                PhysicsShape::Sphere(crate::scripts::ai::SWARM_CORE_RADIUS),
+                CollisionGroup::actor(),
+                false,
+                DynamicPhysicsOptions {
+                    gravity_scale: 0.0,
+                    restitution: 0.0,
+                    ..dynamics_options
+                },
+            );
+            physics.set_enabled_rotations(entity_id, false, false, false);
+            return Some(body);
+        }
+    }
+
     // Dark's Tweq emitter hands the fresh object to launchProjectile. Preserve
     // that explicit creation mode here: frobbable emitted objects (Ops4's Grub
     // is one) would otherwise take the selectable-fixture branch below and

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5744,7 +5744,9 @@ impl MissionCore {
                     .borrow::<View<dark::properties::PropAI>>()
                     .unwrap()
                     .get(*id)
-                    .is_ok_and(|ai| ai.0.eq_ignore_ascii_case("grub"));
+                    .is_ok_and(|ai| {
+                        matches!(ai.0.to_ascii_lowercase().as_str(), "grub" | "swarmer")
+                    });
                 if !holds_terminal_death_pose && !launched_with_no_root_motion && !physics_driven_ai
                 {
                     self.physics.set_velocity(*id, scaled);
@@ -7747,12 +7749,19 @@ impl MissionCore {
                 }
 
                 Effect::RadiusStim {
+                    source_entity_id,
                     center,
                     radius,
                     intensity,
                     stim_template_id,
                 } => {
-                    self.apply_radius_stimulus(None, center, radius, intensity, stim_template_id);
+                    self.apply_radius_stimulus(
+                        source_entity_id,
+                        center,
+                        radius,
+                        intensity,
+                        stim_template_id,
+                    );
                 }
 
                 Effect::RaiseNoise { origin, radius } => {

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -88,14 +88,12 @@ pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
 }
 
 fn object_actor_radius(world: &World, entity: EntityId) -> Option<f32> {
-    if !world
-        .borrow::<View<dark::properties::PropAI>>()
-        .ok()?
-        .get(entity)
-        .ok()?
-        .0
-        .eq_ignore_ascii_case("grub")
-    {
+    let ai = world.borrow::<View<dark::properties::PropAI>>().ok()?;
+    let ai = &ai.get(entity).ok()?.0;
+    if ai.eq_ignore_ascii_case("swarmer") {
+        return Some(super::SWARM_CORE_RADIUS);
+    }
+    if !ai.eq_ignore_ascii_case("grub") {
         return None;
     }
     let dimensions = world.borrow::<View<PropPhysDimensions>>().ok()?;

--- a/shock2vr/src/scripts/ai/mod.rs
+++ b/shock2vr/src/scripts/ai/mod.rs
@@ -17,3 +17,6 @@ pub use grub_ai::*;
 pub use turret_ai::*;
 
 use super::{Effect, Message, MessagePayload, Script};
+
+mod swarmer_ai;
+pub use swarmer_ai::{SWARM_CORE_RADIUS, SwarmerAI};

--- a/shock2vr/src/scripts/ai/swarmer_ai.rs
+++ b/shock2vr/src/scripts/ai/swarmer_ai.rs
@@ -1,0 +1,444 @@
+//! Particle-cloud AI. Ground navigation supplies horizontal routes; a separate
+//! motor follows the authored hover height and sweeps the cloud's solid core.
+use super::{
+    ai_util,
+    mobile_awareness::MobileAwareness,
+    steering::{PathFollowSteeringStrategy, SteeringStrategy},
+};
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    scripts::{
+        AIPropertyUpdate, Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState,
+        ScriptStateError,
+    },
+    time::Time,
+};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation3, Vector3, Zero, vec3};
+use dark::{
+    SCALE_FACTOR,
+    properties::{
+        AIAlertLevel, Link, PropAIMoveSpeed, PropAIMoveZOffset, PropAISwarm, StimPropagator,
+    },
+};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+/// Retail authors a point collider. A small finite core keeps the cloud
+/// shootable and gives Rapier a stable body without making every bug solid.
+pub const SWARM_CORE_RADIUS: f32 = 0.3;
+const KEY: &str = "shock2vr.swarmer_ai";
+const PULSE_SECONDS: f32 = 0.5;
+
+#[derive(Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+enum Mode {
+    #[default]
+    Close,
+    BackOff,
+}
+#[derive(Default, Clone, Serialize, Deserialize)]
+struct SwarmerState {
+    awareness: MobileAwareness,
+    mode: Mode,
+    retreat: Option<Vector3<f32>>,
+    retry_remaining: f32,
+    bob_phase: f32,
+    pulse_remaining: f32,
+    dead: bool,
+}
+pub struct SwarmerAI {
+    state: SwarmerState,
+    chase: PathFollowSteeringStrategy,
+    wander: PathFollowSteeringStrategy,
+    retreat_route: Option<PathFollowSteeringStrategy>,
+}
+impl SwarmerAI {
+    pub fn new() -> Self {
+        Self {
+            state: SwarmerState::default(),
+            chase: PathFollowSteeringStrategy::chase_player(),
+            wander: PathFollowSteeringStrategy::wander(3.0),
+            retreat_route: None,
+        }
+    }
+    fn die(&mut self, entity_id: EntityId) -> Effect {
+        if self.state.dead {
+            return Effect::NoEffect;
+        }
+        self.state.dead = true;
+        Effect::SlayEntity { entity_id }
+    }
+}
+
+fn floor_height(physics: &PhysicsWorld, entity: EntityId, position: Vector3<f32>) -> Option<f32> {
+    physics
+        .ray_cast2_as_actor(
+            Point3::from_vec(position),
+            -Vector3::unit_y(),
+            12.0,
+            InternalCollisionGroups::WORLD,
+            Some(entity),
+            true,
+        )
+        .filter(|hit| hit.hit_normal.y > 0.55)
+        .map(|hit| hit.hit_point.y)
+}
+
+/// Original cAISwarmer adds half a Dark foot on a four-second sine wave.
+fn hover_height(base: f32, phase: f32) -> f32 {
+    base + (phase * std::f32::consts::TAU / 4.0).sin() * (0.5 / SCALE_FACTOR)
+}
+
+fn clearance(
+    physics: &PhysicsWorld,
+    entity: EntityId,
+    position: Vector3<f32>,
+    direction: Vector3<f32>,
+    distance: f32,
+) -> f32 {
+    physics.projectile_spawn_distance(
+        Point3::from_vec(position),
+        direction,
+        distance,
+        SWARM_CORE_RADIUS,
+        &|other| other != entity,
+    )
+}
+
+/// Probe the intended flight volume, including upward/downward motion. If a
+/// wall blocks it, choose a nearby heading that still advances toward the goal.
+fn flight_velocity(
+    physics: &PhysicsWorld,
+    entity: EntityId,
+    position: Vector3<f32>,
+    desired: Vector3<f32>,
+    dt: f32,
+) -> Vector3<f32> {
+    let speed = desired.magnitude();
+    if speed < 0.001 {
+        return Vector3::zero();
+    }
+    let probe = (speed * 0.25).max(SWARM_CORE_RADIUS * 2.0);
+    let direction = desired / speed;
+    let mut best = Vector3::zero();
+    let mut best_score = 0.0;
+    for angle in [0.0, 35.0, -35.0, 70.0, -70.0, 90.0, -90.0] {
+        let candidate = Quaternion::from_angle_y(Deg(angle)) * direction;
+        let room = (clearance(physics, entity, position, candidate, probe) - 0.02).max(0.0);
+        let allowed_speed = speed.min(room / dt.max(0.001)).min(speed * room / probe);
+        let score = allowed_speed * candidate.dot(direction).max(0.05);
+        if score > best_score {
+            best_score = score;
+            best = candidate * allowed_speed;
+        }
+    }
+    best
+}
+
+fn backoff_point(
+    world: &World,
+    physics: &PhysicsWorld,
+    entity: EntityId,
+    position: Vector3<f32>,
+    distance: f32,
+) -> Option<Vector3<f32>> {
+    use rand::Rng;
+    let first = rand::thread_rng().gen_range(0.0..360.0);
+    for i in 0..8 {
+        let direction = Quaternion::from_angle_y(Deg(first + i as f32 * 45.0)) * Vector3::unit_z();
+        if clearance(physics, entity, position, direction, distance) < distance - 0.05 {
+            continue;
+        }
+        let target = position + direction * distance;
+        if floor_height(physics, entity, target).is_none() {
+            continue;
+        }
+        let on_nav = world
+            .borrow::<UniqueView<crate::mission::GlobalPathfinding>>()
+            .ok()
+            .is_none_or(|nav| {
+                nav.0
+                    .as_ref()
+                    .is_none_or(|nav| nav.cell_from_position(target).is_some())
+            });
+        if on_nav {
+            return Some(target);
+        }
+    }
+    None
+}
+
+impl Script for SwarmerAI {
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(KEY)
+    }
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, &self.state, KEY)
+    }
+    fn restore_state(
+        &mut self,
+        saved: &ScriptState,
+        _: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        self.state = saved.decode(1, KEY)?;
+        self.retreat_route = self.state.retreat.map(PathFollowSteeringStrategy::to_point);
+        Ok(())
+    }
+    fn initialize(&mut self, entity: EntityId, world: &World) -> Effect {
+        self.state.awareness = MobileAwareness::from_world(world, entity);
+        Effect::NoEffect
+    }
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if ai_util::is_killed(entity_id, world) {
+            return self.die(entity_id);
+        }
+        if self.state.dead {
+            return Effect::NoEffect;
+        }
+        let dt = time.elapsed.as_secs_f32();
+        if dt <= 0.0 {
+            return Effect::NoEffect;
+        }
+        self.state.bob_phase = (self.state.bob_phase + dt) % 4.0;
+        self.state.retry_remaining = (self.state.retry_remaining - dt).max(0.0);
+        self.state.pulse_remaining -= dt;
+        let (visible, awareness) = self.state.awareness.update(world, physics, entity_id, dt);
+        let mut effects = vec![awareness];
+        let (pos, _) = ai_util::get_position_and_forward(world, entity_id);
+        let position = pos.to_vec();
+        let chasing = self.state.awareness.target.is_some()
+            && matches!(
+                self.state.awareness.alertness.current_level,
+                AIAlertLevel::Moderate | AIAlertLevel::High
+            );
+        let config = world
+            .borrow::<View<PropAISwarm>>()
+            .unwrap()
+            .get(entity_id)
+            .cloned()
+            .unwrap_or_default();
+        let close_distance = config.close_distance.max(SWARM_CORE_RADIUS + 0.7);
+        let target = self.state.awareness.target.unwrap_or(position);
+        let distance = (target - position).magnitude();
+        if chasing
+            && self.state.mode == Mode::Close
+            && visible
+            && distance < close_distance
+            && self.state.retry_remaining <= 0.0
+        {
+            if let Some(retreat) = backoff_point(
+                world,
+                physics,
+                entity_id,
+                position,
+                config.backoff_distance.max(close_distance),
+            ) {
+                self.state.mode = Mode::BackOff;
+                self.state.retreat = Some(retreat);
+                self.retreat_route = Some(PathFollowSteeringStrategy::to_point(retreat));
+            }
+            self.state.retry_remaining = 4.0;
+        } else if self.state.mode == Mode::BackOff
+            && (!chasing
+                || self.state.retry_remaining <= 0.0
+                || self
+                    .state
+                    .retreat
+                    .is_some_and(|p| (p - position).magnitude() < 0.5))
+        {
+            self.state.mode = Mode::Close;
+            self.state.retreat = None;
+            self.retreat_route = None;
+            self.state.retry_remaining = 0.0;
+        }
+        let heading = ai_util::current_yaw(entity_id, world);
+        let route = if chasing {
+            if self.state.mode == Mode::BackOff {
+                self.retreat_route.as_mut().unwrap()
+            } else {
+                &mut self.chase
+            }
+        } else {
+            &mut self.wander
+        };
+        let steering = route.steer(heading, world, physics, entity_id, time);
+        let no_nav = world
+            .borrow::<UniqueView<crate::mission::GlobalPathfinding>>()
+            .ok()
+            .is_none_or(|n| n.0.is_none());
+        let direction = if let Some((steering, effect)) = steering {
+            effects.push(effect);
+            Some(Quaternion::from_angle_y(steering.desired_heading) * Vector3::unit_z())
+        } else if no_nav && chasing && visible {
+            let delta = self.state.retreat.unwrap_or(target) - position;
+            let flat = vec3(delta.x, 0.0, delta.z);
+            (flat.magnitude2() > 0.001).then(|| flat.normalize())
+        } else {
+            None
+        };
+        let hover = world
+            .borrow::<View<PropAIMoveZOffset>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|p| p.0)
+            .unwrap_or(3.0 / SCALE_FACTOR);
+        let floor = floor_height(physics, entity_id, position);
+        let desired_y = floor
+            .map(|floor| {
+                floor + hover_height(hover.max(SWARM_CORE_RADIUS * 2.0), self.state.bob_phase)
+            })
+            .unwrap_or(position.y);
+        let speed = world
+            .borrow::<View<PropAIMoveSpeed>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|p| p.0)
+            .unwrap_or(1.0)
+            * 7.5;
+        let horizontal_speed = if self.state.mode == Mode::Close && chasing {
+            speed.min(distance * 3.0)
+        } else {
+            speed
+        };
+        let desired = direction.unwrap_or_else(Vector3::zero) * horizontal_speed
+            + Vector3::unit_y() * ((desired_y - position.y) * 4.0).clamp(-3.0, 3.0);
+        let velocity = flight_velocity(physics, entity_id, position, desired, dt);
+        effects.push(Effect::SetLinearVelocity {
+            entity_id,
+            velocity,
+        });
+        if velocity.x * velocity.x + velocity.z * velocity.z > 0.01 {
+            effects.push(Effect::SetRotation {
+                entity_id,
+                rotation: Quaternion::from_angle_y(Deg(velocity.x.atan2(velocity.z).to_degrees())),
+            });
+        }
+        effects.push(Effect::SetAIProperty {
+            entity_id,
+            update: AIPropertyUpdate::Behavior {
+                name: if !chasing {
+                    "Hover/Wander"
+                } else if self.state.mode == Mode::BackOff {
+                    "BackOff"
+                } else {
+                    "Close"
+                }
+                .into(),
+            },
+        });
+        if self.state.pulse_remaining <= 0.0 {
+            self.state.pulse_remaining = PULSE_SECONDS;
+            for (stim_template_id, options) in
+                crate::scripts::script_util::get_all_links_with_template(world, entity_id, |link| {
+                    match link {
+                        Link::StimSource(options) => Some(*options),
+                        _ => None,
+                    }
+                })
+            {
+                if let StimPropagator::Radius { radius } = options.propagator {
+                    effects.push(Effect::RadiusStim {
+                        source_entity_id: Some(entity_id),
+                        center: position,
+                        radius,
+                        intensity: options.intensity,
+                        stim_template_id,
+                    });
+                }
+            }
+        }
+        Effect::combine(effects)
+    }
+    fn handle_message(
+        &mut self,
+        entity: EntityId,
+        world: &World,
+        _: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Slay => self.die(entity),
+            MessagePayload::SetAlertness { level, pin } => self
+                .state
+                .awareness
+                .set_alertness(world, entity, *level, *pin),
+            MessagePayload::HeardNoise { origin } => {
+                self.state.awareness.hear(world, entity, *origin)
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn flight_core_does_not_cross_a_wall_or_ceiling() {
+        use crate::physics::CollisionGroup;
+        let mut physics = PhysicsWorld::new();
+        let mut world = World::new();
+        let wall = world.add_entity(());
+        let entity = world.add_entity(());
+        let rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 1.0),
+            rotation,
+            Vector3::zero(),
+            vec3(10.0, 10.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(20.0, 20.0, 20.0), EntityId::from_inner(1000).unwrap());
+        physics.update(Vector3::zero(), &mut player);
+        let start = vec3(0.0, 0.0, 0.55);
+        let velocity = flight_velocity(&physics, entity, start, vec3(0.0, 0.0, 7.5), 1.0 / 60.0);
+        assert!((start + velocity / 60.0).z + SWARM_CORE_RADIUS < 0.9);
+        let ceiling = world.add_entity(());
+        physics.add_kinematic(
+            ceiling,
+            vec3(0.0, 1.0, 0.0),
+            rotation,
+            Vector3::zero(),
+            vec3(10.0, 0.2, 10.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        physics.update(Vector3::zero(), &mut player);
+        let start = vec3(0.0, 0.55, 0.0);
+        let velocity = flight_velocity(&physics, entity, start, vec3(0.0, 3.0, 0.0), 1.0 / 60.0);
+        assert!((start + velocity / 60.0).y + SWARM_CORE_RADIUS < 0.9);
+    }
+
+    #[test]
+    fn authored_hover_cycle_is_four_seconds_and_half_a_dark_foot() {
+        assert!((hover_height(1.2, 1.0) - 1.4).abs() < 1e-6);
+        assert!((hover_height(1.2, 3.0) - 1.0).abs() < 1e-6);
+        assert!((hover_height(1.2, 4.0) - 1.2).abs() < 1e-6);
+    }
+    #[test]
+    fn retreat_and_pulse_phase_survive_hydration() {
+        let mut ai = SwarmerAI::new();
+        ai.state.mode = Mode::BackOff;
+        ai.state.retreat = Some(vec3(1.0, 2.0, 3.0));
+        ai.state.retry_remaining = 2.25;
+        ai.state.bob_phase = 1.5;
+        ai.state.pulse_remaining = 0.3;
+        let saved = ai.save_state().unwrap();
+        let mut restored = SwarmerAI::new();
+        restored
+            .restore_state(
+                &saved,
+                &ScriptRestoreContext::new(&std::collections::HashMap::new()),
+            )
+            .unwrap();
+        assert_eq!(saved, restored.save_state().unwrap());
+        assert!(restored.retreat_route.is_some());
+    }
+}

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -5,7 +5,7 @@ use crate::{physics::PhysicsWorld, time::Time};
 
 use super::{
     Effect, MessagePayload, NoopScript, Script,
-    ai::{AnimatedMonsterAI, CameraAI, GrubAI, TurretAI},
+    ai::{AnimatedMonsterAI, CameraAI, GrubAI, SwarmerAI, TurretAI},
     script_util,
 };
 
@@ -54,6 +54,7 @@ impl Script for BaseMonster {
         if let Some((key, saved)) = child {
             self.ai = match key.as_str() {
                 "shock2vr.grub_ai" => Box::new(GrubAI::new()),
+                "shock2vr.swarmer_ai" => Box::new(SwarmerAI::new()),
                 "shock2vr.turret" => Box::new(TurretAI::new()),
                 _ => {
                     return Err(super::ScriptStateError::InvalidPayload {
@@ -125,8 +126,7 @@ impl Script for BaseMonster {
                     "shockdefault" => Box::new(AnimatedMonsterAI::new()),
                     "turret" => Box::new(TurretAI::new()),
                     "grub" => Box::new(GrubAI::new()),
-                    // TODO: flying object-model controller.
-                    "swarmer" => Box::new(NoopScript {}),
+                    "swarmer" => Box::new(SwarmerAI::new()),
 
                     _ => Box::new(AnimatedMonsterAI::idle()),
                 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -576,6 +576,7 @@ pub enum Effect {
     /// Radiation sources refresh this every frame while their player is in
     /// range; the player status integrates the ambient exposure separately.
     RadiusStim {
+        source_entity_id: Option<EntityId>,
         center: Vector3<f32>,
         radius: f32,
         intensity: f32,

--- a/shock2vr/src/scripts/internal_radiation_source.rs
+++ b/shock2vr/src/scripts/internal_radiation_source.rs
@@ -51,6 +51,7 @@ impl Script for InternalRadiationSource {
         let center = point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)));
 
         Effect::RadiusStim {
+            source_entity_id: None,
             center,
             radius,
             intensity,
@@ -97,6 +98,7 @@ mod tests {
         assert!(matches!(
             effect,
             Effect::RadiusStim {
+                source_entity_id: None,
                 center,
                 radius: 6.0,
                 intensity: 8.0,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod proximity_grenade;
 pub mod speech_registry;
 pub mod speech_util;
 pub mod stasis;
+mod swarm;
 
 mod apparition;
 mod auto_install_soft;
@@ -970,12 +971,7 @@ impl ScriptWorld {
             "grubegg" => Box::new(BaseEgg::new(EggPayload::Grub)),
             "swarmeregg" => Box::new(BaseEgg::new(EggPayload::Swarmer)),
             "gooprojectile" => Box::new(GooProjectile::new()),
-            // The flying annelid a swarmer pod hatches. Its retail script owns
-            // the swarm's flocking; the port's `swarmer` AI is still a stub, so
-            // a hatched swarm is a damageable particle cloud that does not yet
-            // chase. Mapped explicitly so the pod can hatch at all - the
-            // fallback would panic on load.
-            "swarm" => Box::new(NoopScript::new()),
+            "swarm" => Box::new(swarm::Swarm::new()),
             "containerscript" => gui_script(Box::new(ContainerGui::loot_container())),
 
             "lootable" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/swarm.rs
+++ b/shock2vr/src/scripts/swarm.rs
@@ -1,0 +1,94 @@
+//! The object script owns the retail twenty-second lifetime; SwarmerAI owns flight.
+use super::{
+    Effect, Message, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+};
+use crate::{physics::PhysicsWorld, time::Time};
+use shipyard::{EntityId, World};
+const KEY: &str = "shock2vr.swarm_lifetime";
+pub struct Swarm {
+    remaining: f32,
+    expired: bool,
+}
+impl Swarm {
+    pub fn new() -> Self {
+        Self {
+            remaining: 20.0,
+            expired: false,
+        }
+    }
+}
+impl Script for Swarm {
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(KEY)
+    }
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, &(self.remaining, self.expired), KEY)
+    }
+    fn restore_state(
+        &mut self,
+        saved: &ScriptState,
+        _: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        (self.remaining, self.expired) = saved.decode(1, KEY)?;
+        Ok(())
+    }
+    fn update(&mut self, entity: EntityId, _: &World, _: &PhysicsWorld, time: &Time) -> Effect {
+        if self.expired {
+            return Effect::NoEffect;
+        }
+        self.remaining = (self.remaining - time.elapsed.as_secs_f32()).max(0.0);
+        if self.remaining > 0.0 {
+            return Effect::NoEffect;
+        }
+        self.expired = true;
+        Effect::Send {
+            msg: Message {
+                to: entity,
+                payload: MessagePayload::Slay,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn lifetime_restores_remaining_time_and_slays_once() {
+        let mut swarm = Swarm::new();
+        let world = World::new();
+        let physics = PhysicsWorld::new();
+        let entity = EntityId::from_inner(1).unwrap();
+        let advance = |swarm: &mut Swarm, seconds| {
+            swarm.update(
+                entity,
+                &world,
+                &physics,
+                &Time {
+                    elapsed: std::time::Duration::from_secs_f32(seconds),
+                    ..Time::default()
+                },
+            )
+        };
+        assert!(matches!(advance(&mut swarm, 12.0), Effect::NoEffect));
+        let saved = swarm.save_state().unwrap();
+        let mut restored = Swarm::new();
+        restored
+            .restore_state(
+                &saved,
+                &ScriptRestoreContext::new(&std::collections::HashMap::new()),
+            )
+            .unwrap();
+        assert!(matches!(advance(&mut restored, 7.0), Effect::NoEffect));
+        assert!(matches!(
+            advance(&mut restored, 1.0),
+            Effect::Send {
+                msg: Message {
+                    payload: MessagePayload::Slay,
+                    ..
+                }
+            }
+        ));
+        assert!(matches!(advance(&mut restored, 10.0), Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/swarmer-ai.e2e.test.ts
+++ b/tools/shock2-sdk/test/swarmer-ai.e2e.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("hatched swarm flies, backs off, damages nearby player and expires", { skip: !enabled, timeout: 300_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  const health = (await game.info()).player.hit_points!;
+  await game.player.teleport({ x: -6, y: 1, z: 6 });
+  await game.step({ frames: 15 });
+  const [swarm] = await game.entities.byTemplate(-183);
+  assert.ok(swarm, "approaching the swarmer pod must hatch its cloud");
+  const start = (await game.entities.detail(swarm.id)).position;
+  let moved = false;
+  const behaviors = new Set<string>();
+  for (let i = 0; i < 36; i++) {
+    await game.step({ frames: 10 });
+    const detail = await game.entities.detail(swarm.id);
+    const [body] = (await game.physics.bodies({ entityId: swarm.id })).bodies;
+    assert.ok(body);
+    assert.equal(body.body_type, "dynamic");
+    assert.ok(body.position[1]! > 0.3 && body.position[1]! < 4, `cloud must hover: ${body.position}`);
+    moved ||= Math.hypot(detail.position[0]! - start[0]!, detail.position[2]! - start[2]!) > 0.7;
+    for (const prop of detail.properties) if (prop.name === "AIBehavior") behaviors.add(prop.value);
+  }
+  assert.ok(moved, "the cloud must leave its pod");
+  assert.ok([...behaviors].some(v => v.includes("BackOff")), `swarm must retreat between approaches: ${[...behaviors]}`);
+  assert.ok((await game.info()).player.hit_points! < health, "authored proximity stim must reach the player");
+  // The Swarm script's twenty-second lifetime runs independently of AI combat.
+  await game.player.teleport({ x: 20, y: 1, z: 6 });
+  await game.step({ frames: 850 });
+  assert.equal((await game.entities.byTemplate(-183)).length, 0, "expired swarm must disappear");
+  assert.equal((await game.physics.bodies({ entityId: swarm.id })).bodies.length, 0);
+});
+
+test("rec1 swarm flight and remaining lifetime survive save/load", { skip: !enabled, timeout: 300_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "rec1.mis" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(264);
+  assert.ok(pod, "discover the authored swarmer pod by mission object id");
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 5 });
+  const [swarm] = await game.entities.byTemplate(-183);
+  assert.ok(swarm);
+  await game.entities.sendMessage(swarm.id, { type: "SetAlertness", level: "Lowest" });
+  await game.step({ frames: 295 });
+  const before = await game.entities.detail(swarm.id);
+  const slot = `swarmer_lifetime_${Date.now()}`;
+  assert.equal((await game.save(slot)).success, true);
+  assert.equal((await game.load(slot)).success, true);
+  const [restored] = await game.entities.byTemplate(-183);
+  assert.ok(restored);
+  const [body] = (await game.physics.bodies({ entityId: restored.id })).bodies;
+  assert.ok(body && body.body_type === "dynamic", "restore the flying body");
+  assert.ok(Math.hypot(...body.position.map((v, i) => v - before.position[i]!)) < 0.1,
+    "loading should preserve the cloud position");
+  await game.step({ frames: 780 });
+  assert.equal((await game.entities.byTemplate(-183)).length, 1, "saved swarm should live until its remaining deadline");
+  await game.step({ frames: 180 });
+  assert.equal((await game.entities.byTemplate(-183)).length, 0, "loading must not restart the twenty-second clock");
+});


### PR DESCRIPTION
Hatched swarms previously remained stationary particle clouds. This adds `SwarmerAI` as a sibling of `AnimatedMonsterAI`: the cloud hovers, follows navigation routes toward the player, backs off between approaches and deals authored proximity damage. The separate `Swarm` script now expires it after twenty seconds.

Stacked on #1518 (`feat/annelid-ai`). This layer reuses its awareness and BaseMonster state wrapper, plus the existing chase/wander/fixed-point path followers. The authored particle animation remains intact; the controller moves the emitter. Save/load preserves hover phase, retreat destination, damage timing and remaining lifetime. Stasis pauses movement and damage; the independent lifetime timer continues.

## Boundaries and approximations

- The retail zero-radius point body becomes a radius-.3 collision/aiming core; individual particle bugs have no hitboxes. Health remains the authored 36 HP.
- Hover uses the authored two-unit ground offset with the original four-second, .2-unit bob. Navigation is ground routes plus hover, not a new volumetric pathfinder.
- The close threshold has a one-unit minimum for player/core collision clearance. Retreat actions have a fixed four-second retry budget within the original three-to-five-second range.
- Radius damage pulses every .5 seconds; generic Dark stimulus timing records remain unimplemented. Existing falloff, receptrons and obstruction checks apply, without explosion knockback. Radius effects can now identify their source so the cloud cannot obstruct its own damage ray.

## Validation

- 10 runtime checks passed: swarmer hatch/flight/backoff/damage/expiry, rec1 save/load lifetime, grub movement/hitboxes/landing, annelid eggs/volleys, and toxin/radiation regressions.
- 588 script tests passed, plus focused swarm property, hover, saved state, wall/ceiling clearance and lifetime tests.
- Desktop/debug runtime checks, SDK build, formatting and diff checks passed.

## Before and after

![Swarmer flight before and after](https://gist.githubusercontent.com/tommy-xr/8df5d13220335d7e1a389cb5dc1207b8/raw/swarmer-before-after.gif)

Identical headless sequences: the cloud remains above its pod before; afterward it hovers, pursues the player and deals proximity damage. Flight also verified in VR; rec1 pod264 verified for hatching and hovering.

![Swarmer comparison still](https://gist.githubusercontent.com/tommy-xr/8df5d13220335d7e1a389cb5dc1207b8/raw/swarmer-before-after.png)

All capture runtimes shut down.

See [implementation notes](projects/swarmer-ai.md) for authored data and original-source references.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
