### PR TITLE
fix(annelid): hatch wall pods through their outward-facing mouths

### DIFF
--- a/projects/grub-ai.md
+++ b/projects/grub-ai.md
@@ -126,3 +126,24 @@ Every egg plays the authored `pod_exp` schema once, spatially at its shell.
 The schema maps to the available `eggopen1` / `eggopen2` samples. The existing
 saved hatch latch suppresses repeated payload creation and audio. Goo emission
 and swarmer flight retain their existing velocity behavior.
+
+## Wall pod placement
+
+`wpod` / `wpodopen` are separate wall-shell models whose mouth faces local -Z;
+they are not pitched floor-shell models. Payload placement uses that mouth
+axis (with the mission rotation), while floor shells retain local +Y clearance.
+The open wall shell's bounds are x±0.8, y[-1.54,0.8], z±0.379. The same .8-unit
+creature clearance puts the grub outside its mouth, then the existing opener-
+directed launch takes over.
+
+Goo wall pods also aim their emitter's projectile-local +Z frame along the
+shell's outward -Z axis. The emitter's additional velocity is world-relative:
+its CfgTweqEm misc8 does not include TWEQ_MC_RELVEL256. Preserve that world-up
+component rather than pitching it or the projectile component into the ceiling.
+
+All four concrete mission instances inheriting Grub Wall Pod (-1333)—command1
+2348/2349 and rick2 751/752—override their scripts with GooEgg. The wall-grub
+station in debug_annelid therefore uses the unmodified gamesys archetype; the
+real command1 instance independently verifies mission overrides, yaw180,
+placement, and outward goo velocity. Unit tests cover yaw0/90/180 for all three
+payloads. Floor-pod behavior remains covered by the existing regression tests.

--- a/shock2vr/src/scenes/debug_annelid.rs
+++ b/shock2vr/src/scenes/debug_annelid.rs
@@ -1,7 +1,7 @@
 //! Annelid egg pods, one station per authored kind, tripped by walking up to
 //! them.
 //!
-//! The three pods look identical and differ only in their script, so the bug
+//! The floor pods look identical and differ only in their script, so the bug
 //! "eggs spawn nothing" is invisible in a real level: a pod that opens and
 //! produces nothing is indistinguishable from one that was never near enough
 //! to hatch. Here each kind stands alone at a labeled station with a known
@@ -11,6 +11,7 @@
 //! - Goo pod (`GooEgg`)     - a toxic emitter lobbing venom-stimmed goo shots
 //! - Grub pod (`GrubEgg`)   - a crawling annelid
 //! - Swarmer pod (`SwarmerEgg`) - a flying annelid swarm
+//! - Wall grub pod - unmodified GrubEgg archetype, mounted against a wall
 //!
 //! Missions trip their pods with an authored "Floor Egg Tripwire" (a once,
 //! player-enter tripwire SwitchLinked to the pod). Runtime link authoring has
@@ -42,8 +43,7 @@ use super::debug_common::{
 
 struct EggStation {
     label: &'static str,
-    /// The floor variant of each pod: the wall variants differ only in model
-    /// orientation, and a floor pod sits where a walker can reach it.
+    /// Unmodified gamesys archetype, including a wall-mounted GrubEgg.
     template_id: i32,
     /// Station centre along +Z; every pod is the same distance ahead.
     z: f32,
@@ -64,6 +64,11 @@ const STATIONS: &[EggStation] = &[
         label: "Swarmer pod - flier",
         template_id: -1332,
         z: 6.0,
+    },
+    EggStation {
+        label: "Wall grub pod - approach from -Z",
+        template_id: -1333,
+        z: 12.0,
     },
 ];
 
@@ -96,6 +101,12 @@ pub fn create_debug_annelid_scene(
             vec3(2.0 * TRIP_RADIUS, 0.1, 2.0 * TRIP_RADIUS),
         ));
     }
+    // wpod's mouth faces local -Z; mount its back against this solid wall.
+    boxes.push((
+        vec3(0.25, 0.25, 0.30),
+        vec3(-STATION_DISTANCE, 2.0, 12.6),
+        vec3(5.0, 4.0, 0.4),
+    ));
     let (objects, collider) = boxes_to_geometry(&boxes);
 
     let mut builder = DebugSceneBuilder::new("debug_annelid")
