### PR TITLE
fix(annelid): launch hatching grubs toward the opener and play pod audio

### DIFF
--- a/projects/grub-ai.md
+++ b/projects/grub-ai.md
@@ -104,3 +104,25 @@ Reference implementations examined:
 [joint tweqs](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/ENGFEAT/TWEQCTRL.CPP),
 [object articulation](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/DarkEngine/LIBSRC/MD/RENDER.C),
 and [AI velocity control](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/AI/AIUTILS.CPP).
+
+## Pod emergence and hatch audio
+
+`BaseEgg` gives a newly hatched grub an initial world-space velocity toward
+its opener: 2.4 units/s horizontally and 3 units/s upward (an unobstructed
+rise of about .46 units). GrubAI preserves the ballistic launch until support
+is acquired, then resumes ordinary movement. Direct actor senders are honored;
+mission tripwires/relays identify themselves in `TurnOn`, so those use the live
+player position. Without a target, the pod's horizontal facing is used.
+
+These launch constants are a deliberate gameplay fallback, not claimed retail
+parity. The [script reference](https://thiefmissions.com/telliamed/allscripts.html)
+identifies GrubEgg's payload but does not specify its launch vector. The shipped
+Grub template has no initial-velocity property, and the available engine source
+does not include the egg script implementation. We did not establish the vector
+from the shipped, stripped `allobjs.osm` either. Previously, the rec1 elevator
+pod's grub dropped into its shell and waited for an AI hop to escape.
+
+Every egg plays the authored `pod_exp` schema once, spatially at its shell.
+The schema maps to the available `eggopen1` / `eggopen2` samples. The existing
+saved hatch latch suppresses repeated payload creation and audio. Goo emission
+and swarmer flight retain their existing velocity behavior.

--- a/shock2vr/src/scripts/base_egg.rs
+++ b/shock2vr/src/scripts/base_egg.rs
@@ -1,10 +1,13 @@
-use cgmath::vec3;
-use dark::properties::PropPosition;
+use cgmath::{InnerSpace, Quaternion, Vector3, vec3};
+use dark::properties::{PropAI, PropCreature, PropPosition};
+use engine::audio::AudioHandle;
 use serde::{Deserialize, Serialize};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    mission::entity_creator::CreateEntityOptions, physics::PhysicsWorld, util::vec3_to_point3,
+    mission::{PlayerInfo, entity_creator::CreateEntityOptions},
+    physics::PhysicsWorld,
+    util::vec3_to_point3,
 };
 
 use super::{
@@ -95,9 +98,9 @@ impl Script for BaseEgg {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+        let MessagePayload::TurnOn { from } = msg else {
             return Effect::NoEffect;
-        }
+        };
         // A pod hatches once. Its tripwire is authored ONCE, but a pod can
         // also be reached by a relayed TurnOn, and a second clutch of grubs
         // from a shell that is already open is not a thing the game does.
@@ -117,7 +120,20 @@ impl Script for BaseEgg {
         self.hatched = true;
 
         let lift = self.payload.lift();
-        let mut effects = vec![change_to_last_model(world, entity_id)];
+        let initial_velocity = if matches!(self.payload, EggPayload::Grub) {
+            grub_emergence_velocity(position, rotation, opener_position(world, *from))
+        } else {
+            vec3(0.0, 0.0, 0.0)
+        };
+        let mut effects = vec![
+            change_to_last_model(world, entity_id),
+            Effect::PlaySound {
+                handle: AudioHandle::new(),
+                name: "pod_exp".into(),
+                source: Some(entity_id),
+                spatial: true,
+            },
+        ];
         effects.extend(self.payload.template_names().iter().map(|template_name| {
             Effect::CreateEntityByTemplateName {
                 source_entity_id: entity_id,
@@ -125,9 +141,9 @@ impl Script for BaseEgg {
                 position: vec3_to_point3(position + rotation * vec3(0.0, lift, 0.0)),
                 // The pod's own facing: a wall pod hatches out of the wall.
                 orientation: rotation,
-                // The payloads carry their own motion: the emitter's tweq
-                // launches the goo, and a creature walks or flies.
-                initial_velocity: vec3(0.0, 0.0, 0.0),
+                // GrubAI preserves this launch until landing. Goo and swarm
+                // motion remains owned by their emitter / flight controller.
+                initial_velocity,
                 // Ordinary creation, NOT the emitter's launched-projectile
                 // mode: that path installs the template's authored projectile
                 // sphere, and the Swarm's is zero-radius, so the visible
@@ -171,3 +187,147 @@ const GOO_MUZZLE_CLEARANCE: f32 = 1.2;
 /// The lip of an open pod, measured off the shell's own bounds (its top sits
 /// 0.78 above the origin), so a hatched creature sits in the shell's mouth.
 const SHELL_MOUTH: f32 = 0.8;
+
+/// TurnOn identifies the sender, which is usually a relay/tripwire rather
+/// than its activator. Honor a direct actor sender; use the live player for
+/// relayed mission triggers, whose messages do not preserve that provenance.
+fn opener_position(world: &World, from: EntityId) -> Option<Vector3<f32>> {
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok();
+    if let Some(player) = &player {
+        if from == player.entity_id {
+            return Some(player.pos);
+        }
+    }
+    let actor = world
+        .borrow::<View<PropAI>>()
+        .ok()
+        .is_some_and(|v| v.get(from).is_ok())
+        || world
+            .borrow::<View<PropCreature>>()
+            .ok()
+            .is_some_and(|v| v.get(from).is_ok());
+    if actor {
+        if let Some(position) = world
+            .borrow::<View<PropPosition>>()
+            .ok()
+            .and_then(|v| v.get(from).ok().map(|p| p.position))
+        {
+            return Some(position);
+        }
+    }
+    player.map(|p| p.pos)
+}
+
+/// Deliberate fallback, not a recovered retail constant: a short arc toward
+/// the opener clears the lip instead of dropping the grub inside the shell.
+/// Keep a world-up component even for wall pods; gravity is world-down.
+fn grub_emergence_velocity(
+    position: Vector3<f32>,
+    rotation: Quaternion<f32>,
+    target: Option<Vector3<f32>>,
+) -> Vector3<f32> {
+    let horizontal = |v: Vector3<f32>| vec3(v.x, 0.0, v.z);
+    let delta = target
+        .map(|p| horizontal(p - position))
+        .filter(|v| v.magnitude2() > 0.0001)
+        .unwrap_or_else(|| {
+            let forward = horizontal(rotation * Vector3::unit_z());
+            if forward.magnitude2() > 0.0001 {
+                forward
+            } else {
+                Vector3::unit_z()
+            }
+        });
+    delta.normalize() * 2.4 + Vector3::unit_y() * 3.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, Rotation3};
+
+    fn position(at: Vector3<f32>) -> PropPosition {
+        PropPosition {
+            position: at,
+            cell: 0,
+            rotation: Quaternion::from_angle_y(Deg(0.0)),
+        }
+    }
+
+    #[test]
+    fn emergence_aims_horizontally_with_bounded_lift_even_for_wall_pods() {
+        for rotation in [
+            Quaternion::from_angle_y(Deg(90.0)),
+            Quaternion::from_angle_x(Deg(90.0)),
+        ] {
+            let v = grub_emergence_velocity(
+                Vector3::new(0.0, 0.0, 0.0),
+                rotation,
+                Some(vec3(-10.0, -30.0, 0.0)),
+            );
+            assert!((v.x + 2.4).abs() < 0.001);
+            assert!(v.z.abs() < 0.001);
+            assert_eq!(v.y, 3.0);
+            for target in [None, Some(vec3(0.0, 10.0, 0.0))] {
+                let fallback = grub_emergence_velocity(vec3(0.0, 0.0, 0.0), rotation, target);
+                assert!(fallback.magnitude().is_finite());
+                assert_eq!(fallback.y, 3.0);
+            }
+        }
+    }
+
+    #[test]
+    fn relays_aim_at_player_but_direct_actor_senders_are_honored() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let relay = world.add_entity((position(vec3(-10.0, 0.0, 0.0)),));
+        let actor = world.add_entity((position(vec3(0.0, 0.0, -10.0)), PropAI("Grub".into())));
+        world.add_unique(PlayerInfo {
+            pos: vec3(10.0, 0.0, 0.0),
+            rotation: Quaternion::from_angle_y(Deg(0.0)),
+            entity_id: player,
+            inventory_entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+        });
+        assert_eq!(opener_position(&world, relay), Some(vec3(10.0, 0.0, 0.0)));
+        assert_eq!(opener_position(&world, actor), Some(vec3(0.0, 0.0, -10.0)));
+        assert_eq!(opener_position(&world, player), Some(vec3(10.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn each_pod_plays_one_spatial_hatch_sound_and_only_grubs_launch() {
+        let mut world = World::new();
+        let pod = world.add_entity((position(vec3(0.0, 0.0, 0.0)),));
+        let physics = PhysicsWorld::new();
+        for payload in [EggPayload::Grub, EggPayload::Goo, EggPayload::Swarmer] {
+            let grub = matches!(payload, EggPayload::Grub);
+            let mut script = BaseEgg::new(payload);
+            let msg = MessagePayload::TurnOn { from: pod };
+            let Effect::Multiple(effects) = script.handle_message(pod, &world, &physics, &msg)
+            else {
+                panic!("hatch effects")
+            };
+            assert_eq!(effects.iter().filter(|e| matches!(e, Effect::PlaySound { name, spatial: true, source: Some(id), .. } if name == "pod_exp" && *id == pod)).count(), 1);
+            for effect in effects {
+                if let Effect::CreateEntityByTemplateName {
+                    initial_velocity, ..
+                } = effect
+                {
+                    assert_eq!(initial_velocity.magnitude2() > 0.0, grub);
+                }
+            }
+            assert!(matches!(
+                script.handle_message(pod, &world, &physics, &msg),
+                Effect::NoEffect
+            ));
+            let state = script.save_state().unwrap();
+            assert!(
+                state
+                    .decode::<BaseEggState>(1, SCRIPT_STATE_KEY)
+                    .unwrap()
+                    .hatched
+            );
+        }
+    }
+}

--- a/tools/shock2-sdk/test/grub-ai.e2e.test.ts
+++ b/tools/shock2-sdk/test/grub-ai.e2e.test.ts
@@ -75,21 +75,47 @@ test("a launched grub settles with its visible model above the floor", {
   await game.step({ frames: 30 });
   const [grub] = await game.entities.byTemplate(-182);
   assert.ok(grub);
-  // Hold calm to isolate physical landing from a new attack at the player.
+  // Keep the player out of perception range so a new attack cannot turn
+  // this landing assertion into a sample from the next hop. The hatch now
+  // supplies the launch itself; no extra debug impulse is necessary.
+  await game.player.teleport({ x: 30, y: 1, z: 30 });
   await game.entities.sendMessage(grub.id, { type: "SetAlertness", level: "Lowest" });
-  await game.step({ frames: 1 });
-  const [body] = (await game.physics.bodies({ entityId: grub.id })).bodies;
-  assert.ok(body && body.mass);
-  const response = await fetch(`${game.baseUrl}/v1/physics/bodies/${body.body_id}/impulse`, {
-    method: "POST", body: JSON.stringify({ impulse: [0, body.mass * 0.9, body.mass * 3] }),
-  });
-  assert.equal(response.ok, true);
   await game.step({ frames: 180 });
   const [landed] = (await game.physics.bodies({ entityId: grub.id })).bodies;
   assert.ok(landed);
-  assert.ok(Math.abs(landed.velocity[1]!) < 0.05, "the actor should have landed");
+  assert.ok(Math.abs(landed.velocity[1]!) < 0.05, `the actor should have landed: ${landed.position}, velocity ${landed.velocity}`);
   // This station's kerb is at y=.1; grub3's lower extent is -.052.
   assert.ok(landed.position[1]! > 0.14 && landed.position[1]! < 0.17,
     `the model must rest on the kerb, not below it: ${landed.position}`);
   assert.ok(landed.angular_velocity.every(v => Math.abs(v) < 0.001));
+});
+
+// Regression for rec1's elevator pod: the old hatch dropped the grub into
+// the shell, where it waited for AI locomotion to get it out.
+test("rec1 grub emergence immediately arcs toward the player and clears the shell", {
+  skip: !enabled, timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "rec1.mis" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(131);
+  assert.ok(pod);
+  await game.player.teleport({ x: 2.5, y: -4, z: -112 });
+  const before = new Set((await game.entities.byTemplate(-182)).map(e => e.id));
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 3 });
+  const grub = (await game.entities.byTemplate(-182)).find(e => !before.has(e.id));
+  assert.ok(grub);
+  const [launched] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+  assert.ok(launched);
+  assert.ok(launched.velocity[0]! > 1, "launch must aim toward the player on +X");
+  assert.ok(launched.velocity[1]! > 1, "hatch must lift the grub rather than drop it");
+  await game.entities.sendMessage(grub.id, { type: "SetAlertness", level: "Lowest" });
+  await game.step({ frames: 24 });
+  const [emerged] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+  assert.ok(emerged);
+  assert.ok(emerged.position[0]! - launched.position[0]! > 0.6,
+    "the launch must carry the grub beyond the shell before ground locomotion");
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 3 });
+  assert.equal((await game.entities.byTemplate(-182)).filter(e => !before.has(e.id)).length, 1);
 });


### PR DESCRIPTION
Opening a grub pod currently creates a stationary grub at its mouth: in rec1 it drops into the shell and waits for an AI hop to escape. Launch it immediately in a short upward arc toward the opener, then let GrubAI resume movement on landing. Every pod also plays the existing `pod_exp` schema once, spatially at the shell; its `eggopen1` and `eggopen2` samples are present and load successfully.

The launch is an explicit gameplay fallback: the available retail script reference and engine source do not specify its vector, and inspection of the shipped script binary did not establish it. Use 2.4 world units/s horizontally toward the activating actor plus 3 units/s upward. Relayed mission triggers identify the relay as sender, so they target the live player; missing targets fall back to pod facing. Goo and swarm velocity behavior is unchanged.

Stacked on #1522. Follow-up to #1492's pod hatching; this does not change the separate emitter-velocity conversion in #1497.

Validation: 593 script unit tests, six egg/grub integration tests, debug-runtime build and formatting checks pass. The rec1 regression checks immediate upward motion toward the player and shell clearance. The landing test now moves the player out of perception range to avoid measuring a subsequent combat hop. Deterministic rec1 captures verify the launch in both flat and VR; runtime logs confirm `pod_exp` resolves and its clip loads. Pitched-pod launch direction is unit-tested; a real wall-pod hatch has not been captured.

![Grub emergence before and after](https://gist.githubusercontent.com/tommy-xr/398973c99708da078d7158773acf6f0d/raw/202614ef92740ce82c9e6fb6408eec6df8fe8d5f/grub-emergence-before-after.gif)

Same deterministic rec1 elevator-pod sequence before/after. The nearby player is struck by the emerging grub, braking its flight. Before the change, the grub drops into the shell and eventually escapes via AI movement. The regression test places the player farther away to check unobstructed shell clearance.

![Grub emergence comparison still](https://gist.githubusercontent.com/tommy-xr/398973c99708da078d7158773acf6f0d/raw/grub-emergence-before-after.png)
