### PR TITLE
feat(difficulty): select a fixed difficulty for new campaigns

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -221,16 +221,20 @@ Steps are edge-triggered, so a held stick moves one place, and they are the same
 `StepPsiSelection` the readout's four arrows emit - the selection applies live,
 and the panel pages to whatever tier it lands on.
 
-### Campaign difficulty in debug runs
+### Campaign difficulty
 
-Start a fresh mission with `cargo dbgr --mission medsci1.mis --difficulty hard`.
+New Game offers Easy, Normal (the default), Hard, and Impossible. Choose a level,
+then Start Game; the choice is fixed for that campaign. Starting another game
+creates a fresh character and fresh mission state.
+
+For debug runs, use `cargo dbgr --mission medsci1.mis --difficulty hard`.
 The choices are `easy`, `normal` (default), `hard`, and `impossible`; the SDK
 accepts the same strings as `GameServer.launch({ mission, difficulty })`.
 Difficulty is fixed for a campaign and reported by `/v1/info` as
 `player.difficulty`. Saves and deck transitions retain it, including when loading
 an existing campaign from a runtime launched with a different choice. The generic
-quest-bit API cannot change it. Gameplay consumers are being added in the
-subsequent difficulty stack layers.
+quest-bit API cannot change it. The choice drives authored player pools, trainer
+and replicator prices, mission object masks, and Easy ecology and hypo bonuses.
 
 ### Developer options
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2074,6 +2074,26 @@ impl Game {
                 self.pending_transition = None;
                 self.set_active_scene(Box::new(LoadGameScene::new()));
             }