@@ -112,13 +123,24 @@ pub fn create_debug_annelid_scene(
     for station in STATIONS {
         let mut label = SceneObject::world_space_text(station.label, font.clone(), 0.0);
         label.set_transform(
-            Matrix4::from_translation(vec3(-STATION_DISTANCE, 2.4, station.z))
-                * Matrix4::from_nonuniform_scale(
-                    0.10 * engine::measure_text_width(&**font, station.label, 1.0),
-                    0.10,
-                    1.0,
-                )
-                * Matrix4::from_angle_x(Deg(180.0)),
+            Matrix4::from_translation(vec3(
+                -STATION_DISTANCE,
+                if station.template_id == -1333 {
+                    3.3
+                } else {
+                    2.4
+                },
+                station.z,
+            )) * Matrix4::from_nonuniform_scale(
+                0.10 * engine::measure_text_width(&**font, station.label, 1.0),
+                0.10,
+                1.0,
+            ) * Matrix4::from_angle_x(Deg(180.0))
+                * Matrix4::from_angle_y(Deg(if station.template_id == -1333 {
+                    180.0
+                } else {
+                    0.0
+                })),
         );
         builder = builder.add_scene_object(label);
     }
@@ -129,11 +151,11 @@ pub fn create_debug_annelid_scene(
         asset_cache,
         audio_context,
     });
-    // A hatching pod is a fight; start the player able to survive all three.
+    // A hatching pod is a fight; start the player able to survive every station.
     max_player_stats(&mut core, "debug_annelid");
 
     println!(
-        "[debug_annelid] Three annelid egg pods stand {STATION_DISTANCE} units ahead, one per kind.\n\
+        "[debug_annelid] Four annelid egg pods stand {STATION_DISTANCE} units ahead, one per kind.\n\
          Walk within {TRIP_RADIUS} units of a pod (onto its kerb) to trip it, exactly as a\n\
          mission's Floor Egg Tripwire would. Goo = toxic projectiles, Grub = a crawler,\n\
          Swarmer = a flying swarm. Each pod trips once."
@@ -167,7 +189,15 @@ impl DebugSceneHooks for AnnelidHooks {
                 .map(|station| {
                     spawn_at(
                         station.template_id,
-                        Point3::new(-STATION_DISTANCE, 0.6, station.z),
+                        Point3::new(
+                            -STATION_DISTANCE,
+                            if station.template_id == -1333 {
+                                1.7
+                            } else {
+                                0.6
+                            },
+                            station.z,
+                        ),
                     )
                 })
                 .collect();

--- a/shock2vr/src/scripts/base_egg.rs
+++ b/shock2vr/src/scripts/base_egg.rs
@@ -1,5 +1,5 @@
-use cgmath::{InnerSpace, Quaternion, Vector3, vec3};
-use dark::properties::{PropAI, PropCreature, PropPosition};
+use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, Vector3, vec3};
+use dark::properties::{PropAI, PropCreature, PropModelName, PropPosition};
 use engine::audio::AudioHandle;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, UniqueView, View, World};
@@ -49,15 +49,8 @@ impl EggPayload {
         }
     }
 
