### PR TITLE
fix(physics): convert emitted projectile velocity units only once

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8797,8 +8797,9 @@ impl MissionCore {
                                     // Same re-permutation as the GunFlash
                                     // casing path: the parser's runtime vector
                                     // back into a +Z-forward launch frame.
+                                    // PropPhysInitialVelocity is already in
+                                    // world units; only change its launch frame.
                                     orientation * vec3(velocity.0.z, velocity.0.y, -velocity.0.x)
-                                        / SCALE_FACTOR
                                 })
                             })
                             .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));

--- a/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
+++ b/tools/shock2-sdk/test/annelid-eggs.e2e.test.ts
@@ -102,8 +102,17 @@ test(
     const [pod] = await game.entities.byTemplate(-1476);
     assert.ok(pod);
     await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+    // Sample the first glob before the volley can collide and change speed.
+    await game.step({ frames: 7 });
+    const firstShots = await game.entities.byTemplate(-1557);
+    assert.ok(firstShots.length > 0);
+    const [first] = (await game.physics.bodies({ entityId: firstShots[0]!.id })).bodies;
+    assert.ok(first);
+    const speed = Math.hypot(first.velocity[0]!, first.velocity[2]!);
+    assert.ok(Math.abs(speed - 3.2) < 0.05,
+      `authored 8 Dark units/s must become 3.2 world units/s exactly once, got ${speed}`);
     // Long enough for all four to be away (100 ms apart) and still airborne.
-    await game.step({ frames: 26 });
+    await game.step({ frames: 19 });
 
     const shots = await game.entities.byTemplate(-1557);
     assert.equal(shots.length, 4);


### PR DESCRIPTION
Tweq-launched projectiles had their `PhysInitialVelocity` divided by the world scale twice. Remove the second conversion: the first goo glob now leaves at the authored 3.20 world units/s horizontally instead of 1.28. Launch-frame rotation and the emitter's additive velocity remain intact.

Stacked on #1529; fixes the speed-conversion follow-up from #1497. The underlying stack is rebased onto current main, including toxin behavior.

Validation: eight egg/grub/swarmer integration tests pass, including an exact first-glob speed regression sampled before collisions alter velocity. The rebased stack's 593 script tests passed. Debug runtime builds and formatting checks pass.

![Goo volley before and after](https://gist.githubusercontent.com/tommy-xr/dddee860d3c8dff87758f84ff38876b9/raw/volley-before-after.gif)

Identical fixed-60Hz `debug_annelid` hatch sequence. Measured first-glob horizontal speed: 1.28 → 3.20 world units/s; the corrected volley travels farther from the pod.

![Goo volley comparison still](https://gist.githubusercontent.com/tommy-xr/dddee860d3c8dff87758f84ff38876b9/raw/volley-before-after.png)
