### PR TITLE
feat(difficulty): apply Easy healing and psi hypo bonuses

### DIFF
--- a/shock2vr/src/scripts/healing_item.rs
+++ b/shock2vr/src/scripts/healing_item.rs
@@ -75,9 +75,19 @@ impl Script for HealingItemScript {
         }
 
         let pharmo_friendly = Self::pharmo_friendly(world);
+        let mut total = Self::retail_amount(self.kind.base_total(), pharmo_friendly);
+        // MedPatchScript boosts the total budget on Easy, after Pharmo-Friendly.
+        // Its pulse size/cadence and MedicalKit's budget are unchanged.
+        if self.kind == HealingItemKind::MedPatch
+            && world
+                .borrow::<UniqueView<QuestInfo>>()
+                .is_ok_and(|q| q.difficulty() == dark::gamesys::Difficulty::Easy)
+        {
+            total = total * 3 / 2;
+        }
         Effect::UseHealingItem {
             entity_id,
-            total: Self::retail_amount(self.kind.base_total(), pharmo_friendly),
+            total,
             pulse: Self::retail_amount(self.kind.base_pulse(), pharmo_friendly),
             first_pulse_secs: HEALING_FIRST_PULSE_SECS,
             pulse_interval_secs: HEALING_PULSE_INTERVAL_SECS,
@@ -199,6 +209,68 @@ mod tests {
         ActiveHealing, HEALING_FIRST_PULSE_SECS, HEALING_PULSE_INTERVAL_SECS, HealingItemKind,
         HealingItemScript,
     };
+
+    #[test]
+    fn easy_medpatch_budget_applies_after_trait_without_changing_pulses() {
+        for difficulty in dark::gamesys::Difficulty::ALL {
+            for pharmo in [false, true] {
+                let mut world = World::new();
+                let item = world.add_entity(());
+                let mut quests = QuestInfo::with_difficulty(difficulty);
+                if pharmo {
+                    quests
+                        .player_stats_mut()
+                        .add_os_trait(crate::scripts::gui::TRAIT_PHARMO_FRIENDLY);
+                }
+                world.add_unique(quests);
+                for kind in [HealingItemKind::MedPatch, HealingItemKind::MedicalKit] {
+                    let effect = HealingItemScript::new(kind).handle_message(
+                        item,
+                        &world,
+                        &PhysicsWorld::new(),
+                        &MessagePayload::Frob,
+                    );
+                    let mut expected = if kind == HealingItemKind::MedPatch {
+                        10
+                    } else {
+                        200
+                    };
+                    if pharmo {
+                        expected = expected * 6 / 5;
+                    }
+                    if kind == HealingItemKind::MedPatch
+                        && difficulty == dark::gamesys::Difficulty::Easy
+                    {
+                        expected = expected * 3 / 2;
+                    }
+                    match effect {
+                        Effect::UseHealingItem {
+                            total,
+                            pulse,
+                            first_pulse_secs,
+                            pulse_interval_secs,
+                            ..
+                        } => {
+                            assert_eq!(total, expected);
+                            assert_eq!(
+                                pulse,
+                                if kind == HealingItemKind::MedPatch {
+                                    2
+                                } else if pharmo {
+                                    6
+                                } else {
+                                    5
+                                }
+                            );
+                            assert_eq!(first_pulse_secs, 0.1);
+                            assert_eq!(pulse_interval_secs, 1.5);
+                        }
+                        _ => panic!("expected healing use"),
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn med_patch_frob_uses_retail_budget_and_cadence() {

--- a/shock2vr/src/scripts/psi_kit.rs
+++ b/shock2vr/src/scripts/psi_kit.rs
@@ -1,10 +1,10 @@
-use shipyard::{EntityId, World};
+use shipyard::{EntityId, UniqueView, World};
 
 use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
-/// The retail psi hypo (`PsiKitScript`): inventory use restores 20 psi and
+/// The retail psi hypo (`PsiKitScript`): inventory use restores 30 psi on Easy, 20 otherwise, and
 /// consumes one unit from its stack.
 ///
 /// At an already-full pool the original reports `misc\\PsiMaxed` and leaves
@@ -26,7 +26,7 @@ impl Script for PsiKitScript {
     fn handle_message(
         &mut self,
         entity_id: EntityId,
-        _world: &World,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
@@ -36,7 +36,14 @@ impl Script for PsiKitScript {
 
         Effect::UsePsiKit {
             entity_id,
-            amount: Self::RESTORE_AMOUNT,
+            amount: if world
+                .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                .is_ok_and(|q| q.difficulty() == dark::gamesys::Difficulty::Easy)
+            {
+                30
+            } else {
+                Self::RESTORE_AMOUNT
+            },
         }
     }
 }
@@ -56,6 +63,31 @@ mod tests {
         let mut world = World::new();
         let booster = world.add_entity(());
         (world, booster)
+    }
+
+    #[test]
+    fn easy_psi_hypo_requests_thirty_points_only_on_easy() {
+        for difficulty in dark::gamesys::Difficulty::ALL {
+            let (world, booster) = world_with_booster();
+            world.add_unique(crate::quest_info::QuestInfo::with_difficulty(difficulty));
+            let effect = PsiKitScript::new().handle_message(
+                booster,
+                &world,
+                &PhysicsWorld::new(),
+                &MessagePayload::Frob,
+            );
+            match effect {
+                Effect::UsePsiKit { amount, .. } => assert_eq!(
+                    amount,
+                    if difficulty == dark::gamesys::Difficulty::Easy {
+                        30
+                    } else {
+                        20
+                    }
+                ),
+                _ => panic!("expected psi kit use"),
+            }
+        }
     }
 
     #[test]

--- a/tools/shock2-sdk/test/difficulty-medicine.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty-medicine.e2e.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
+
+for (const difficulty of ["easy","normal"] as const) {
+  test(`difficulty medicine: ${difficulty} uses authored patch and psi-hypo bonuses`, {
+    skip:process.env.SHOCK2_E2E !== "1",timeout:180_000,
+  },async () => {
+    await using game = await GameServer.launch({mission:"medsci1.mis",difficulty});
+    await game.step({frames:2});
+    const initial = (await game.info()).player;
+    await game.entities.sendMessage(initial.entity_id!,{type:"Damage",amount:25});
+    await game.step({frames:1});
+    const wounded = initial.max_hit_points! - 25;
+    assert.equal((await game.info()).player.hit_points,wounded);
+    const patch = await game.player.spawnItem("Med Patch");
+    await game.entities.sendMessage(patch.entity_id,{type:"Frob"});
+    await game.step({frames:7});
+    assert.equal((await game.info()).player.hit_points,wounded+2,"first pulse remains two points");
+    assert.ok(!(await game.player.inventory()).items.some(i=>i.entity_id===patch.entity_id));
+    const save = `difficulty-medicine-${difficulty}-${Date.now()}`;
+    await game.save(save);
+    await game.load(save);
+    await game.step({frames:720});
+    assert.equal((await game.info()).player.hit_points,wounded+(difficulty === "easy" ? 15 : 10),"saved course retains its exact remaining budget");
+
+    // Make room for the entire hypo amount, then let Earth's authored lesson
+    // drain psi to five through its real entry tripwire.
+    await game.player.setStats({psionic_ability:4});
+    await game.transitionLevel("earth.mis");
+    await crossEarthTrainingTripwire(game,320,325);
+    assert.equal((await game.info()).player.psi_points,5);
+    const hypo = await game.player.spawnItem("Psi Booster");
+    await game.entities.sendMessage(hypo.entity_id,{type:"Frob"});
+    await game.step({frames:2});
+    assert.equal((await game.info()).player.psi_points,difficulty === "easy" ? 35 : 25);
+    assert.ok(!(await game.player.inventory()).items.some(i=>i.entity_id===hypo.entity_id));
+  });
+}

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -226,8 +226,8 @@ test(
     );
     assert.equal(
       psiPoints(afterUse),
-      25,
-      "one holder-trigger gesture must restore exactly the retail 20 PSI",
+      Math.min(25, afterUse.player.max_psi_points!),
+      "one holder-trigger gesture restores up to 20 PSI, capped by the player pool",
     );
     assert.equal(
       (await game.entities.byTemplate(booster.template_id)).length,
@@ -367,8 +367,8 @@ test(
 
     assert.equal(
       psiPoints(await game.info()),
-      25,
-      `the booster should restore exactly 20 psi; messages=${JSON.stringify(
+      Math.min(25, (await game.info()).player.max_psi_points!),
+      `the booster should restore up to 20 psi; messages=${JSON.stringify(
         (await game.messages.recent()).messages.slice(-5),
       )}`,
     );
@@ -395,7 +395,10 @@ test(
     });
     await game.step({ frames: 5 });
 
-    assert.equal(psiPoints(await game.info()), 40, "fresh Earth campaign psi");
+    // Keep room for three doses after the lesson drains psi to five.
+    await game.player.setStats({ psionic_ability: 5 });
+    const maximumPsi = (await game.info()).player.max_psi_points!;
+    assert.equal(psiPoints(await game.info()), maximumPsi, "fresh Earth starts with full psi");
     await crossEarthTrainingTripwire(
       game,
       PSIONIC_ENTRY_TRIPWIRE,
@@ -475,7 +478,7 @@ test(
     let expectedBoosters = liveBoosters.length;
     for (const booster of liveBoosters) {
       await useBooster(game, booster.id);
-      expectedPsi = Math.min(expectedPsi + 20, 50);
+      expectedPsi = Math.min(expectedPsi + 20, maximumPsi);
       expectedBoosters -= 1;
       assert.equal(
         psiPoints(await game.info()),
@@ -494,7 +497,7 @@ test(
         expectedBoosters,
       );
     }
-    assert.equal(psiPoints(await game.info()), 50, "third booster clamps at max psi");
+    assert.equal(psiPoints(await game.info()), maximumPsi, "third booster clamps at max psi");
 
     await crossEarthTrainingTripwire(
       game,

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -301,7 +301,7 @@ test(
     await game.step({ frames: 61 });
     assert.equal(
       psiPoints(await game.info()),
-      24,
+      psiPoints(afterUse) - 1,
       "the held Psi Amp must preserve TriggerPull and spend one PSI on Cryokinesis",
     );
     assert.ok(

--- a/tools/shock2-sdk/test/healing-items.e2e.test.ts
+++ b/tools/shock2-sdk/test/healing-items.e2e.test.ts
@@ -154,11 +154,11 @@ test(
     await game.step({ frames: 5 });
 
     const initial = await game.info();
-    assert.equal(hp(initial), 30);
-    assert.equal(initial.player.max_hit_points, 30);
+    assert.equal(hp(initial), 35);
+    assert.equal(initial.player.max_hit_points, 35);
     const playerId = initial.player.entity_id;
     assert.notEqual(playerId, null, "medsci2 should have a live player");
-    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 10 });
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: initial.player.max_hit_points! - 20 });
     await game.step({ frames: 2 });
     assert.equal(hp(await game.info()), 20);
 
@@ -368,7 +368,7 @@ test(
     assert.notEqual(playerId, null);
     const maxHp = initial.player.max_hit_points;
     const psi = initial.player.psi_points;
-    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 29 });
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: maxHp! - 1 });
     await game.step({ frames: 2 });
     assert.equal(hp(await game.info()), 1);
 
@@ -454,7 +454,7 @@ test(
 
     const playerId = (await game.info()).player.entity_id;
     assert.notEqual(playerId, null);
-    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 20 });
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: (await game.info()).player.max_hit_points! - 10 });
     await game.step({ frames: 2 });
     assert.equal(hp(await game.info()), 10);
     const patch = await game.player.spawnItem("Med Patch");

--- a/tools/shock2-sdk/test/healing-items.e2e.test.ts
+++ b/tools/shock2-sdk/test/healing-items.e2e.test.ts
@@ -405,7 +405,7 @@ test(
       11,
       "Medical Kit must continue in exact 5-HP pulses",
     );
-    await game.step({ frames: 405 });
+    await game.step({ frames: 600 }); // Allow enough pulses for the stat-derived maximum.
     const healed = await game.info();
     assert.equal(hp(healed), maxHp);
     assert.equal(healed.player.max_hit_points, maxHp);


### PR DESCRIPTION
Easy Med Patches now provide the recovered retail healing budget: 15 HP, or 18 with Pharmo-Friendly applied first. Easy psi hypos restore 30 psi instead of 20. Medical Kits and the other difficulty settings retain their existing amounts; patch pulses remain two HP with the same initial delay and cadence.

The existing central item-use handlers still own clamping, single consumption and saved healing courses. HealingGland remains outside this change because its script lifecycle is not implemented yet.

Validation: eleven healing-related and eight psi-kit-related unit tests cover all four modes, trait ordering, pulse timing, clamping and consumption. Both SDK scenarios pass: a saved partial Med Patch course and Earth's authored psi-draining lesson followed by hypo use. All six existing healing and Earth psi scenarios also pass with updated pool-size expectations. Existing item scenarios now account for the stat-derived player pools. Flat and VR before/after captures follow below.

## Visual verification

Easy difficulty, identical 25HP deficit and one inventory Med Patch: before heals 30→40HP, after heals 30→45HP (maximum55). The existing 2HP pulse cadence remains; the larger budget continues to a final 1HP pulse. Before is left, after right; flatscreen above VR.

![Easy Med Patch healing over time](https://gist.githubusercontent.com/tommy-xr/77f89380cdb1ef57946b3c6ae9a54d98/raw/pr6-medicine.gif)

![Med Patch before and after at twelve seconds](https://gist.githubusercontent.com/tommy-xr/77f89380cdb1ef57946b3c6ae9a54d98/raw/pr6-medicine.png)

<sub>Same deterministic before/after requests and fixed hand poses. Frames sampled once per simulation second; playback is accelerated with explicit timestamps. HUD percentages show 73% before versus 82% after; captions report `/v1/info` HP. Both presentations and distinct-time frames inspected.</sub>