-    /// How far above the pod's origin the payload is created, along the POD's
-    /// own up (the wall-mounted variants run these same scripts, so a
-    /// world-space offset would push their payload into the wall).
-    ///
-    /// The goo emitter needs real clearance - it fires from where it stands,
-    /// and inside the shell its globs splash on the pod instead of on the
-    /// player. A creature only needs to clear the shell's mouth: nothing
-    /// grounds it until its own locomotion runs, so a larger offset leaves it
-    /// visibly hovering and a smaller one hides it inside the pod.
+    /// Clearance from the pod origin along its mouth direction. Goo needs
+    /// extra clearance so emitted globs do not immediately strike the shell.
     fn lift(&self) -> f32 {
         match self {
             EggPayload::Goo => GOO_MUZZLE_CLEARANCE,
@@ -117,9 +110,24 @@ impl Script for BaseEgg {
         };
         self.hatched = true;
 
-        let lift = self.payload.lift();
+        // The wall shell is different art, not a pitched floor shell: wpod
+        // opens along local -Z while eggcl opens along local +Y.
+        let wall_pod = world
+            .borrow::<View<PropModelName>>()
+            .ok()
+            .is_some_and(|models| {
+                models.get(entity_id).is_ok_and(|model| {
+                    model.0.eq_ignore_ascii_case("wpod") || model.0.eq_ignore_ascii_case("wpodopen")
+                })
+            });
+        let (offset, payload_rotation) = hatch_transform(&self.payload, rotation, wall_pod);
+        let fallback_rotation = if wall_pod {
+            rotation * Quaternion::from_angle_y(Deg(180.0))
+        } else {
+            rotation
+        };
         let initial_velocity = if matches!(self.payload, EggPayload::Grub) {
-            grub_emergence_velocity(position, rotation, opener_position(world, *from))
+            grub_emergence_velocity(position, fallback_rotation, opener_position(world, *from))
         } else {
             vec3(0.0, 0.0, 0.0)
         };
@@ -136,9 +144,8 @@ impl Script for BaseEgg {
             Effect::CreateEntityByTemplateName {
                 source_entity_id: entity_id,
                 template_name: (*template_name).to_owned(),
-                position: vec3_to_point3(position + rotation * vec3(0.0, lift, 0.0)),
-                // The pod's own facing: a wall pod hatches out of the wall.
-                orientation: rotation,
+                position: vec3_to_point3(position + offset),
+                orientation: payload_rotation,
                 // GrubAI preserves this launch until landing. Goo and swarm
                 // motion remains owned by their emitter / flight controller.
                 initial_velocity,
@@ -185,6 +192,27 @@ const GOO_MUZZLE_CLEARANCE: f32 = 1.2;
 /// The lip of an open pod, measured off the shell's own bounds (its top sits
 /// 0.78 above the origin), so a hatched creature sits in the shell's mouth.
 const SHELL_MOUTH: f32 = 0.8;
+
+/// Place payloads outside the actual model mouth, respecting mission yaw.
+/// Goo's projectile-local +Z launch frame must face out of the wall.
+/// Its Tweq's additional +Y velocity is authored world-relative and stays up.
+fn hatch_transform(
+    payload: &EggPayload,
+    rotation: Quaternion<f32>,
+    wall: bool,
+) -> (Vector3<f32>, Quaternion<f32>) {
+    let direction = if wall {
+        -Vector3::unit_z()
+    } else {
+        Vector3::unit_y()
+    };
+    let orientation = if wall && matches!(payload, EggPayload::Goo) {
+        rotation * Quaternion::from_angle_y(Deg(180.0))
+    } else {
+        rotation
+    };
+    (rotation * direction * payload.lift(), orientation)
+}
 
 /// TurnOn identifies the sender, which is usually a relay/tripwire rather
 /// than its activator. Honor a direct actor sender; use the live player for
@@ -249,6 +277,24 @@ mod tests {
             position: at,
             cell: 0,
             rotation: Quaternion::from_angle_y(Deg(0.0)),
+        }
+    }
+
+    #[test]
+    fn wall_mouth_and_goo_emission_follow_authored_model_axis_and_yaw() {
+        for yaw in [0.0, 90.0, 180.0] {
+            let rotation = Quaternion::from_angle_y(Deg(yaw));
+            let outward = rotation * -Vector3::unit_z();
+            for payload in [EggPayload::Grub, EggPayload::Goo, EggPayload::Swarmer] {
+                let (offset, facing) = hatch_transform(&payload, rotation, true);
+                assert!((offset - outward * payload.lift()).magnitude() < 0.0001);
+                if matches!(payload, EggPayload::Goo) {
+                    assert!((facing * Vector3::unit_z() - outward).magnitude() < 0.0001);
+                }
+                let (floor_offset, floor_facing) = hatch_transform(&payload, rotation, false);
+                assert!((floor_offset - Vector3::unit_y() * payload.lift()).magnitude() < 0.0001);
+                assert_eq!(floor_facing, rotation);
+            }
         }
     }
 

--- a/tools/shock2-sdk/test/wall-pods.e2e.test.ts
+++ b/tools/shock2-sdk/test/wall-pods.e2e.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("wall grub emerges through its mouth rather than above its shell", { skip: !enabled, timeout: 120_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_annelid" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(-1333);
+  assert.ok(pod);
+  await game.player.teleport({ x: -8, y: 1, z: 9.8 });
+  await game.step({ frames: 3 });
+  const [grub] = await game.entities.byTemplate(-182);
+  assert.ok(grub, "natural approach must hatch the unmodified wall-grub archetype");
+  assert.ok(grub.position[2]! < pod.position[2]! - 0.6, "payload starts outside the local -Z mouth");
+  assert.ok(grub.position[1]! < pod.position[1]! + 0.35, "payload must not appear above the shell");
+  const [body] = (await game.physics.bodies({ entityId: grub.id })).bodies;
+  assert.ok(body && body.velocity[2]! < -1 && body.velocity[1]! > 1, "grub launches toward opener with lift");
+  await game.step({ frames: 20 });
+  const moved = await game.entities.detail(grub.id);
+  assert.ok(moved.position[2]! < grub.position[2]! - 0.3, "grub escapes outward without the backing wall stopping it");
+});
+
+test("command1's yawed wall pod respects its GooEgg override and emits out of the wall", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "command1.mis" });
+  await game.step({ frames: 1 });
+  const [pod] = await game.entities.byTemplate(2348);
+  assert.ok(pod);
+  const existingClouds = new Set((await game.entities.byTemplate(-438)).map(e => e.id));
+  const existingShots = new Set((await game.entities.byTemplate(-1557)).map(e => e.id));
+  await game.entities.sendMessage(pod.id, { type: "TurnOn" });
+  await game.step({ frames: 3 });
+  const cloud = (await game.entities.byTemplate(-438)).find(e => !existingClouds.has(e.id));
+  assert.ok(cloud, "this mission overrides Grub Wall Pod with GooEgg");
+  assert.ok(cloud.position[2]! > pod.position[2]! + 1, "yaw180 turns local -Z mouth toward world +Z");
+  assert.ok(Math.abs(cloud.position[1]! - pod.position[1]!) < 0.1);
+  await game.step({ frames: 4 });
+  const shot = (await game.entities.byTemplate(-1557)).find(e => !existingShots.has(e.id));
+  assert.ok(shot);
+  const [body] = (await game.physics.bodies({ entityId: shot.id })).bodies;
+  assert.ok(body && body.velocity[2]! > 1, "goo projectile's local launch frame must face outward");
+});


