### PR TITLE
feat(difficulty): filter fresh mission objects by authored masks

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -482,6 +482,22 @@ pub struct PropPhysState {
     pub rot_velocity: Vector3<f32>,
 }
 
+/// Retail masks use the gamesys difficulty index: Easy is bit 1, not bit 0.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropDifficultyDestroy(pub u32);
+impl PropDifficultyDestroy {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self(read_u32(reader))
+    }
+}
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropDifficultyPermit(pub u32);
+impl PropDifficultyPermit {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self(read_u32(reader))
+    }
+}
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropLocked(pub bool);
 
@@ -1684,6 +1700,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$KeypadCod",
             |reader, _len| read_u32(reader),
             PropKeypadCode,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$DiffDestr",
+            PropDifficultyDestroy::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$DiffPermi",
+            PropDifficultyPermit::read,
+            identity,
             accumulator::latest,
         ),
         define_prop("P$Locked", PropLocked::read, identity, accumulator::latest),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1083,7 +1083,9 @@ impl Game {
             {
                 Box::new(SaveFileEntityPopulator::create(save_data.clone()))
             } else {
-                Box::new(MissionEntityPopulator::create())
+                Box::new(MissionEntityPopulator::create(
+                    pending.quest_info.difficulty(),
+                ))
             }
         };
 

--- a/shock2vr/src/mission/entity_populator/mission_entity_populator.rs
+++ b/shock2vr/src/mission/entity_populator/mission_entity_populator.rs
@@ -1,12 +1,14 @@
 use cgmath::{Deg, Quaternion, Rotation3};
+use dark::gamesys::Difficulty;
 use dark::properties::WrappedEntityId;
+use dark::properties::{Link, Links, PropDifficultyDestroy, PropDifficultyPermit};
 ///
 /// mission_entity_populator.rs
 ///
 /// An implementation of EntityPopulator that creates entities based on the entity data
 /// in a mission file
-use shipyard::{IntoIter, View, ViewMut, World};
-use std::collections::HashMap;
+use shipyard::{Get, IntoIter, View, ViewMut, World};
+use std::collections::{HashMap, HashSet};
 
 use dark::ss2_entity_info::SystemShock2EntityInfo;
 
@@ -14,11 +16,13 @@ use crate::mission::entity_creator;
 
 use super::{EntityPopulation, EntityPopulator};
 
-pub struct MissionEntityPopulator {}
+pub struct MissionEntityPopulator {
+    difficulty: Difficulty,
+}
 
 impl MissionEntityPopulator {
-    pub fn create() -> MissionEntityPopulator {
-        MissionEntityPopulator {}
+    pub fn create(difficulty: Difficulty) -> MissionEntityPopulator {
+        MissionEntityPopulator { difficulty }
     }
 }
 
@@ -69,10 +73,144 @@ impl EntityPopulator for MissionEntityPopulator {
             );
         }
 
