### PR TITLE
fix(annelid): apply the goo cloud venom burst and expire its particles

### DIFF
--- a/projects/egg-goo-cloud.md
+++ b/projects/egg-goo-cloud.md
@@ -1,0 +1,44 @@
+# Egg goo cloud
+
+EggGooCloud (-438) is a one-shot burst, not a persistent toxin zone. The
+shipped gamesys `LD$arSrcDes` record links it to Venom (-387) and authors:
+
+| Offset | Field | Value |
+| --- | --- | --- |
+| 0 | Propagator | 2 (radius) |
+| 4 | Intensity | 2 |
+| 8 | Valid fields | 3 (shape and lifecycle) |
+| 12 | Radius | 10 Dark units / 4 world units |
+| 16 | Shape flags | 1 (raycast) |
+| 20 | Dispersion | 0 (constant intensity) |
+| 44 | Lifecycle flags | 0 (finite, no lifecycle-triggered destruction) |
+| 48 | Period | 5000 ms |
+| 52 | Maximum firings | 1 |
+| 56 | Intensity slope | 0 |
+
+The original [periodic lifecycle](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/ACTREACT/SSRCLIFE.CPP)
+fires at birth, then at each period. With max_firings=1, this is one immediate
+pulse; 5000ms is neither a delay nor the cloud lifetime. The
+[radius propagator](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/ACTREACT/RADIAG8R.CPP)
+uses constant intensity for dispersion0 and rejects obstructed targets.
+The port reuses its existing multi-ray body exposure calculation: partial
+cover reduces exposure instead of using retail's single all-or-nothing ray.
+
+An internal EggGooCloud script supplies this engine-owned behavior without
+inventing an authored object script or enabling unimplemented periodic stimuli
+on unrelated objects. It reads intensity/radius from the existing parsed link.
+The generic radius-effect applier now supports constant intensity while
+retaining existing falloff for explosions, radiation sources and swarmers.
+Venom reaches the existing player receptron/toxin system, including resistance,
+Toxin Shield, persistent poisoning and detox treatment.
+
+The particle group authors animation_type0 (one-shot), ten particles, and
+lifetimes0.9–1.3sec. The renderer already stops emitting once that burst ends.
+The original [particle-group simulation](https://github.com/DeathEngine2/LookingGlass-DarkEngine/blob/main/thief_2_service_release/rdrive/prj/thief2/src/RENDER/PGROUP.C)
+returns expiration once its one-shot particles are exhausted. The cloud script
+cleans up at the longest authored particle lifetime (a conservative upper
+bound, rather than the random final particle's exact death). Its saved state
+retains the spent pulse and remaining lifetime, preventing replay on load.
+
+General arSrcDesc lifecycle and dispersion parsing remains outside this focused
+fix. Other radius source types retain their existing controllers.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -549,6 +549,16 @@ pub fn create_entity_core(
         processed_scripts.push("internal_radiation_source".to_owned());
     }
 
+    // EggGooCloud (-438) has no authored object script: its single radius
+    // pulse and one-shot particle lifetime belong to Dark's engine services.
+    if crate::mission::mission_core::template_is_or_descends_from(
+        ss2_entity_info::get_hierarchy(entity_info),
+        template_id,
+        -438,
+    ) {
+        processed_scripts.push("internal_egg_goo_cloud".to_owned());
+    }
+
     // ...and remove any duplicates!
     processed_scripts.sort_unstable();
     processed_scripts.dedup();

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5887,6 +5887,7 @@ impl MissionCore {
         stim_template_id: i32,
     ) {
         self.apply_radius_stimulus(
+            true,
             Some(source_entity_id),
             center,
             radius,
@@ -5906,6 +5907,7 @@ impl MissionCore {
     /// the explosion-only physical impulse and without a source to exclude.
     fn apply_radius_stimulus(
         &mut self,
+        linear_falloff: bool,
         source_entity_id: Option<EntityId>,
         center: Vector3<f32>,
         radius: f32,
@@ -5929,7 +5931,11 @@ impl MissionCore {
                 let position = crate::util::point3_to_vec3(position);
                 let distance = (position - center).magnitude();
                 if distance < radius {
-                    let falloff = 1.0 - distance / radius;
+                    let falloff = if linear_falloff {
+                        1.0 - distance / radius
+                    } else {
+                        1.0
+                    };
                     let exposure = blast_exposure(
                         &self.physics,
                         source_entity_id,
@@ -5960,7 +5966,13 @@ impl MissionCore {
                 );
                 in_range.push((
                     player.entity_id,
-                    intensity * (1.0 - distance / radius) * exposure,
+                    intensity
+                        * if linear_falloff {
+                            1.0 - distance / radius
+                        } else {
+                            1.0
+                        }
+                        * exposure,
                 ));
             }
         }
@@ -7749,6 +7761,7 @@ impl MissionCore {
                 }
 
                 Effect::RadiusStim {
+                    linear_falloff,
                     source_entity_id,
                     center,
                     radius,
@@ -7756,6 +7769,7 @@ impl MissionCore {
                     stim_template_id,
                 } => {
                     self.apply_radius_stimulus(
+                        linear_falloff,
                         source_entity_id,
                         center,
                         radius,

--- a/shock2vr/src/scripts/ai/swarmer_ai.rs
+++ b/shock2vr/src/scripts/ai/swarmer_ai.rs
@@ -343,6 +343,7 @@ impl Script for SwarmerAI {
             {
                 if let StimPropagator::Radius { radius } = options.propagator {
                     effects.push(Effect::RadiusStim {
+                        linear_falloff: true,
                         source_entity_id: Some(entity_id),
                         center: position,
                         radius,

--- a/shock2vr/src/scripts/base_egg.rs
+++ b/shock2vr/src/scripts/base_egg.rs
@@ -28,10 +28,8 @@ struct BaseEggState {
 pub enum EggPayload {
     /// `GooEgg` - "a toxic egg". The emitter is a `TweqEmitterConfig` object
     /// that lobs four venom-stimmed "Goo Projectile"s and then destroys
-    /// itself. The cloud is currently decoration: it authors a Venom radius
-    /// stim, but the port applies radius stims only from explosions and the
-    /// radiation source, so the toxin a goo pod actually deals is the globs'
-    /// contact stim.
+    /// itself. EggGooCloud adds its authored one-shot Venom radius pulse
+    /// and expires after its particle burst.
     Goo,
     /// `GrubEgg` - "a crawling-annelid egg".
     Grub,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -576,6 +576,8 @@ pub enum Effect {
     /// Radiation sources refresh this every frame while their player is in
     /// range; the player status integrates the ambient exposure separately.
     RadiusStim {
+        /// False for authored constant-intensity clouds; true for existing blasts/hazards.
+        linear_falloff: bool,
         source_entity_id: Option<EntityId>,
         center: Vector3<f32>,
         radius: f32,

--- a/shock2vr/src/scripts/egg_goo_cloud.rs
+++ b/shock2vr/src/scripts/egg_goo_cloud.rs
@@ -1,0 +1,167 @@
+//! EggGooCloud's engine-owned one-shot radius stimulus and particle lifetime.
+//! Its arSrcDesc authors one immediate pulse, radius4, intensity2, raycast,
+//! no dispersion. Period5000 is irrelevant with max_firings1. See
+//! projects/egg-goo-cloud.md for the raw record and original lifecycle source.
+use dark::properties::{Link, PropParticleLaunchInfo, PropPosition, StimPropagator};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+use super::{
+    Effect, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    script_util::get_all_links_with_template,
+};
+use crate::{physics::PhysicsWorld, time::Time};
+
+const KEY: &str = "shock2vr.egg_goo_cloud";
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct EggGooCloud {
+    fired: bool,
+    remaining: Option<f32>,
+}
+
+impl Script for EggGooCloud {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if self.remaining.is_none() {
+            let launch = world.borrow::<View<PropParticleLaunchInfo>>().unwrap();
+            let Ok(launch) = launch.get(entity_id) else {
+                return Effect::NoEffect;
+            };
+            // All particles launch together. Keep the entity through the
+            // longest authored particle, then discard the spent effect.
+            self.remaining = Some(launch.min_time.max(launch.max_time).max(0.0));
+        }
+        if !self.fired {
+            let positions = world.borrow::<View<PropPosition>>().unwrap();
+            let Ok(position) = positions.get(entity_id) else {
+                return Effect::NoEffect;
+            };
+            self.fired = true;
+            return Effect::combine(
+                get_all_links_with_template(world, entity_id, |link| match link {
+                    Link::StimSource(options) => Some(*options),
+                    _ => None,
+                })
+                .into_iter()
+                .filter_map(|(stim_template_id, options)| {
+                    let StimPropagator::Radius { radius } = options.propagator else {
+                        return None;
+                    };
+                    Some(Effect::RadiusStim {
+                        linear_falloff: false,
+                        source_entity_id: Some(entity_id),
+                        center: position.position,
+                        radius,
+                        intensity: options.intensity,
+                        stim_template_id,
+                    })
+                })
+                .collect(),
+            );
+        }
+        let remaining = self.remaining.as_mut().unwrap();
+        *remaining -= time.elapsed.as_secs_f32();
+        if *remaining <= 0.0 {
+            Effect::DestroyEntity { entity_id }
+        } else {
+            Effect::NoEffect
+        }
+    }
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(KEY)
+    }
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, self, KEY)
+    }
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        *self = state.decode(1, KEY)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Links, StimSourceOptions, ToLink};
+    #[test]
+    fn cloud_pulses_once_at_full_intensity_and_restores_remaining_burst_lifetime() {
+        let mut world = World::new();
+        let zero = vec3(0.0, 0.0, 0.0);
+        let entity = world.add_entity((
+            PropPosition {
+                position: zero,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            PropParticleLaunchInfo {
+                launch_type: 0,
+                loc_min: zero,
+                loc_max: zero,
+                vel_min: zero,
+                vel_max: zero,
+                min_radius: 0.0,
+                max_radius: 0.0,
+                min_time: 0.9,
+                max_time: 1.3,
+            },
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: -387,
+                    to_entity_id: None,
+                    link: Link::StimSource(StimSourceOptions {
+                        intensity: 2.0,
+                        propagator: StimPropagator::Radius { radius: 4.0 },
+                    }),
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut cloud = EggGooCloud::default();
+        let advance = |cloud: &mut EggGooCloud, seconds: f32| {
+            cloud.update(
+                entity,
+                &world,
+                &physics,
+                &Time {
+                    elapsed: std::time::Duration::from_secs_f32(seconds),
+                    ..Time::default()
+                },
+            )
+        };
+        let effects = Effect::flatten(vec![advance(&mut cloud, 0.01)]);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::RadiusStim {
+                linear_falloff: false,
+                intensity: 2.0,
+                radius: 4.0,
+                stim_template_id: -387,
+                ..
+            }]
+        ));
+        assert!(matches!(advance(&mut cloud, 0.5), Effect::NoEffect));
+        let mut restored = EggGooCloud::default();
+        restored
+            .restore_state(
+                &cloud.save_state().unwrap(),
+                &ScriptRestoreContext::new(&std::collections::HashMap::new()),
+            )
+            .unwrap();
+        assert!(matches!(advance(&mut restored, 0.5), Effect::NoEffect));
+        assert!(matches!(
+            advance(&mut restored, 0.31),
+            Effect::DestroyEntity { .. }
+        ));
+    }
+}

--- a/shock2vr/src/scripts/internal_radiation_source.rs
+++ b/shock2vr/src/scripts/internal_radiation_source.rs
@@ -51,6 +51,7 @@ impl Script for InternalRadiationSource {
         let center = point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)));
 
         Effect::RadiusStim {
+            linear_falloff: true,
             source_entity_id: None,
             center,
             radius,
@@ -98,6 +99,7 @@ mod tests {
         assert!(matches!(
             effect,
             Effect::RadiusStim {
+            linear_falloff: true,
                 source_entity_id: None,
                 center,
                 radius: 6.0,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -28,6 +28,7 @@ mod dead_power_cell;
 mod delay_grenade;
 mod destroy_all_by_name;
 mod die_shodan_die;
+mod egg_goo_cloud;
 mod energy_station;
 mod energy_weapon;
 mod exp_cookie;
@@ -1054,6 +1055,7 @@ impl ScriptWorld {
             "internal_psi_powers" => gui_script(Box::new(PsiPowersGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
+            "internal_egg_goo_cloud" => Box::new(egg_goo_cloud::EggGooCloud::default()),
             "internal_radiation_source" => Box::new(InternalRadiationSource),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),

--- a/tools/shock2-sdk/test/egg-goo-cloud.e2e.test.ts
+++ b/tools/shock2-sdk/test/egg-goo-cloud.e2e.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("goo pod's cloud poisons immediately before its globs, then expires", { skip: !enabled, timeout: 120_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  await game.player.teleport({ x: -6, y: 1, z: -6 });
+  await game.step({ frames: 3 });
+  assert.equal((await game.entities.byTemplate(-1557)).length, 0, "no glob may have delivered the toxin yet");
+  assert.equal((await game.entities.byTemplate(-438)).length, 1);
+  const exposure = (await game.info()).player.toxin_level;
+  // The shell occludes part of the shared radius effect's body-ray samples.
+  assert.ok(exposure > 0 && exposure <= 2, "cloud delivers authored Venom through the cover-aware radius path");
+  const hp = (await game.info()).player.hit_points!;
+  await game.player.teleport({ x: 0, y: 1, z: -6 });
+  await game.step({ frames: 90 });
+  assert.equal((await game.entities.byTemplate(-438)).length, 0, "spent particle cloud must be removed");
+  assert.equal((await game.info()).player.toxin_level, exposure, "leaving the burst does not cure poison");
+  await game.step({ frames: 600 });
+  assert.ok((await game.info()).player.hit_points! < hp, "natural Venom exposure must feed toxin damage ticks");
+});
+
+test("goo cloud does not poison distant players or pulse again for a late arrival", { skip: !enabled, timeout: 120_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(-1476);
+  assert.ok(pod);
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.toxin_level, 0);
+  await game.player.teleport({ x: -6, y: 1, z: -6 });
+  await game.step({ frames: 1 });
+  assert.equal((await game.info()).player.toxin_level, 0, "one-shot source must not fire again each frame");
+});


### PR DESCRIPTION
Goo pods now deliver the cloud's authored Venom burst before their first projectile launches, and remove the spent cloud after its one-shot particles finish. Venom feeds the existing toxin status, resistance, shield and treatment systems. This closes the decorative-cloud follow-up from #1492.

The raw gamesys lifecycle record authors **one immediate pulse**, intensity2, radius4 world units, and no dispersion. Its5000ms period is irrelevant with max_firings1; it is not a five-second delay or a persistent hazard. Particle lifetimes0.9–1.3sec determine cleanup. The saved script latch and remaining lifetime prevent replay after load. Source analysis and exact record offsets are documented in `projects/egg-goo-cloud.md`.

The shared radius-effect path now permits constant intensity while keeping existing falloff for blasts, radiation and swarmers. It retains the port's multi-ray cover attenuation: the shell partially occludes the test player, so intensity2 produces about1.11 toxin exposure rather than retail's single-ray all-or-nothing result.

Stacked on #1530 after rebasing the workstream onto current main's toxin implementation.

Validation: 594 script tests and eight egg/cloud/hazard integration tests pass. Coverage includes immediate natural exposure before any glob exists, distant and late-arriving players, lasting toxin damage, cleanup, saved pulse/lifetime state, Endurance and Toxin Shield. Flat and VR natural hatches agree. Debug runtime builds, formatting checks and all 23 mission-load smoke tests pass.

![Egg goo venom burst](https://gist.githubusercontent.com/tommy-xr/475a0618cb2303f1f9c623b2aa28b667/raw/goo-cloud-before-after.gif)

Identical fixed-60Hz hatch: toxin0 →1.11 by frame3, before any glob launch. At frame90 the fixed cloud entity is gone; the baseline leaves an invisible orphan (its particles already faded).

![Cloud comparison still](https://gist.githubusercontent.com/tommy-xr/475a0618cb2303f1f9c623b2aa28b667/raw/goo-cloud-before-after.png)