### PR DESCRIPTION
Wall pods were treated like floor pods: payloads appeared above the shell instead of outside its mouth. Use the wall model's local -Z mouth axis, transformed by mission rotation, while retaining floor pods' local +Y clearance. Aim goo projectiles outward too; the emitter's separate authored world-up velocity remains intact.

Adds a backed wall-grub station to `debug_annelid`. All four shipped instances inheriting Grub Wall Pod override their scripts with GooEgg, so the fixture uses the unmodified gamesys archetype and a separate command1 test verifies the real mission's override and yaw 180°.

Stacked on #1531, completing the wall-pod follow-up to #1492/#1529.

Validation: 595 script tests and ten egg/cloud/grub/wall integration tests pass, including initial wall-mouth position, upward/outward grub motion, actual command1 goo direction, and unchanged floor-pod behavior. Unit tests cover yaw 0°/90°/180° and all payload types. Both flat and VR captures show the corrected grub emergence. All 23 mission-load smoke tests passed after the stack's entity-creation changes; debug builds and formatting checks pass.

![Wall grub emergence](https://gist.githubusercontent.com/tommy-xr/83cfdb154d5b75c7c3e62afd3511e59d/raw/wall-grub-before-after.gif)

Same deterministic fixture sequence: the grub now emerges in front of the mouth. Frame 3 position changes from [-8,2.637,11.880] to [-8,1.837,11.080]; flat and VR agree.

![Wall grub comparison](https://gist.githubusercontent.com/tommy-xr/83cfdb154d5b75c7c3e62afd3511e59d/raw/wall-grub-before-after.png)

![Mission wall goo](https://gist.githubusercontent.com/tommy-xr/83cfdb154d5b75c7c3e62afd3511e59d/raw/wall-goo-before-after.gif)

Real command1 pod 2348 uses GooEgg. Its payload now appears outside the mouth and the projectile-local launch direction points outward.

![Mission wall goo comparison](https://gist.githubusercontent.com/tommy-xr/83cfdb154d5b75c7c3e62afd3511e59d/raw/wall-goo-before-after.png)