+        // Properties and containment are inherited before evaluation, but no
+        // scripts or physics have been instantiated yet. Saves use a separate
+        // populator, so their already-filtered object set is never reconsidered.
+        filter_difficulty(world, &mut template_to_entity_id, self.difficulty);
+
         EntityPopulation {
             template_to_entity_id,
             entity_id_map: HashMap::new(),
             script_states: Vec::new(),
+        }
+    }
+}
+
+fn filter_difficulty(
+    world: &mut World,
+    objects: &mut HashMap<i32, WrappedEntityId>,
+    difficulty: Difficulty,
+) {
+    let bit = 1u32 << difficulty.retail_index();
+    let mut excluded = HashSet::new();
+    {
+        let destroy = world.borrow::<View<PropDifficultyDestroy>>().unwrap();
+        let permit = world.borrow::<View<PropDifficultyPermit>>().unwrap();
+        for (&id, entity) in objects.iter().filter(|(id, _)| **id > 0) {
+            if destroy.get(entity.0).is_ok_and(|p| p.0 & bit != 0)
+                || permit.get(entity.0).is_ok_and(|p| p.0 & bit == 0)
+            {
+                excluded.insert(id);
+            }
+        }
+    }
+    // Destroying a container also destroys its contents, transitively. Include
+    // cycle protection for malformed containment graphs.
+    {
+        let links = world.borrow::<View<Links>>().unwrap();
+        let mut pending: Vec<_> = excluded.iter().copied().collect();
+        while let Some(id) = pending.pop() {
+            if let Some(entity) = objects.get(&id) {
+                if let Ok(links) = links.get(entity.0) {
+                    for link in &links.to_links {
+                        if matches!(link.link, Link::Contains(_))
+                            && link.to_template_id > 0
+                            && excluded.insert(link.to_template_id)
+                        {
+                            pending.push(link.to_template_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for id in &excluded {
+        if let Some(entity) = objects.remove(id) {
+            world.delete_entity(entity.0);
+        }
+    }
+    // Remove incoming links as well: a removed concrete target must not become
+    // a deferred spawn/reference. Abstract template links remain available.
+    let mut links = world.borrow::<ViewMut<Links>>().unwrap();
+    for links in (&mut links).iter() {
+        links
+            .to_links
+            .retain(|link| !excluded.contains(&link.to_template_id));
+    }
+}
+
+#[cfg(test)]
+mod difficulty_tests {
+    use super::*;
+    use dark::properties::ToLink;
+    #[test]
+    fn difficulty_masks_remove_nested_contents_and_incoming_links() {
+        for difficulty in Difficulty::ALL {
+            let mut world = World::new();
+            let container = world.add_entity((PropDifficultyDestroy(0x10),));
+            let child = world.add_entity(());
+            let grandchild = world.add_entity(());
+            let donor = world.add_entity((PropDifficultyDestroy(0x1e),));
+            let hard_only = world.add_entity((PropDifficultyPermit(0x38),));
+            let playtest_only = world.add_entity((PropDifficultyPermit(1),));
+            let survivor = world.add_entity(());
+            let link = |id, entity, kind| ToLink {
+                to_template_id: id,
+                to_entity_id: Some(WrappedEntityId(entity)),
+                link: kind,
+            };
+            world.add_component(
+                container,
+                (Links {
+                    to_links: vec![link(2, child, Link::Contains(0))],
+                },),
+            );
+            world.add_component(
+                child,
+                (Links {
+                    to_links: vec![link(3, grandchild, Link::Contains(0))],
+                },),
+            );
+            world.add_component(
+                survivor,
+                (Links {
+                    to_links: vec![
+                        link(1, container, Link::Contains(0)),
+                        link(-1, donor, Link::Contains(1)),
+                    ],
+                },),
+            );
+            let mut objects = HashMap::from([
+                (1, WrappedEntityId(container)),
+                (2, WrappedEntityId(child)),
+                (3, WrappedEntityId(grandchild)),
+                (-1, WrappedEntityId(donor)),
+                (4, WrappedEntityId(hard_only)),
+                (5, WrappedEntityId(playtest_only)),
+                (6, WrappedEntityId(survivor)),
+            ]);
+            filter_difficulty(&mut world, &mut objects, difficulty);
+            for id in [1, 2, 3] {
+                assert_eq!(
+                    objects.contains_key(&id),
+                    difficulty != Difficulty::Impossible
+                );
+            }
+            assert!(objects.contains_key(&-1));
+            assert!(!objects.contains_key(&5));
+            assert_eq!(
+                objects.contains_key(&4),
+                matches!(difficulty, Difficulty::Hard | Difficulty::Impossible)
+            );
+            let links = world.borrow::<View<Links>>().unwrap();
+            assert_eq!(
+                links.get(survivor).unwrap().to_links.len(),
+                if difficulty == Difficulty::Impossible {
+                    1
+                } else {
+                    2
+                }
+            );
         }
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -297,7 +297,7 @@ pub fn create_initial_scene(
         global_context,
         options.spawn_location.clone(),
         QuestInfo::with_difficulty(options.difficulty),
-        Box::new(MissionEntityPopulator::create()),
+        Box::new(MissionEntityPopulator::create(options.difficulty)),
         HeldItemSaveData::empty(),
         options,
     );
@@ -329,7 +329,9 @@ pub fn load_mission_from_save_data(
             let populator = SaveFileEntityPopulator::create(save_data_cloned);
             Box::new(populator)
         } else {
-            Box::new(MissionEntityPopulator::create())
+            Box::new(MissionEntityPopulator::create(
+                save_data.global_data.quest_info.difficulty(),
+            ))
         }
     };
 

--- a/tools/shock2-sdk/test/difficulty-placement.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty-placement.e2e.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+for (const difficulty of ["easy","normal","hard","impossible"] as const) {
+  test(`difficulty placement: ${difficulty} honors authored masks and survives reload`, {
+    skip:process.env.SHOCK2_E2E !== "1", timeout:180_000,
+  },async () => {
+    await using game = await GameServer.launch({mission:"medsci1.mis",difficulty});
+    const count = async (id:number) => (await game.entities.byTemplate(id)).length;
+    assert.equal(await count(1363),difficulty === "easy" ? 1 : 0,"Easy-only world pistol");
+    assert.equal(await count(2060),difficulty === "impossible" ? 0 : 1,"corpse pistol is absent on Impossible");
+    const save = `difficulty-placement-${difficulty}-${Date.now()}`;
+    await game.save(save);
+    await game.transitionLevel("ops4.mis");
+    for (const id of [317,319]) {
+      assert.equal(await count(id),difficulty === "hard" || difficulty === "impossible" ? 1 : 0,"Hard/Impossible grenade hybrid");
+    }
+    await game.load(save);
+    assert.equal(await count(1363),difficulty === "easy" ? 1 : 0);
+    assert.equal(await count(2060),difficulty === "impossible" ? 0 : 1);
+  });
+}


### PR DESCRIPTION
Fresh mission loads now apply inherited P$DiffDestr/P$DiffPermi masks using retail difficulty bits (Easy=1 through Impossible=4). MedSci's Easy-only pistol no longer appears on Normal/Hard/Impossible, and Operations' Hard/Impossible guards no longer appear on the easier settings.

Filtering runs after properties and links are hydrated, before scripts and physics start. Rejected containers take their nested contents with them, incoming links to rejected concrete objects are removed, and abstract donor templates remain available. Saves restore their existing object set through the save populator without filtering again.

Validation: seven difficulty-focused unit tests including nested containment and dangling-link removal; four SDK scenarios checking MedSci and Operations placement plus save/load at every difficulty. All 23 SDK mission loading scenarios pass against the pinned placement build. Flat/VR before-and-after placement evidence follows below.

## Visual verification

MedSci1 pistol1363 is present before filtering and excluded after filtering on Impossible. Before is left, after right; flatscreen above VR. Both runs use the same recorded world coordinates, camera path and fixed simulation steps. Entity discovery confirms one matching object before and zero after.

![Difficulty placement comparison](https://gist.githubusercontent.com/tommy-xr/a050c6d2e772e417920e4dab01711ff3/raw/pr4-placement.gif)

![Before and after authored pistol placement](https://gist.githubusercontent.com/tommy-xr/a050c6d2e772e417920e4dab01711ff3/raw/pr4-placement.png)

<sub>Captured headlessly with identical deterministic requests against immutable before/after binaries; both presentations inspected.</sub>