+            GlobalEffect::StartNewCampaign { difficulty } => {
+                self.pending_transition = None;
+                self.campaign_completed = false;
+                self.mission_to_save_data.clear();
+                // Seed the movie's carried state explicitly: the previous
+                // campaign and the cutscene's empty world must both be irrelevant.
+                self.preserved_scene_state = Some(PreservedSceneState {
+                    quest_info: QuestInfo::with_difficulty(difficulty),
+                    held_data: HeldItemSaveData::empty(),
+                    player_vitals: None,
+                    hazards: Default::default(),
+                    active_psi: Default::default(),
+                });
+                self.handle_global_effect(
+                    GlobalEffect::new_game_transition(
+                        scenes::main_menu::NEW_GAME_MISSION.to_owned(),
+                    )
+                    .after_cutscene(scenes::main_menu::NEW_GAME_CUTSCENE),
+                );
+            }
             GlobalEffect::ShowMainMenu => {
                 self.pending_transition = None;
                 // The flag means "the finale is on screen", so reaching the menu

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -3,12 +3,12 @@
 //! A minimal `GameScene` that draws the original `MAIN.PCX` backdrop with the
 //! six mouse-clickable menu entries, described on the shared [`UiCanvas`]. It
 //! reads `InputContext::pointer` (normalized screen coords) and emits a
-//! `GlobalEffect` on click: New Game -> `TransitionLevel` into the first
-//! mission, Quit -> `Quit`. Entries the port does not implement yet are drawn
+//! `GlobalEffect` on click. New Game opens a difficulty selection page, then
+//! starts a fresh campaign; Quit emits `Quit`. Unimplemented entries are drawn
 //! dimmed and ignore clicks.
 //!
-//! Everything the screen needs is read from the shipped data rather than
-//! hardcoded: labels from `MAIN.STR`, button rects from `MAINR.BIN`. That
+//! Main-menu labels come from `MAIN.STR` and button rects from `MAINR.BIN`.
+//! The difficulty page reuses those rects with the retail difficulty labels. That
 //! matters beyond fidelity - the community mod layers (SCP) ship a redrawn
 //! backdrop *with a retuned `*R.BIN`*, so a hardcoded rect is wrong on a
 //! modded install.
@@ -49,11 +49,11 @@ use crate::{
 use std::collections::HashMap;
 
 /// Mission loaded when the player chooses "New Game".
-const NEW_GAME_MISSION: &str = "earth.mis";
+pub(crate) const NEW_GAME_MISSION: &str = "earth.mis";
 /// The intro movie the original played on New Game, before the first level.
 /// Only this button gets it - the developer launcher boots the same level with
 /// no cutscene, and a load resumes straight into the save.
-const NEW_GAME_CUTSCENE: &str = "cs1.avi";
+pub(crate) const NEW_GAME_CUTSCENE: &str = "cs1.avi";
 
 /// The menu is authored on the original 640x480 `MAIN.PCX` canvas.
 const CANVAS_W: f32 = 640.0;
@@ -87,6 +87,9 @@ const FALLBACK_BUTTON_PITCH: f32 = 76.0;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MenuAction {
     NewGame,
+    ChooseDifficulty(dark::gamesys::Difficulty),
+    StartCampaign,
+    Back,
     LoadGame,
     Developer,
     Quit,
@@ -213,6 +216,15 @@ fn resolve_click_at(
 
 /// The menu entry at a canvas point, if any. Shared by the click and the
 /// rollover sound so the two can never disagree about where an entry is.
+fn difficulty_hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
+    let index = rects.iter().take(6).position(|rect| rect.contains(point))?;
+    Some(match index {
+        0..=3 => MenuAction::ChooseDifficulty(dark::gamesys::Difficulty::ALL[index]),
+        4 => MenuAction::StartCampaign,
+        _ => MenuAction::Back,
+    })
+}
+
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
     hit_menu_item(point, MENU_ITEMS, rects, |_| true)
 }
@@ -241,6 +253,8 @@ pub struct MainMenuScene {
     world: World,
     scene_name: String,
     menu: FrontendMenu<MenuAction>,
+    choosing_difficulty: bool,
+    difficulty: dark::gamesys::Difficulty,
 }
 
 impl MainMenuScene {
@@ -250,6 +264,8 @@ impl MainMenuScene {
         Self {
             world,
             scene_name: "main_menu".to_owned(),
+            choosing_difficulty: false,
+            difficulty: dark::gamesys::Difficulty::Normal,
             menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
         }
     }
@@ -276,6 +292,45 @@ impl MainMenuScene {
         // Button rects come from the original `MAINR.BIN` layout and labels
         // from `MAIN.STR` (both cached by the asset cache after first load).
         let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        if self.choosing_difficulty {
+            canvas.text_native(
+                Rect::new(20.0, 190.0, 280.0, 35.0),
+                "Choose difficulty",
+                MENU_FONT,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+            canvas.text(
+                Rect::new(20.0, 232.0, 280.0, 35.0),
+                "Fixed for this campaign",
+                MENU_FONT,
+                16.0,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+            let labels: Vec<String> = dark::gamesys::Difficulty::ALL
+                .into_iter()
+                .map(|d| {
+                    if d == self.difficulty {
+                        format!("> {} <", d.label())
+                    } else {
+                        d.label().to_owned()
+                    }
+                })
+                .chain(["Start Game".to_owned(), "Back".to_owned()])
+                .collect();
+            for (rect, label) in rects.iter().zip(labels) {
+                let opacity = if pointer_canvas.is_some_and(|point| rect.contains(point)) {
+                    HOVER_OPACITY
+                } else {
+                    IDLE_OPACITY
+                };
+                canvas
+                    .text_native(*rect, &label, MENU_FONT, HAlign::Center, VAlign::Middle)
+                    .opacity(opacity);
+            }
+            return canvas;
+        }
         let labels = self.menu.labels(asset_cache, LABELS_FILE, MENU_ITEMS);
         for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
             let opacity = if item.action.is_none() {
@@ -317,16 +372,40 @@ impl GameScene for MainMenuScene {
             time.elapsed,
             input_context,
             game_options.presentation_mode,
-            |point| hit(point, &rects),
-            |point| hit(point, &rects),
+            |point| {
+                if self.choosing_difficulty {
+                    difficulty_hit(point, &rects)
+                } else {
+                    hit(point, &rects)
+                }
+            },
+            |point| {
+                if self.choosing_difficulty {
+                    difficulty_hit(point, &rects)
+                } else {
+                    hit(point, &rects)
+                }
+            },
         );
 
         match action {
             Some(MenuAction::NewGame) => {
-                vec![Effect::GlobalEffect(
-                    GlobalEffect::new_game_transition(NEW_GAME_MISSION.to_owned())
-                        .after_cutscene(NEW_GAME_CUTSCENE),
-                )]
+                self.choosing_difficulty = true;
+                self.difficulty = dark::gamesys::Difficulty::Normal;
+                Vec::new()
+            }
+            Some(MenuAction::ChooseDifficulty(difficulty)) => {
+                self.difficulty = difficulty;
+                Vec::new()
+            }
+            Some(MenuAction::Back) => {
+                self.choosing_difficulty = false;
+                Vec::new()
+            }
+            Some(MenuAction::StartCampaign) => {
+                vec![Effect::GlobalEffect(GlobalEffect::StartNewCampaign {
+                    difficulty: self.difficulty,
+                })]
             }
             Some(MenuAction::LoadGame) => {
                 vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
@@ -419,6 +498,30 @@ mod tests {
     // The runtimes render at a 4:3 resolution, so PreserveAspect == stretch and
     // normalized coords map straight to the 640x480 canvas.
     const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
+
+    #[test]
+    fn difficulty_page_maps_four_choices_start_and_back_to_shared_rects() {
+        for (index, difficulty) in dark::gamesys::Difficulty::ALL.into_iter().enumerate() {
+            let rect = FALLBACK_RECTS[index];
+            assert_eq!(
+                difficulty_hit(
+                    vec2(rect.x + rect.w / 2.0, rect.y + rect.h / 2.0),
+                    &FALLBACK_RECTS
+                ),
+                Some(MenuAction::ChooseDifficulty(difficulty))
+            );
+        }
+        for (index, action) in [(4, MenuAction::StartCampaign), (5, MenuAction::Back)] {
+            let rect = FALLBACK_RECTS[index];
+            assert_eq!(
+                difficulty_hit(
+                    vec2(rect.x + rect.w / 2.0, rect.y + rect.h / 2.0),
+                    &FALLBACK_RECTS
+                ),
+                Some(action)
+            );
+        }
+    }
 
     #[test]
     fn rising_edge_over_new_game_activates_it() {

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -8,7 +8,7 @@
 //! dimmed and ignore clicks.
 //!
 //! Main-menu labels come from `MAIN.STR` and button rects from `MAINR.BIN`.
-//! The difficulty page reuses those rects with the retail difficulty labels. That
+//! The difficulty page uses `NEWGAME.PCX`, `NEWGAME.STR` and `NEWGAMER.BIN`. That
 //! matters beyond fidelity - the community mod layers (SCP) ship a redrawn
 //! backdrop *with a retuned `*R.BIN`*, so a hardcoded rect is wrong on a
 //! modded install.
@@ -76,6 +76,22 @@ const IDLE_OPACITY: f32 = 0.6;
 /// Opacity for the entry under the pointer.
 const HOVER_OPACITY: f32 = 1.0;
 
+const NEW_GAME_LAYOUT_FILE: &str = "NEWGAMER.BIN";
+const NEW_GAME_LABELS_FILE: &str = "NEWGAME.STR";
+// Raw NEWGAMER.BIN order: title, four difficulty buttons, Start, Options,
+// Cancel. Retail drkpanl.cpp remaps raw indices through rect_newgame before
+// using shkmenu.cpp's enum; this port keeps the file order directly.
+const NEW_GAME_RECTS: [Rect; 8] = [
+    Rect::new(257.0, 21.0, 126.0, 25.0),
+    Rect::new(4.0, 66.0, 152.0, 60.0),
+    Rect::new(164.0, 66.0, 152.0, 60.0),
+    Rect::new(324.0, 66.0, 152.0, 60.0),
+    Rect::new(484.0, 66.0, 152.0, 60.0),
+    Rect::new(305.0, 264.0, 143.0, 64.0),
+    Rect::new(305.0, 332.0, 143.0, 64.0),
+    Rect::new(305.0, 400.0, 143.0, 64.0),
+];
+
 // Fallback button geometry, used only when `MAINR.BIN` is missing: the decoded
 // vanilla values - a column of six 179x60 buttons at x=400 on a 76px pitch.
 const FALLBACK_BUTTON_X: f32 = 400.0;
@@ -94,6 +110,65 @@ enum MenuAction {
     Developer,
     Quit,
 }
+
+const NEW_GAME_ITEMS: &[FrontendMenuItem<MenuAction>] = &[
+    FrontendMenuItem {
+        string_key: "difficulty",
+        fallback_label: "Difficulty:",
+        action: None,
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "diff_0",
+        fallback_label: "Easy",
+        action: Some(MenuAction::ChooseDifficulty(
+            dark::gamesys::Difficulty::Easy,
+        )),
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "diff_1",
+        fallback_label: "Normal",
+        action: Some(MenuAction::ChooseDifficulty(
+            dark::gamesys::Difficulty::Normal,
+        )),
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "diff_2",
+        fallback_label: "Hard",
+        action: Some(MenuAction::ChooseDifficulty(
+            dark::gamesys::Difficulty::Hard,
+        )),
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "diff_3",
+        fallback_label: "Impossible",
+        action: Some(MenuAction::ChooseDifficulty(
+            dark::gamesys::Difficulty::Impossible,
+        )),
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "start",
+        fallback_label: "Start Game",
+        action: Some(MenuAction::StartCampaign),
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "options",
+        fallback_label: "Options",
+        action: None,
+        label_override: None,
+    },
+    FrontendMenuItem {
+        string_key: "cancel",
+        fallback_label: "Cancel",
+        action: Some(MenuAction::Back),
+        label_override: None,
+    },
+];
 
 // MAIN.PCX (native 640x480) has a vertical stack of six buttons down the right
 // side. This list is in screen order, top to bottom, so an item's index is also
@@ -217,12 +292,7 @@ fn resolve_click_at(
 /// The menu entry at a canvas point, if any. Shared by the click and the
 /// rollover sound so the two can never disagree about where an entry is.
 fn difficulty_hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
-    let index = rects.iter().take(6).position(|rect| rect.contains(point))?;
-    Some(match index {
-        0..=3 => MenuAction::ChooseDifficulty(dark::gamesys::Difficulty::ALL[index]),
-        4 => MenuAction::StartCampaign,
-        _ => MenuAction::Back,
-    })
+    hit_menu_item(point, NEW_GAME_ITEMS, rects, |_| true)
 }
 
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
@@ -285,52 +355,50 @@ impl MainMenuScene {
     ) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
 
-        // Full-screen backdrop.
-        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "MAIN.PCX");
-
-        // Menu items, centered in their button and brighter when hovered.
-        // Button rects come from the original `MAINR.BIN` layout and labels
-        // from `MAIN.STR` (both cached by the asset cache after first load).
-        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
         if self.choosing_difficulty {
-            canvas.text_native(
-                Rect::new(20.0, 190.0, 280.0, 35.0),
-                "Choose difficulty",
-                MENU_FONT,
-                HAlign::Center,
-                VAlign::Middle,
-            );
+            canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "NEWGAME.PCX");
+            let rects = self
+                .menu
+                .rects(asset_cache, NEW_GAME_LAYOUT_FILE, &NEW_GAME_RECTS);
+            let labels = self
+                .menu
+                .labels(asset_cache, NEW_GAME_LABELS_FILE, NEW_GAME_ITEMS);
+            for (index, ((item, rect), label)) in
+                NEW_GAME_ITEMS.iter().zip(&rects).zip(labels).enumerate()
+            {
+                let selected = item.action == Some(MenuAction::ChooseDifficulty(self.difficulty));
+                let label = if selected {
+                    format!("> {} <", label)
+                } else {
+                    label
+                };
+                let opacity = if index == 0 || selected {
+                    HOVER_OPACITY
+                } else if item.action.is_none() {
+                    // Retail's Options slot is visible but unavailable until a
+                    // real options screen exists; it cannot discard this selection.
+                    DISABLED_OPACITY
+                } else if pointer_canvas.is_some_and(|point| rect.contains(point)) {
+                    HOVER_OPACITY
+                } else {
+                    IDLE_OPACITY
+                };
+                canvas
+                    .text_native_fit(*rect, &label, MENU_FONT, HAlign::Center, VAlign::Middle)
+                    .opacity(opacity);
+            }
             canvas.text(
-                Rect::new(20.0, 232.0, 280.0, 35.0),
+                Rect::new(4.0, 130.0, 632.0, 25.0),
                 "Fixed for this campaign",
                 MENU_FONT,
                 16.0,
                 HAlign::Center,
                 VAlign::Middle,
             );
-            let labels: Vec<String> = dark::gamesys::Difficulty::ALL
-                .into_iter()
-                .map(|d| {
-                    if d == self.difficulty {
-                        format!("> {} <", d.label())
-                    } else {
-                        d.label().to_owned()
-                    }
-                })
-                .chain(["Start Game".to_owned(), "Back".to_owned()])
-                .collect();
-            for (rect, label) in rects.iter().zip(labels) {
-                let opacity = if pointer_canvas.is_some_and(|point| rect.contains(point)) {
-                    HOVER_OPACITY
-                } else {
-                    IDLE_OPACITY
-                };
-                canvas
-                    .text_native(*rect, &label, MENU_FONT, HAlign::Center, VAlign::Middle)
-                    .opacity(opacity);
-            }
             return canvas;
         }
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "MAIN.PCX");
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
         let labels = self.menu.labels(asset_cache, LABELS_FILE, MENU_ITEMS);
         for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
             let opacity = if item.action.is_none() {
@@ -367,7 +435,12 @@ impl GameScene for MainMenuScene {
             *world_time = time.clone();
         }
 
-        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let rects = if self.choosing_difficulty {
+            self.menu
+                .rects(asset_cache, NEW_GAME_LAYOUT_FILE, &NEW_GAME_RECTS)
+        } else {
+            self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS)
+        };
         let action = self.menu.update(
             time.elapsed,
             input_context,
@@ -500,27 +573,52 @@ mod tests {
     const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
 
     #[test]
-    fn difficulty_page_maps_four_choices_start_and_back_to_shared_rects() {
+    fn difficulty_page_maps_four_choices_start_and_cancel_to_retail_rects() {
+        let center = |index: usize| {
+            let rect = NEW_GAME_RECTS[index];
+            vec2(rect.x + rect.w / 2.0, rect.y + rect.h / 2.0)
+        };
         for (index, difficulty) in dark::gamesys::Difficulty::ALL.into_iter().enumerate() {
-            let rect = FALLBACK_RECTS[index];
             assert_eq!(
-                difficulty_hit(
-                    vec2(rect.x + rect.w / 2.0, rect.y + rect.h / 2.0),
-                    &FALLBACK_RECTS
-                ),
+                difficulty_hit(center(index + 1), &NEW_GAME_RECTS),
                 Some(MenuAction::ChooseDifficulty(difficulty))
             );
         }
-        for (index, action) in [(4, MenuAction::StartCampaign), (5, MenuAction::Back)] {
-            let rect = FALLBACK_RECTS[index];
-            assert_eq!(
-                difficulty_hit(
-                    vec2(rect.x + rect.w / 2.0, rect.y + rect.h / 2.0),
-                    &FALLBACK_RECTS
-                ),
-                Some(action)
-            );
-        }
+        assert_eq!(
+            difficulty_hit(center(5), &NEW_GAME_RECTS),
+            Some(MenuAction::StartCampaign)
+        );
+        assert_eq!(
+            difficulty_hit(center(7), &NEW_GAME_RECTS),
+            Some(MenuAction::Back)
+        );
+        assert_eq!(
+            difficulty_hit(center(0), &NEW_GAME_RECTS),
+            None,
+            "the heading is not a button"
+        );
+        assert_eq!(
+            difficulty_hit(center(6), &NEW_GAME_RECTS),
+            None,
+            "unimplemented Options is disabled"
+        );
+    }
+
+    #[test]
+    fn difficulty_labels_use_the_newgame_string_keys_and_localized_values() {
+        let strings = HashMap::from([
+            ("difficulty".to_owned(), "Schwierigkeit:".to_owned()),
+            ("diff_0".to_owned(), "Leicht".to_owned()),
+            ("cancel".to_owned(), "Abbrechen".to_owned()),
+        ]);
+        let labels = resolve_menu_labels(Some(&strings), NEW_GAME_ITEMS);
+        assert_eq!(labels[0], "Schwierigkeit:");
+        assert_eq!(labels[1], "Leicht");
+        assert_eq!(labels[7], "Abbrechen");
+        assert_eq!(
+            labels[2], "Normal",
+            "missing strings have readable fallbacks"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -66,6 +66,11 @@ pub enum GlobalEffect {
     /// Return to the main menu, replacing whatever scene is active.
     ShowMainMenu,
 
+    /// Begin a fresh campaign with a fixed difficulty, clearing the previous ledger.
+    StartNewCampaign {
+        difficulty: dark::gamesys::Difficulty,
+    },
+
     /// Open the pause menu over the active scene. The scene cannot open it
     /// itself - the overlay is `Game`'s, and a paused scene is not updated at
     /// all - so the cyber interface's system button asks for it this way.

--- a/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
+++ b/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { isCutsceneScene, stepPastCutscenes } from "./helpers/cutscenes.js";
-import { clickMenuEntry } from "./helpers/frontend-menu.js";
+import { clickMenuEntry, clickCanvas, newGameEntry } from "./helpers/frontend-menu.js";
 
 // The authored campaign moments play their movie before the level they lead to.
 // Negative-first: before the wiring each of these transitions swapped straight
@@ -33,7 +33,8 @@ test(
     await game.step({ frames: 10 });
 
     await clickMenuEntry(game, NEW_GAME_ENTRY);
-    await clickMenuEntry(game, 4); // Start Game, accepting Normal.
+    const [u,v] = newGameEntry("start");
+    await clickCanvas(game, [u*640,v*480]); // Start Game, accepting Normal.
 
     // The intro runs for minutes, so this stops at "the movie is what is on
     // screen, and earth.mis is not loaded yet" rather than playing it out.

--- a/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
+++ b/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
@@ -33,6 +33,7 @@ test(
     await game.step({ frames: 10 });
 
     await clickMenuEntry(game, NEW_GAME_ENTRY);
+    await clickMenuEntry(game, 4); // Start Game, accepting Normal.
 
     // The intro runs for minutes, so this stops at "the movie is what is on
     // screen, and earth.mis is not loaded yet" rather than playing it out.

--- a/tools/shock2-sdk/test/difficulty-new-game.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty-new-game.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { GameServer } from "../src/index.js";
-import { clickMenuEntry, clickCanvas, pauseEntry, menuEntry, panelPoint, AIM_AT_PANEL } from "./helpers/frontend-menu.js";
+import { clickCanvas, pauseEntry, menuEntry, newGameEntry, panelPoint, AIM_AT_PANEL } from "./helpers/frontend-menu.js";
 async function finishIntro(game:GameServer) {
   // Exercise the real hold-to-skip path rather than render the entire movie.
   await game.input.set("right_hand.trigger",1);
@@ -12,9 +12,9 @@ async function finishIntro(game:GameServer) {
 }
 
 const enabled=process.env.SHOCK2_E2E === "1";
-async function click(game:GameServer,index:number,vr=false) {
-  if (!vr) return clickMenuEntry(game,index);
-  const [,y,z]=panelPoint(menuEntry(index));
+async function click(game:GameServer,point:[number,number],vr=false) {
+  if (!vr) return clickCanvas(game,[point[0]*640,point[1]*480]);
+  const [,y,z]=panelPoint(point);
   await game.input.set("right_hand.position",[0,y,z]);
   await game.input.set("right_hand.rotation",AIM_AT_PANEL);
   for (const trigger of [0,1,0]) {
@@ -22,19 +22,21 @@ async function click(game:GameServer,index:number,vr=false) {
     await game.step({frames:5});
   }
 }
-for (const [difficulty,index] of [["easy",0],["normal",1],["hard",2],["impossible",3]] as const) {
+for (const difficulty of ["easy","normal","hard","impossible"] as const) {
   test(`new campaign: ${difficulty} selection survives the intro`,{skip:!enabled,timeout:120_000},async()=>{
     await using game=await GameServer.launch({mission:"main_menu",difficulty:"hard"});
     await game.step({frames:10});
-    await click(game,0);
+    await click(game,menuEntry(0));
     assert.equal((await game.info()).mission,"main_menu","selection precedes the intro");
     if (difficulty === "normal") {
-      await click(game,2); // Change the pending selection, then cancel it.
-      await click(game,5);
-      await click(game,0);
+      await click(game,newGameEntry("hard")); // Change the pending selection, then cancel it.
+      await click(game,newGameEntry("cancel"));
+      await click(game,menuEntry(0));
       // Starting without another choice must use the Normal default.
-    } else await click(game,index);
-    await click(game,4);
+    } else await click(game,newGameEntry(difficulty));
+    await click(game,newGameEntry("options"));
+    assert.equal((await game.info()).mission,"main_menu","unimplemented Options does not leave the selection page");
+    await click(game,newGameEntry("start"));
     assert.equal((await game.info()).mission,"cs1.avi");
     await finishIntro(game);
     const info=await game.info();
@@ -46,9 +48,9 @@ for (const [difficulty,index] of [["easy",0],["normal",1],["hard",2],["impossibl
 test("new campaign: VR controller selects Impossible",{skip:!enabled,timeout:120_000},async()=>{
   await using game=await GameServer.launch({mission:"main_menu",debugFlags:["--vr"]});
   await game.step({frames:10});
-  await click(game,0,true);
-  await click(game,3,true);
-  await click(game,4,true);
+  await click(game,menuEntry(0),true);
+  await click(game,newGameEntry("impossible"),true);
+  await click(game,newGameEntry("start"),true);
   assert.equal((await game.info()).mission,"cs1.avi");
   await finishIntro(game);
   assert.equal((await game.info()).player.difficulty,"impossible");
@@ -63,9 +65,9 @@ test("new campaign: previous character and visited missions are cleared",{skip:!
   await clickCanvas(game,pauseEntry(4));
   await game.step({frames:10});
   assert.equal((await game.info()).mission,"main_menu");
-  await click(game,0);
-  await click(game,0); // Easy
-  await click(game,4);
+  await click(game,menuEntry(0));
+  await click(game,newGameEntry("easy")); // Easy
+  await click(game,newGameEntry("start"));
   await finishIntro(game);
   const fresh=(await game.info()).player;
   assert.equal(fresh.difficulty,"easy");

--- a/tools/shock2-sdk/test/difficulty-new-game.e2e.test.ts
+++ b/tools/shock2-sdk/test/difficulty-new-game.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { clickMenuEntry, clickCanvas, pauseEntry, menuEntry, panelPoint, AIM_AT_PANEL } from "./helpers/frontend-menu.js";
+async function finishIntro(game:GameServer) {
+  // Exercise the real hold-to-skip path rather than render the entire movie.
+  await game.input.set("right_hand.trigger",1);
+  await game.step({frames:125});
+  await game.input.set("right_hand.trigger",0);
+  await game.step({frames:5});
+  assert.equal((await game.info()).mission,"earth.mis");
+}
+
+const enabled=process.env.SHOCK2_E2E === "1";
+async function click(game:GameServer,index:number,vr=false) {
+  if (!vr) return clickMenuEntry(game,index);
+  const [,y,z]=panelPoint(menuEntry(index));
+  await game.input.set("right_hand.position",[0,y,z]);
+  await game.input.set("right_hand.rotation",AIM_AT_PANEL);
+  for (const trigger of [0,1,0]) {
+    await game.input.set("right_hand.trigger",trigger);
+    await game.step({frames:5});
+  }
+}
+for (const [difficulty,index] of [["easy",0],["normal",1],["hard",2],["impossible",3]] as const) {
+  test(`new campaign: ${difficulty} selection survives the intro`,{skip:!enabled,timeout:120_000},async()=>{
+    await using game=await GameServer.launch({mission:"main_menu",difficulty:"hard"});
+    await game.step({frames:10});
+    await click(game,0);
+    assert.equal((await game.info()).mission,"main_menu","selection precedes the intro");
+    if (difficulty === "normal") {
+      await click(game,2); // Change the pending selection, then cancel it.
+      await click(game,5);
+      await click(game,0);
+      // Starting without another choice must use the Normal default.
+    } else await click(game,index);
+    await click(game,4);
+    assert.equal((await game.info()).mission,"cs1.avi");
+    await finishIntro(game);
+    const info=await game.info();
+    assert.equal(info.mission,"earth.mis");
+    assert.equal(info.player.difficulty,difficulty);
+    assert.equal(info.player.max_hit_points,{easy:55,normal:35,hard:27,impossible:10}[difficulty]);
+  });
+}
+test("new campaign: VR controller selects Impossible",{skip:!enabled,timeout:120_000},async()=>{
+  await using game=await GameServer.launch({mission:"main_menu",debugFlags:["--vr"]});
+  await game.step({frames:10});
+  await click(game,0,true);
+  await click(game,3,true);
+  await click(game,4,true);
+  assert.equal((await game.info()).mission,"cs1.avi");
+  await finishIntro(game);
+  assert.equal((await game.info()).player.difficulty,"impossible");
+});
+test("new campaign: previous character and visited missions are cleared",{skip:!enabled,timeout:180_000},async()=>{
+  await using game=await GameServer.launch({mission:"medsci1.mis",difficulty:"impossible"});
+  await game.player.setStats({endurance:4,cyber_modules:99});
+  assert.equal((await game.entities.byTemplate(1363)).length,0);
+  await game.transitionLevel("earth.mis"); // Records the old filtered MedSci deck.
+  await game.input.trigger("TogglePauseMenu");
+  await game.step({frames:10});
+  await clickCanvas(game,pauseEntry(4));
+  await game.step({frames:10});
+  assert.equal((await game.info()).mission,"main_menu");
+  await click(game,0);
+  await click(game,0); // Easy
+  await click(game,4);
+  await finishIntro(game);
+  const fresh=(await game.info()).player;
+  assert.equal(fresh.difficulty,"easy");
+  assert.equal(fresh.stats?.endurance,1);
+  assert.equal(fresh.stats?.cyber_modules,0);
+  await game.transitionLevel("medsci1.mis");
+  assert.equal((await game.entities.byTemplate(1363)).length,1,"fresh Easy deck replaces the old Impossible snapshot");
+  assert.equal((await game.info()).player.hit_points,55);
+});

--- a/tools/shock2-sdk/test/helpers/frontend-menu.ts
+++ b/tools/shock2-sdk/test/helpers/frontend-menu.ts
@@ -16,6 +16,15 @@ export const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y
 export const menuEntry = (index: number): [number, number] =>
   norm(400 + 179 / 2, 20 + index * 76 + 60 / 2);
 
+/** Normalized centers of the retail NEWGAMER.BIN controls. */
+export function newGameEntry(control: "easy" | "normal" | "hard" | "impossible" | "start" | "options" | "cancel"): [number, number] {
+  const centers: Record<typeof control, [number, number]> = {
+    easy: [80, 96], normal: [240, 96], hard: [400, 96], impossible: [560, 96],
+    start: [376.5, 296], options: [376.5, 364], cancel: [376.5, 432],
+  };
+  return norm(...centers[control]);
+}
+
 /**
  * Click one main-menu entry with the flat pointer. Clicks are rising-edge, so
  * the press has to start on a frame where the previous one was unpressed.


### PR DESCRIPTION
New Game opens the retail difficulty screen using NEWGAME.PCX for artwork, NEWGAMER.BIN for its layout, and NEWGAME.STR for labels. Easy, Normal, Hard and Impossible appear across the top, with Normal selected by default. Start Game begins the intro; Cancel returns to the main menu. The authored Options control is visibly disabled until a settings screen is implemented.

Both flat and VR presentation render and hit-test the same resolved canvas. Difficulty is fixed for the campaign. Starting a campaign clears the previous mission ledger and seeds a fresh character with the selected difficulty, so an old character or visited deck cannot leak into the new game.

Validation: 23 menu-related unit tests cover shared hit regions, disabled controls, localized labels and fallbacks. All six SDK new-campaign scenarios pass through the retail layout, including every difficulty, Cancel/defaulting, disabled Options, real VR controller input, intro skip, and an Easy campaign replacing a visited Impossible deck. The following PNG and GIF compare the earlier reused main-menu screen with the retail assets in both presentations.

## Visual verification

The retail `NEWGAME.PCX`, `NEWGAMER.BIN` and `NEWGAME.STR` replace the reused main-menu layout. Before is left, retail assets are right; flatscreen above VR. Both runs follow the same choices: initial Normal, then Easy, Hard and Impossible. Labels and selection markers fit the authored horizontal rectangles, and the fixed-campaign subtitle fits below them.

![Retail new-game layout and selection comparison](https://gist.githubusercontent.com/tommy-xr/38bdd378c4c02b39a1440a4607707d64/raw/pr7-retail-menu.gif)

![Before and after retail new-game assets in flat and VR](https://gist.githubusercontent.com/tommy-xr/38bdd378c4c02b39a1440a4607707d64/raw/pr7-retail-menu.png)

The flat pointer and real VR controller ray/trigger each selected Impossible, pressed Start Game, skipped the intro with a trigger hold, and reached `earth.mis` with `difficulty=impossible` and maximum HP10. Options is visibly disabled.

<sub>Identical semantic actions target each layout’s authored rectangles using immutable before/after binaries. Captured with deterministic stepping; selection states are held longer in the loop for readability. Both presentations, subtitle placement and VR hit/selection agreement inspected.</sub>
