### PR TITLE
feat(difficulty): apply Easy ecology timing and population rules

### DIFF
--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -1310,11 +1310,7 @@ impl ScriptWorld {
             }
             "toxinpatch" => Box::new(hazard_objects::HazardObject::ToxinPatch),
             "triggerecology" => Box::new(TriggerEcology::new()),
-            // Retail's difficulty variant applies shock.cfg/difficulty
-            // population adjustments before entering this same state machine.
-            // The port has neither setting yet, so its authored baseline is
-            // identical to TriggerEcology.
-            "triggerecologydiff" => Box::new(TriggerEcology::new()),
+            "triggerecologydiff" => Box::new(TriggerEcology::new_diff()),
             "unhackhack" => Box::new(UnimplementedScript::new(&script_name)),
             _ => Box::new(PanicOnLoadScript { name: script_name }),
         }

--- a/shock2vr/src/scripts/trigger_ecology.rs
+++ b/shock2vr/src/scripts/trigger_ecology.rs
@@ -26,6 +26,7 @@ struct TriggerEcologyState {
 /// A security `Alarm` switches to the alert-column population profile until
 /// the authored recovery window expires or a `Reset` arrives.
 pub struct TriggerEcology {
+    difficulty_aware: bool,
     seconds_until_poll: f32,
     recovery_seconds_remaining: Option<f32>,
 }
@@ -33,8 +34,44 @@ pub struct TriggerEcology {
 impl TriggerEcology {
     pub fn new() -> Self {
         Self {
+            difficulty_aware: false,
             seconds_until_poll: 0.0,
             recovery_seconds_remaining: None,
+        }
+    }
+
+    pub fn new_diff() -> Self {
+        Self {
+            difficulty_aware: true,
+            ..Self::new()
+        }
+    }
+
+    fn is_easy(&self, world: &World) -> bool {
+        self.difficulty_aware
+            && world
+                .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                .ok()
+                .is_some_and(|q| q.difficulty() == dark::gamesys::Difficulty::Easy)
+    }
+    fn period(&self, world: &World, authored: f32) -> f32 {
+        authored.max(0.0) * if self.is_easy(world) { 2.0 } else { 1.0 }
+    }
+    fn population_params(
+        &self,
+        world: &World,
+        minimum: i32,
+        maximum: i32,
+        random: i32,
+    ) -> (i32, i32, i32) {
+        if self.is_easy(world) {
+            (
+                if minimum > 1 { minimum - 1 } else { minimum },
+                if maximum > 1 { maximum - 1 } else { maximum },
+                random.saturating_mul(2),
+            )
+        } else {
+            (minimum, maximum, random)
         }
     }
 
@@ -131,9 +168,12 @@ impl TriggerEcology {
             ECOLOGY_STATE_ALERT => ECOLOGY_STATE_ALERT as usize,
             _ => return Effect::NoEffect,
         };
-        let minimum = ecology.min_count[state_index];
-        let maximum = ecology.max_count[state_index];
-        let random_chance = ecology.random_chance[state_index];
+        let (minimum, maximum, random_chance) = self.population_params(
+            world,
+            ecology.min_count[state_index],
+            ecology.max_count[state_index],
+            ecology.random_chance[state_index],
+        );
         let population = Self::population(world, ecology_type.0) as i32;
         let random_hit = random_chance > 0 && rand::thread_rng().gen_range(0..random_chance) == 0;
         if Self::should_spawn(population, minimum, maximum, random_hit) {
@@ -149,7 +189,7 @@ impl Script for TriggerEcology {
         let ecologies = world.borrow::<View<PropEcology>>().unwrap();
         self.seconds_until_poll = ecologies
             .get(entity_id)
-            .map(|ecology| ecology.period_seconds.max(0.0))
+            .map(|ecology| self.period(world, ecology.period_seconds))
             .unwrap_or(0.0);
         drop(ecologies);
         // Legacy saves persist the alerted `P$EcoState` but carry no private
@@ -178,7 +218,7 @@ impl Script for TriggerEcology {
                 ecologies
                     .get(entity_id)
                     .ok()
-                    .map(|ecology| ecology.period_seconds.max(0.0))
+                    .map(|ecology| self.period(world, ecology.period_seconds))
             });
         let Some(period_seconds) = period_seconds else {
             return Effect::NoEffect;
@@ -300,6 +340,54 @@ mod tests {
 
     use super::*;
     use crate::runtime_props::RuntimePropCanonicalTemplateId;
+
+    #[test]
+    fn easy_diff_ecology_scales_derived_values_without_mutating_authored_data() {
+        for difficulty in dark::gamesys::Difficulty::ALL {
+            let world = World::new();
+            world.add_unique(crate::quest_info::QuestInfo::with_difficulty(difficulty));
+            let diff = TriggerEcology::new_diff();
+            let plain = TriggerEcology::new();
+            let easy = difficulty == dark::gamesys::Difficulty::Easy;
+            assert_eq!(diff.period(&world, 15.0), if easy { 30.0 } else { 15.0 });
+            assert_eq!(
+                diff.population_params(&world, 2, 4, 3),
+                if easy { (1, 3, 6) } else { (2, 4, 3) }
+            );
+            assert_eq!(diff.population_params(&world, 0, 1, 0), (0, 1, 0));
+            assert_eq!(plain.period(&world, 15.0), 15.0);
+            assert_eq!(plain.population_params(&world, 2, 4, 3), (2, 4, 3));
+        }
+    }
+    #[test]
+    fn easy_diff_ecology_initializes_and_rearms_with_doubled_period() {
+        let mut world = World::new();
+        world.add_unique(crate::quest_info::QuestInfo::with_difficulty(
+            dark::gamesys::Difficulty::Easy,
+        ));
+        let entity = world.add_entity((
+            ecology_props([0; 3], [0; 3], [0.0; 3], [0; 3]),
+            PropEcoType(1),
+        ));
+        let mut script = TriggerEcology::new_diff();
+        script.initialize(entity, &world);
+        assert_eq!(script.seconds_until_poll, 30.0);
+        step(&mut script, entity, &world, 15);
+        assert_eq!(script.seconds_until_poll, 15.0);
+        let saved = script.save_state().unwrap();
+        let mut restored = TriggerEcology::new_diff();
+        restored
+            .restore_state(&saved, &ScriptRestoreContext::new(&HashMap::new()))
+            .unwrap();
+        assert_eq!(
+            restored.seconds_until_poll, 15.0,
+            "restore retains the remaining time without rescaling"
+        );
+        assert!(restored.difficulty_aware);
+        script = restored;
+        step(&mut script, entity, &world, 15);
+        assert_eq!(script.seconds_until_poll, 30.0);
+    }
 
     fn ecology_props(
         min_count: [i32; 3],

--- a/tools/shock2-sdk/test/difficulty-ecology.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty-ecology.e2e.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+for (const difficulty of ["easy","normal"] as const) {
+  test(`difficulty ecology: ${difficulty} follows authored alarm spawn timing`, {
+    skip:process.env.SHOCK2_E2E !== "1",timeout:180_000,
+  },async () => {
+    await using game = await GameServer.launch({mission:"medsci1.mis",difficulty});
+    const [camera] = await game.entities.byTemplate(77);
+    assert.ok(camera);
+    // Camera77 -> Diff ecology78 -> generator81. Its authored alert profile
+    // is min/max2, period10s, random0; actual spawned OG-Pipe instances carry
+    // archetype -397 while placed objects have positive mission identities.
+    const count = async () => (await game.entities.byTemplate(-397)).length;
+    assert.equal(await count(),0);
+    await game.entities.sendMessage(camera.id,{type:"SetAlertness",level:"High"});
+    // Sample beyond the timer boundary: initialization and queued spawning
+    // can put the visible actor a few frames after the nominal deadline.
+    await game.step({frames:660});
+    assert.equal(await count(),difficulty === "easy" ? 0 : 1);
+    if (difficulty === "easy") {
+      const save = `difficulty-ecology-${Date.now()}`;
+      await game.save(save);
+      await game.load(save);
+      assert.equal(await count(),0);
+    }
+    await game.step({frames:600});
+    assert.equal(await count(),difficulty === "easy" ? 1 : 2);
+    await game.step({frames:600});
+    assert.equal(await count(),difficulty === "easy" ? 1 : 2,"population ceiling remains stable");
+  });
+}


### PR DESCRIPTION
Easy campaigns now use the confirmed TriggerEcologyDiff behavior: double the polling period, subtract one from normal/alert minimum and maximum populations only when greater than one, and double the random-spawn denominator. Plain TriggerEcology and the other campaign difficulties retain authored behavior.

The script derives these values without changing its properties. Its existing saved timer and alert-recovery state retain their exact remaining durations across load, with no repeated scaling.

Validation: fourteen ecology unit tests, including boundary values, plain-script behavior, Easy timer initialization/rearming and save/restore. A real MedSci camera 77 alarm drives ecology 78 and its authored generator: before/after captures show the first spawn at 10 versus 20 seconds and two versus one live spawned guards at 40 seconds. Both SDK alarm-flow scenarios pass, including an Easy mid-timer save/load.

## Visual verification

On Easy, the same MedSci1 camera 77 alarm drives authored Diff ecology 78 and generator81. Before, OG-Pipes spawn near 10 and 20 seconds; after, the first appears near 20 seconds and the population remains one at 40 seconds (previously two). The pawn stays at its initial position so distance/visibility spawning rules remain active. Only the camera moves to observe the generator.

![Easy ecology spawn timing before and after](https://gist.githubusercontent.com/tommy-xr/cc1d2be47838a1a73531ed812ae6ea1d/raw/pr5-ecology.gif)

![Ecology comparison at 10.10 and 20.10 seconds](https://gist.githubusercontent.com/tommy-xr/cc1d2be47838a1a73531ed812ae6ea1d/raw/pr5-ecology.png)

The clip shows the 9.65–10.8s and 19.65–20.8s windows with timestamps. Counts report all newly discovered OG-Pipes, including those outside the camera: by 20 seconds the original actor has pursued the pawn and the second baseline spawn uses marker151. The after actor is visibly delayed at generator81.

<sub>Same deterministic requests against immutable before/after binaries. Camera SetAlertness High activates the real linked alarm; no enemy is manually spawned. Screenshots and moving frames inspected. Population snapshots at 40 seconds confirm before=2, after=1.</sub>
