### PR TITLE
feat(vr): add passthrough glove fit and global hand calibration

### DIFF
--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -116,6 +116,45 @@ An `am start` success or a live PID does not prove XR is rendering. Require
 the first-frame marker, a focused XR state, a top-resumed activity, and
 advancing focused performance samples.
 
+## Passthrough glove fit experiment
+
+`debug_gloves` requests `XR_FB_passthrough` only while it is the active scene
+and `glove_fit_passthrough` is enabled. It submits a reconstruction underlay
+before the alpha-enabled projection layer, with environment blend mode
+`OPAQUE`, as required by [Meta's native passthrough documentation](https://developers.meta.com/horizon/documentation/native/android/mobile-passthrough/).
+The manifest declares `com.oculus.feature.PASSTHROUGH` optional, and extension
+and system capability checks permit a black-background fallback.
+
+The eye target clears to RGBA zero. Straight-alpha shader colors accumulate
+premultiplied RGB in that target; preserve coverage alpha with separate alpha
+factors `ONE, ONE_MINUS_SRC_ALPHA`. Applying `SRC_ALPHA` to alpha itself
+squares coverage and blends translucent UI incorrectly over the room. Rebuild
+passthrough resources after `STOPPING`, and destroy them explicitly before
+Android's `process::exit`, which skips Rust destructors.
+The debug runtime encodes screenshots as RGB, so matching those PNGs verifies
+color output but cannot establish that framebuffer alpha is correct.
+
+Expect `SHOCK2QUEST_PASSTHROUGH state=running|stopped|unsupported|failed`.
+`running` proves resource creation, not visible camera content. This integration
+must be checked on Quest: room visible, both gloves tracked, hide/show working,
+exit to a normal scene, re-entry, and suspend/resume. A local black-background
+PNG cannot verify compositor passthrough or physical fit. If the user defers
+device work (for example while charging), complete local checks and report the
+device checks as pending; do not wake/install/launch for that pass.
+
+The compositor owns the passthrough image; application swapchain captures do
+not contain it. Inspect device captures for actual room content before claiming
+mixed-reality evidence, and use the wearer’s observation if capture omits it.
+For physical fit, keep controllers held and record `glove_fit_grip_pose`,
+`glove_forward_cm`, `glove_side_cm`, `glove_up_cm` and `glove_fit_size` together (see `DEVELOPMENT.md`). These
+use a global forward default of −15 cm; the other fit controls remain scene-only
+previews. Passthrough does not add optical hand tracking.
+
+Dependency trap: the checked-in `openxr` 0.21.1 wrapper's `Passthrough::start`
+calls the pause function. The experiment uses `IS_RUNNING_AT_CREATION` and
+destroys layer before feature on exit; do not replace this with pause/start
+until the dependency implementation is verified or fixed.
+
 ## Capture device visuals every iteration
 
 Capture from the Quest for every implementation iteration, including failed
@@ -181,6 +220,12 @@ desynchronizes what a wearer sees from where the game thinks they are aiming
 (and `head.look`'s yaw/pitch is the flat camera convention, not the VR head
 frame). Prefer the hand channels for VR interaction.
 
+When testing scene reloads locally, include a run with `--defer-transitions`.
+The debug runtime's usual immediate-transition shortcut can bypass the shipping
+`Game` dispatch: Quest testing exposed `DebugReloadLevel` sending generated
+scene names to the `.mis` parser. It now reuses the debug-scene launcher; the
+SDK's `debug-reload.e2e.test.ts` covers repeated resets with shipping behavior.
+
 ## Toward a device debug runtime
 
 Prefer a thin loopback-only HTTP server reached through `adb forward`, sharing
@@ -207,6 +252,12 @@ than returning stale pixels.
   transitions, storage permission, and data sentinels.
 - **Home remains visible:** repeat proximity-close and start with `-S`; inspect
   the top-resumed activity with `dumpsys activity activities`.
+- **Loading dots after repeated Home/reopen:** record the latest XR state and
+  whether the frame counter advances. Quest 3 testing reproduced a persistent
+  `IDLE` state in both `debug_gloves` and `debug_minimal`, even with Android's
+  activity resumed; a fresh `launch` recovers. One successful resume does not
+  establish repeated-cycle reliability. Compare a scene without passthrough
+  before attributing this symptom to the passthrough lifecycle.
 - **Immediate native crash:** use
   `adb logcat RustStdoutStderr:V AndroidRuntime:E DEBUG:E '*:S'`.
 - **Bad performance:** confirm release packaging, stop broad logcat consumers,

--- a/.claude/skills/vr-ui-design/SKILL.md
+++ b/.claude/skills/vr-ui-design/SKILL.md
@@ -173,6 +173,38 @@ remaining gap - PR/issue and open/closed state are marked where it matters.
     gun/psi-amp combinations. Preserve the complete authored UI canvas when
     mounting it on a glove; avoid arbitrary cropping to make it fit.
 
+## Physical glove fit
+
+- Use `debug_gloves` for the passthrough fit experiment; its controls and units
+  are in `DEVELOPMENT.md` under “Glove fit check”. Forward is global (default
+  −15 cm); side/up/size and pose-reference selection remain scene-only previews.
+- Trace the pose actually consumed. The Quest runtime binds both grip and aim,
+  but gameplay currently locates the **aim** spaces for hand transforms. A
+  binding declaration is not evidence that grip drives the glove. Compare both
+  in the fit scene; they can differ in orientation as well as translation.
+- Compare the physical wrist, palm and fingertips while holding controllers,
+  at several orientations, changing offset and size independently. Passthrough
+  visibility does not imply optical hand tracking. A translated silhouette in
+  a debug screenshot does not establish real-hand registration.
+- Fit controls must also reach the pause menu’s separate pointer gloves while
+  the fit scene is active. Share the visual calibration transform; keep the
+  tracked beam, hit dot and click arbitration coherent. Test leaving the scene
+  so preview settings cannot leak into normal menus.
+- Diagnose orientation-dependent error with controller-local side/up offsets
+  (mirror side for left/right), then inspect wrist versus fingertip alignment
+  before assuming translation alone is sufficient. The wearer reported aim
+  reference / forward −15 cm as a useful candidate, with residual palms-down
+  error. The user chose −15 cm as the global forward default; remaining axes
+  still require physical verification.
+- Keep `dark::SCALE_FACTOR` a load-time unit convention. It also feeds tracked
+  meter conversion; changing only some consumers mixes units. A glove-size
+  preview should scale about the hand origin without rescaling head/eye poses.
+  Keep rendered gloves, wrist mounts, held-item transforms and cached/baked
+  grip samples in the same corrected frame. Global forward is applied once to a
+  copy of tracked hand input before menu/gameplay routing (`glove_fit::calibrated_input`),
+  preserving the raw input and head/eye poses. Do not also shift the mesh or bake
+  a live dev parameter into grip/wrist caches.
+
 ## Glove readout implementation notes
 
 - `hand_glove::GloveRenderer::wrist_frame` provides the calibrated mount:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,6 +230,65 @@ free-camera switches. Values are read every frame, so a change is live on the
 next one, and the same registry is exposed over HTTP by the debug runtime
 (`GET`/`POST /v1/dev-params`) for headless runs.
 
+#### Glove fit check (`debug_gloves`)
+
+Open `debug_gloves` from the Developer scene list. On Quest it requests room
+passthrough behind the controller-driven gloves. Desktop/debug use a black
+background and synthetic hand input (`cargo dbgr --mission debug_gloves --vr`).
+The old pose gallery is replaced by the production glove mesh and analog curls;
+`debug_hand_poses` remains available for authored-pose inspection.
+
+Hold Menu to open Pause, then Developer, to adjust these live parameters:
+
+| Label | HTTP key | Meaning |
+| --- | --- | --- |
+| Glove forward cm | `glove_forward_cm` | Default `−15`; applies globally to VR menus and gameplay. Negative pulls back, positive moves along hand-local -Z. Range ±20 cm, steps of 0.5 cm. |
+| Glove side cm | `glove_side_cm` | Default `0`; mirrored controller-local X (positive: right for right hand, left for left). ±10 cm in 0.5 cm steps. |
+| Glove up cm | `glove_up_cm` | Default `0`; controller-local +Y, rotating with your hand. ±10 cm in 0.5 cm steps. |
+| Glove size | `glove_fit_size` | Default `1`; scales the mesh about its hand origin, from 0.5–1.5. |
+| Fit gloves | `glove_fit_visible` | Hide/show the gloves to compare your real hand silhouette. |
+| Hand pose | `glove_fit_grip_pose` | Quest only: choose **Aim** (default, current gameplay reference) or **Grip** (experimental holding reference). HTTP stores Aim as `0`, Grip as `1`. |
+| Fit passthrough | `glove_fit_passthrough` | Quest only: toggle room/black background. Default on. |
+
+Forward applies to the shared VR hand frame everywhere: gloves, wrist UI, held
+items and interaction origins move together. Normal flatscreen gameplay is
+unchanged; the flat fit scene uses the same calibration as VR for comparison.
+The other six controls apply only to this scene, including its pause-menu
+gloves. All controls remain set across scene changes and reset to their defaults
+on app restart. Keep controllers in hand: passthrough shows your real
+hands, but this experiment does **not** implement optical hand tracking. First
+compare aim/grip with offset `0` and size `1`; then adjust one parameter at a
+time while holding still and looking at the wrist, palm and fingertips from
+several angles. Record pose mode, offset and size together. Grip and aim differ
+in rotation as well as position, so translation alone may not align every pose.
+
+Passthrough is optional: unsupported devices or creation failures retain a
+black background and emit `SHOCK2QUEST_PASSTHROUGH` diagnostics. Toggle it off
+and on to retry creation. Leaving the scene releases its passthrough objects.
+Local screenshots verify geometry and tuning, **not** real-hand registration;
+physical fit requires a wearer, and compositor/session recovery requires device checks.
+
+Quest 3 device checks confirmed stereo room passthrough and a successful
+suspend/return cycle. Repeated Home/reopen cycles can also stall at XR `IDLE`
+with loading dots; the same failure reproduces in `debug_minimal` without
+passthrough running. A fresh app launch recovers. Physical glove alignment
+was checked by a wearer: aim reference with forward **−15 cm** aligned well
+with palms facing each other, but gloves sat slightly below real hands with
+palms down. At the wearer’s request, −15 cm is now the global forward default;
+further orientation-dependent refinement remains open. Use the side
+and up controls to test the remaining error, keeping forward and size fixed;
+if the wrist aligns but the fingertips diverge, investigate rotation or size.
+Menu gloves use the same calibrated hand input as gameplay. Side/up/size
+previews only change the fit-scene mesh; beam, hit dot and click targeting
+continue to share one pointer pass.
+
+`dark::SCALE_FACTOR` stays constant. It scales loaded geometry, motion and
+physics data, and feeds `METERS_PER_WORLD_UNIT`; changing it live would mix old
+and new units. Geometry divided by this factor and meters-per-unit multiplied
+by it cancel: it is an internal unit convention, not a physical-size slider.
+Glove size is deliberately an independent fit experiment and
+does not change the world, stereo separation, tracking conversion or saved grips.
+
 #### Testing VR weapon handling at different stats
 
 Open `debug_weapons` from the Developer scene list and pick up a gun from the

--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -36,7 +36,15 @@ impl Engine for OpenGLEngine {
             gl::Enable(gl::BLEND);
             // gl::Enable(gl::CULL_FACE);
             // gl::FrontFace(gl::CW);
-            gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+            // Shaders emit straight RGB; the framebuffer accumulates
+            // premultiplied RGB. Preserve coverage alpha for the Quest
+            // passthrough compositor instead of multiplying alpha by itself.
+            gl::BlendFuncSeparate(
+                gl::SRC_ALPHA,
+                gl::ONE_MINUS_SRC_ALPHA,
+                gl::ONE,
+                gl::ONE_MINUS_SRC_ALPHA,
+            );
             gl::ClearColor(0.0, 0.0, 0.0, 0.0);
             gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -567,7 +567,12 @@ impl SceneObject {
         self.geometry.draw();
         if self.additive_color {
             unsafe {
-                gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+                gl::BlendFuncSeparate(
+                    gl::SRC_ALPHA,
+                    gl::ONE_MINUS_SRC_ALPHA,
+                    gl::ONE,
+                    gl::ONE_MINUS_SRC_ALPHA,
+                );
             }
         }
 

--- a/runtimes/oculus_runtime/Cargo.toml
+++ b/runtimes/oculus_runtime/Cargo.toml
@@ -56,6 +56,11 @@ name = "android.permission.WRITE_EXTERNAL_STORAGE"
 [[package.metadata.android.uses_permission]]
 name = "android.permission.READ_EXTERNAL_STORAGE"
 
+# Optional so ordinary VR remains usable when passthrough is unavailable.
+[[package.metadata.android.uses_feature]]
+name = "com.oculus.feature.PASSTHROUGH"
+required = false
+
 [[package.metadata.android.uses_feature]]
 name = "oculus.software.handtracking"
 required = false

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -23,6 +23,7 @@ use tracing;
 mod android_permissions;
 mod debug_input;
 mod frame_profiler;
+mod passthrough;
 mod quest_config;
 mod refresh_rate;
 
@@ -113,6 +114,7 @@ fn main() {
     let mut enabled_extensions = xr::ExtensionSet::default();
     enabled_extensions.khr_opengl_es_enable = true;
     enabled_extensions.fb_display_refresh_rate = true;
+    enabled_extensions.fb_passthrough = available_extensions.fb_passthrough;
     #[cfg(target_os = "android")]
     {
         enabled_extensions.khr_android_create_instance = true;
@@ -533,6 +535,14 @@ fn main() {
         .create_space(&session, xr::Path::NULL, xr::Posef::IDENTITY)
         .unwrap();
 
+    let right_grip_space = right_grip
+        .create_space(&session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .unwrap();
+    let left_grip_space = left_grip
+        .create_space(&session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .unwrap();
+    let mut fit_passthrough = passthrough::FitPassthrough::new(&xr_instance, system);
+
     // Main loop
     let mut swapchain = None;
     let mut event_storage = xr::EventDataBuffer::new();
@@ -722,6 +732,9 @@ fn main() {
                             game.cancel_menu_hold();
                         }
                         xr::SessionState::STOPPING => {
+                            // Re-create the feature on the next running fit
+                            // frame; do not assume it survives end/begin.
+                            fit_passthrough.update(&session, false);
                             session.end().unwrap();
                             session_running = false;
                             last_update_time = Instant::now();
@@ -812,11 +825,20 @@ fn main() {
         };
 
         session.sync_actions(&[(&action_set).into()]).unwrap();
+        // Gameplay currently uses aim poses. Compare grip poses only in the
+        // fit scene, before the shared tracking conversion and validity checks.
+        let use_grip = passthrough::is_fit_scene(&game)
+            && shock2vr::dev_params::get_bool(shock2vr::dev_params::GLOVE_FIT_GRIP_POSE);
+        let (left_hand_space, right_hand_space) = if use_grip {
+            (&left_grip_space, &right_grip_space)
+        } else {
+            (&left_aim_space, &right_aim_space)
+        };
         // Find where our controllers are located in the Stage space
-        let left_aim_location = left_aim_space
+        let left_hand_location = left_hand_space
             .locate(&stage, xr_frame_state.predicted_display_time)
             .unwrap();
-        let right_aim_location = right_aim_space
+        let right_hand_location = right_hand_space
             .locate(&stage, xr_frame_state.predicted_display_time)
             .unwrap();
         let head_location = head_space
@@ -920,7 +942,7 @@ fn main() {
 
         let _speed = 50.0;
 
-        // let forward_xr = right_aim_location.pose.orientation;
+        // let forward_xr = right_hand_location.pose.orientation;
         // //let forward_xr = views[0].pose.orientation;
         // let dir = cgmath::Quaternion::new(forward_xr.w, forward_xr.x, forward_xr.y, forward_xr.z);
 
@@ -931,10 +953,10 @@ fn main() {
         // and is the zero quaternion entirely when the controllers are not
         // tracked.
         let aim_rotation = cgmath::Quaternion::new(
-            right_aim_location.pose.orientation.w,
-            right_aim_location.pose.orientation.x,
-            right_aim_location.pose.orientation.y,
-            right_aim_location.pose.orientation.z,
+            right_hand_location.pose.orientation.w,
+            right_hand_location.pose.orientation.x,
+            right_hand_location.pose.orientation.y,
+            right_hand_location.pose.orientation.z,
         );
         // ...so the head gets the actual head. Before any view has been
         // located (frame 0) the HEAD SPACE pose - located above, this frame -
@@ -996,21 +1018,21 @@ fn main() {
             stage_offset_meters(),
         );
         let right_hand_position = tracking.stage_to_pawn(vec3(
-            right_aim_location.pose.position.x,
-            right_aim_location.pose.position.y,
-            right_aim_location.pose.position.z,
+            right_hand_location.pose.position.x,
+            right_hand_location.pose.position.y,
+            right_hand_location.pose.position.z,
         ));
 
         let left_hand_position = tracking.stage_to_pawn(vec3(
-            left_aim_location.pose.position.x,
-            left_aim_location.pose.position.y,
-            left_aim_location.pose.position.z,
+            left_hand_location.pose.position.x,
+            left_hand_location.pose.position.y,
+            left_hand_location.pose.position.z,
         ));
         let left_hand_rotation = cgmath::Quaternion::new(
-            left_aim_location.pose.orientation.w,
-            left_aim_location.pose.orientation.x,
-            left_aim_location.pose.orientation.y,
-            left_aim_location.pose.orientation.z,
+            left_hand_location.pose.orientation.w,
+            left_hand_location.pose.orientation.x,
+            left_hand_location.pose.orientation.y,
+            left_hand_location.pose.orientation.z,
         );
 
         let mut input_context = InputContext::default();
@@ -1024,10 +1046,10 @@ fn main() {
         input_context.pose_tracking = Some(shock2vr::input_context::PoseTracking {
             head: head_location.location_flags.contains(tracked_pose_flags),
             hands: [
-                left_aim_location
+                left_hand_location
                     .location_flags
                     .contains(tracked_pose_flags),
-                right_aim_location
+                right_hand_location
                     .location_flags
                     .contains(tracked_pose_flags),
             ],
@@ -1294,6 +1316,11 @@ fn main() {
             )
             .unwrap();
 
+        fit_passthrough.update(
+            &session,
+            passthrough::is_fit_scene(&game)
+                && shock2vr::dev_params::get_bool(shock2vr::dev_params::GLOVE_FIT_PASSTHROUGH),
+        );
         let scene_started = Instant::now();
         let (scene, camera_pos, camera_rot) = game.render();
         let scene_elapsed = scene_started.elapsed();
@@ -1363,39 +1390,74 @@ fn main() {
         // here kills the render thread, and with it the per-frame drain of
         // NativeActivity's lifecycle/input queues - which is what turns a
         // one-frame compositor complaint into an app-wide ANR.
+        // The TRACKED pose, even while the death camera is rendering
+        // from somewhere else entirely. This looks like a bug and is
+        // not: reprojection warps a submitted frame toward the real
+        // head pose at display time, so declaring "this frame was
+        // rendered from down on the floor, on its side" makes the
+        // compositor correct out precisely the displacement the death
+        // camera just introduced. Measured on a Quest 3: submitting the
+        // rendered pose drags the image out of the display frustum and
+        // the fraction of non-black pixels falls 0.83 -> 0.00 (left)
+        // and 0.13 (right) as the fall lands, then holds there for the
+        // whole death window - a black screen for the entire death.
+        // With the tracked pose the same death renders correctly
+        // (0.74-0.75, symmetric, holds to game-over).
+        //
+        // The cost is a small reprojection seam at the image edge
+        // during the 0.9 s fall, when rendered and tracked poses
+        // disagree most. That is the accepted trade: a fraction of a
+        // second of edge artifact, against a three-second blackout.
+        let projection_views = [
+            xr::CompositionLayerProjectionView::new()
+                .pose(views[0].pose)
+                .fov(views[0].fov)
+                .sub_image(sub1),
+            xr::CompositionLayerProjectionView::new()
+                .pose(views[1].pose)
+                .fov(views[1].fov)
+                .sub_image(sub2),
+        ];
+        // openxr 0.21.1 does not export its passthrough composition builder.
+        let underlay = fit_passthrough.layer().map(|layer| {
+            use xr::sys::Handle;
+            xr::sys::CompositionLayerPassthroughFB {
+                ty: xr::sys::CompositionLayerPassthroughFB::TYPE,
+                next: std::ptr::null(),
+                flags: xr::CompositionLayerFlags::EMPTY,
+                space: xr::sys::Space::NULL,
+                layer_handle: layer.as_raw(),
+            }
+        });
+        let projection = xr::CompositionLayerProjection::new()
+            .space(&stage)
+            .layer_flags(if underlay.is_some() {
+                xr::CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA
+            } else {
+                xr::CompositionLayerFlags::EMPTY
+            })
+            .views(&projection_views);
+        let mut layers: Vec<&xr::CompositionLayerBase<'_, xr::OpenGlEs>> = Vec::with_capacity(2);
+        if let Some(underlay) = &underlay {
+            // SAFETY: OpenXR layers share the repr(C) base header, and the
+            // crate's CompositionLayerBase is repr(transparent) over it. The
+            // complete raw layer and its live handle both outlive frame.end.
+            layers.push(unsafe {
+                &*(underlay as *const xr::sys::CompositionLayerPassthroughFB
+                    as *const xr::CompositionLayerBase<'_, xr::OpenGlEs>)
+            });
+        }
+        layers.push(&projection);
         if let Err(error) = frame_stream.end(
             xr_frame_state.predicted_display_time,
-            environment_blend_mode,
-            &[
-                // The TRACKED pose, even while the death camera is rendering
-                // from somewhere else entirely. This looks like a bug and is
-                // not: reprojection warps a submitted frame toward the real
-                // head pose at display time, so declaring "this frame was
-                // rendered from down on the floor, on its side" makes the
-                // compositor correct out precisely the displacement the death
-                // camera just introduced. Measured on a Quest 3: submitting the
-                // rendered pose drags the image out of the display frustum and
-                // the fraction of non-black pixels falls 0.83 -> 0.00 (left)
-                // and 0.13 (right) as the fall lands, then holds there for the
-                // whole death window - a black screen for the entire death.
-                // With the tracked pose the same death renders correctly
-                // (0.74-0.75, symmetric, holds to game-over).
-                //
-                // The cost is a small reprojection seam at the image edge
-                // during the 0.9 s fall, when rendered and tracked poses
-                // disagree most. That is the accepted trade: a fraction of a
-                // second of edge artifact, against a three-second blackout.
-                &xr::CompositionLayerProjection::new().space(&stage).views(&[
-                    xr::CompositionLayerProjectionView::new()
-                        .pose(views[0].pose)
-                        .fov(views[0].fov)
-                        .sub_image(sub1),
-                    xr::CompositionLayerProjectionView::new()
-                        .pose(views[1].pose)
-                        .fov(views[1].fov)
-                        .sub_image(sub2),
-                ]),
-            ],
+            // Quest passthrough uses an explicit compositor layer, not the
+            // environment ALPHA_BLEND mode. The engine already clears RGBA=0.
+            if underlay.is_some() {
+                xr::EnvironmentBlendMode::OPAQUE
+            } else {
+                environment_blend_mode
+            },
+            &layers,
         ) {
             // Only the start of a burst is logged, so a persistently unhappy
             // compositor cannot flood logcat at 90 Hz.
@@ -1446,9 +1508,9 @@ fn main() {
         // if right_aim.is_active(&session, xr::Path::NULL).unwrap() {
         //     print!(
         //         "Right Hand: ({:0<12},{:0<12},{:0<12})",
-        //         right_aim_location.pose.position.x,
-        //         right_aim_location.pose.position.y,
-        //         right_aim_location.pose.position.z
+        //         right_hand_location.pose.position.x,
+        //         right_hand_location.pose.position.y,
+        //         right_hand_location.pose.position.z
         //     );
         //     printed = true;
         // }
@@ -1457,6 +1519,12 @@ fn main() {
         // }
         //render_time = Instant::now();
     }
+
+    // Android exits the process below without running destructors. Release
+    // fit resources while the session and activity are still available.
+    drop(fit_passthrough);
+    drop(left_grip_space);
+    drop(right_grip_space);
 
     // The session is over (EXITING / LOSS_PENDING, or an instance loss). Just
     // returning is not enough on Android: ndk-glue runs `main` on a thread it

--- a/runtimes/oculus_runtime/src/passthrough.rs
+++ b/runtimes/oculus_runtime/src/passthrough.rs
@@ -1,0 +1,104 @@
+//! Optional reconstruction underlay for the glove fit scene.
+use openxr as xr;
+
+pub struct FitPassthrough {
+    supported: bool,
+    attempted: bool,
+    running: Option<RunningPassthrough>,
+}
+
+struct RunningPassthrough {
+    // Drop the layer before its parent feature (Rust drops fields in order).
+    layer: xr::PassthroughLayerFB,
+    _feature: xr::Passthrough,
+}
+
+impl FitPassthrough {
+    pub fn new(instance: &xr::Instance, system: xr::SystemId) -> Self {
+        let supported = instance.exts().fb_passthrough.is_some()
+            && supports_passthrough(instance, system).unwrap_or_else(|error| {
+                println!("SHOCK2QUEST_PASSTHROUGH_SUPPORT_FAILED error={error:?}");
+                false
+            });
+        Self {
+            supported,
+            attempted: false,
+            running: None,
+        }
+    }
+
+    pub fn update(&mut self, session: &xr::Session<xr::OpenGlEs>, requested: bool) {
+        if !requested {
+            if self.running.take().is_some() {
+                println!("SHOCK2QUEST_PASSTHROUGH state=stopped");
+            }
+            self.attempted = false;
+            return;
+        }
+        if self.attempted {
+            return;
+        }
+        self.attempted = true;
+        if !self.supported {
+            println!("SHOCK2QUEST_PASSTHROUGH state=unsupported fallback=black");
+            return;
+        }
+        let result = (|| {
+            // openxr 0.21.1's Passthrough::start mistakenly calls pause.
+            // Start at creation instead, and destroy on exit rather than
+            // relying on that wrapper for a later resume.
+            let flags = xr::PassthroughFlagsFB::IS_RUNNING_AT_CREATION;
+            let feature = session.create_passthrough(flags)?;
+            let layer = session.create_passthrough_layer(
+                &feature,
+                flags,
+                xr::PassthroughLayerPurposeFB::RECONSTRUCTION,
+            )?;
+            Ok::<_, xr::sys::Result>(RunningPassthrough {
+                layer,
+                _feature: feature,
+            })
+        })();
+        match result {
+            Ok(running) => {
+                self.running = Some(running);
+                println!("SHOCK2QUEST_PASSTHROUGH state=running scene=debug_gloves");
+            }
+            Err(error) => {
+                println!("SHOCK2QUEST_PASSTHROUGH state=failed fallback=black error={error:?}")
+            }
+        }
+    }
+
+    pub fn layer(&self) -> Option<&xr::PassthroughLayerFB> {
+        self.running.as_ref().map(|running| &running.layer)
+    }
+}
+
+fn supports_passthrough(instance: &xr::Instance, system: xr::SystemId) -> xr::Result<bool> {
+    let mut capabilities = xr::sys::SystemPassthroughProperties2FB {
+        ty: xr::sys::SystemPassthroughProperties2FB::TYPE,
+        next: std::ptr::null(),
+        capabilities: xr::PassthroughCapabilityFlagsFB::EMPTY,
+    };
+    // SAFETY: both output structures live through the synchronous call. The
+    // extension is enabled before this chain is passed to OpenXR.
+    unsafe {
+        let mut properties = xr::sys::SystemProperties::out(&mut capabilities as *mut _ as _);
+        let result = (instance.fp().get_system_properties)(
+            instance.as_raw(),
+            system,
+            properties.as_mut_ptr(),
+        );
+        if result.into_raw() < 0 {
+            return Err(result);
+        }
+    }
+    Ok(capabilities
+        .capabilities
+        .contains(xr::PassthroughCapabilityFlagsFB::PASSTHROUGH_CAPABILITY))
+}
+
+pub fn is_fit_scene(app: &shock2vr::App) -> bool {
+    matches!(app, shock2vr::App::Ready(game) if game.scene_name() == "debug_gloves")
+}

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -48,6 +48,8 @@ pub struct DevParam {
     pub label: &'static str,
     pub kind: DevParamKind,
     pub default: f32,
+    /// Optional names for the false/true states of a two-choice control.
+    pub bool_labels: Option<[&'static str; 2]>,
 }
 
 /// Index into [`PARAMS`]; obtained from the generated consts or [`find`].
@@ -60,8 +62,15 @@ pub struct DevParamId(usize);
 /// table can mix kinds: the outer macro matches each line as
 /// `kind(args...)` and defers the shape of `args` to these arms.
 macro_rules! dev_param_entry {
+    (bool($key:literal, $label:literal, $default:expr, $off:literal, $on:literal)) => {
+        DevParam {
+            bool_labels: Some([$off, $on]),
+            ..dev_param_entry!(bool($key, $label, $default))
+        }
+    };
     (float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)) => {
         DevParam {
+            bool_labels: None,
             key: $key,
             label: $label,
             kind: DevParamKind::Float {
@@ -74,6 +83,7 @@ macro_rules! dev_param_entry {
     };
     (bool($key:literal, $label:literal, $default:expr)) => {
         DevParam {
+            bool_labels: None,
             key: $key,
             label: $label,
             kind: DevParamKind::Bool,
@@ -85,6 +95,9 @@ macro_rules! dev_param_entry {
 /// One declaration's default, as the `f32` the value table stores. A `bool`
 /// cannot be `as f32`, and this is the one place that conversion belongs.
 macro_rules! dev_param_default {
+    (bool($key:literal, $label:literal, $default:expr, $off:literal, $on:literal)) => {
+        dev_param_default!(bool($key, $label, $default))
+    };
     (float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)) => {
         ($default as f32)
     };
@@ -114,6 +127,21 @@ macro_rules! dev_params {
 }
 
 dev_params! {
+    /// Global VR hand-frame offset along controller-local -Z, in centimeters.
+    /// Includes menu gloves, wrist UI, held items and interactions; negative pulls back.
+    GLOVE_FORWARD_CM = float("glove_forward_cm", "Glove forward cm", -15.0, -20.0, 20.0, 0.5),
+    /// Mirrored local X offset: positive moves right for the right hand, left for the left.
+    GLOVE_SIDE_CM = float("glove_side_cm", "Glove side cm", 0.0, -10.0, 10.0, 0.5),
+    /// Controller-local +Y offset, rotating with the hand rather than world up.
+    GLOVE_UP_CM = float("glove_up_cm", "Glove up cm", 0.0, -10.0, 10.0, 0.5),
+    /// Fit-scene-only model size, about the hand origin; does not rescale tracking.
+    GLOVE_FIT_SIZE = float("glove_fit_size", "Glove size", 1.0, 0.5, 1.5, 0.01),
+    /// Hide the fit gloves to compare the real hand silhouette in passthrough.
+    GLOVE_FIT_VISIBLE = bool("glove_fit_visible", "Fit gloves", true),
+    /// Quest only: compare grip pose against gameplay's current aim pose.
+    GLOVE_FIT_GRIP_POSE = bool("glove_fit_grip_pose", "Hand pose", false, "Aim", "Grip"),
+    /// Quest only: show the room behind debug_gloves. Other scenes stay opaque.
+    GLOVE_FIT_PASSTHROUGH = bool("glove_fit_passthrough", "Fit passthrough", true),
     /// How far ahead of the head the VR frontend/pause panel hangs, in world
     /// units. Default matches the old `ui::FRONTEND_PANEL_DISTANCE` const.
     FRONTEND_PANEL_DISTANCE = float("panel_distance", "Panel distance", 2.0, 0.5, 6.0, 0.1),

--- a/shock2vr/src/glove_fit.rs
+++ b/shock2vr/src/glove_fit.rs
@@ -1,0 +1,179 @@
+//! Global hand-frame calibration, plus fit-scene-only visual previews.
+use cgmath::{Matrix4, Quaternion, Rotation, Vector3, vec3};
+
+use crate::{dev_params, vr_config::Handedness, vr_support::GripPose};
+
+/// Controller-to-hand translation, in the rotation's space and world units.
+/// Subtract it when publishing a raw controller target for a calibrated grip.
+pub(crate) fn forward_translation(rotation: Quaternion<f32>, forward_cm: f32) -> Vector3<f32> {
+    crate::util::tracked_rotation(rotation).map_or(vec3(0.0, 0.0, 0.0), |rotation| {
+        rotation.rotate_vector(vec3(
+            0.0,
+            0.0,
+            -forward_cm * 0.01 / crate::METERS_PER_WORLD_UNIT,
+        ))
+    })
+}
+
+/// Translate the consumed hand frame once, before menus and gameplay diverge.
+/// Cached grip samples and wrist mounts remain relative to that frame, so live
+/// tuning moves glove, held item and interactions together without rebaking.
+/// Work on a copy: callers retain raw tracking and repeated updates never drift.
+pub(crate) fn calibrated_input(
+    input: &crate::input_context::InputContext,
+    presentation: crate::PresentationMode,
+    fit_scene: bool,
+    forward_cm: f32,
+) -> crate::input_context::InputContext {
+    let mut calibrated = input.clone();
+    if presentation == crate::PresentationMode::Vr || fit_scene {
+        for (index, hand) in [&mut calibrated.left_hand, &mut calibrated.right_hand]
+            .into_iter()
+            .enumerate()
+        {
+            if input
+                .pose_tracking
+                .is_some_and(|tracking| !tracking.hands[index])
+            {
+                continue;
+            }
+            hand.position += forward_translation(hand.rotation, forward_cm);
+        }
+    }
+    calibrated
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct GloveFit {
+    pub side_cm: f32,
+    pub up_cm: f32,
+    pub size: f32,
+    pub visible: bool,
+}
+
+impl GloveFit {
+    pub fn current() -> Self {
+        Self {
+            side_cm: dev_params::get(dev_params::GLOVE_SIDE_CM),
+            up_cm: dev_params::get(dev_params::GLOVE_UP_CM),
+            size: dev_params::get(dev_params::GLOVE_FIT_SIZE),
+            visible: dev_params::get_bool(dev_params::GLOVE_FIT_VISIBLE),
+        }
+    }
+
+    /// Physical centimeters in controller space; mirror lateral movement so
+    /// both hands can be fitted symmetrically. Scale about the shifted origin.
+    pub fn transform(self, pose: GripPose, side: Handedness) -> Matrix4<f32> {
+        let offset = side.mirror_point(vec3(self.side_cm, self.up_cm, 0.0))
+            * (0.01 / crate::METERS_PER_WORLD_UNIT);
+        Matrix4::from_translation(pose.position)
+            * Matrix4::from(pose.rotation)
+            * Matrix4::from_translation(offset)
+            * Matrix4::from_scale(self.size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, InnerSpace, Quaternion, Rotation, Rotation3, Transform, point3};
+
+    #[test]
+    fn global_forward_preserves_tracking_and_calibrates_each_hand_once() {
+        use crate::{
+            PresentationMode,
+            input_context::{InputContext, PoseTracking},
+        };
+        let mut raw = InputContext::default();
+        raw.left_hand.position = vec3(-0.3, 0.7, -0.4);
+        raw.right_hand.position = vec3(0.3, 0.7, -0.4);
+        raw.left_hand.rotation = Quaternion::from_angle_y(Deg(90.0));
+        raw.right_hand.rotation = Quaternion::from_angle_x(Deg(45.0));
+        raw.pose_tracking = Some(PoseTracking {
+            head: true,
+            hands: [true, true],
+        });
+        for presentation in [PresentationMode::Vr, PresentationMode::Flat] {
+            for fit_scene in [false, true] {
+                let first = calibrated_input(&raw, presentation, fit_scene, -15.0);
+                let again = calibrated_input(&raw, presentation, fit_scene, -15.0);
+                let zero = calibrated_input(&raw, presentation, fit_scene, 0.0);
+                assert_eq!(first.head.position, raw.head.position);
+                assert_eq!(first.head.rotation, raw.head.rotation);
+                for (original, (actual, repeated)) in
+                    [&raw.left_hand, &raw.right_hand].into_iter().zip([
+                        (&first.left_hand, &again.left_hand),
+                        (&first.right_hand, &again.right_hand),
+                    ])
+                {
+                    let expected_meters = if presentation == PresentationMode::Vr || fit_scene {
+                        original.rotation.rotate_vector(vec3(0.0, 0.0, 0.15))
+                    } else {
+                        vec3(0.0, 0.0, 0.0)
+                    };
+                    assert!(
+                        ((actual.position - original.position) * crate::METERS_PER_WORLD_UNIT
+                            - expected_meters)
+                            .magnitude()
+                            < 1e-6
+                    );
+                    assert_eq!(actual.position, repeated.position);
+                    assert_eq!(actual.rotation, original.rotation);
+                }
+                assert_eq!(zero.left_hand.position, raw.left_hand.position);
+                assert_eq!(zero.right_hand.position, raw.right_hand.position);
+            }
+        }
+        raw.pose_tracking.as_mut().unwrap().hands[0] = false;
+        let adjusted = calibrated_input(&raw, PresentationMode::Vr, false, -15.0);
+        assert_eq!(adjusted.left_hand.position, raw.left_hand.position);
+        assert_eq!(raw.left_hand.position, vec3(-0.3, 0.7, -0.4));
+    }
+
+    #[test]
+    fn calibration_is_physical_mirrored_and_rotates_with_the_hand() {
+        let baseline = GloveFit {
+            side_cm: 0.0,
+            up_cm: 0.0,
+            size: 1.0,
+            visible: true,
+        };
+        for roll in [0.0, 90.0, 180.0] {
+            let pose = GripPose {
+                position: vec3(3.0, 2.0, -4.0),
+                rotation: Quaternion::from_angle_y(Deg(30.0)) * Quaternion::from_angle_z(Deg(roll)),
+            };
+            let origin = point3(0.0, 0.0, 0.0);
+            let sample = point3(0.02, 0.1, -0.2);
+            for side in [Handedness::Left, Handedness::Right] {
+                let base = baseline.transform(pose, side);
+                let production =
+                    Matrix4::from_translation(pose.position) * Matrix4::from(pose.rotation);
+                assert!(
+                    (base.transform_point(sample) - production.transform_point(sample)).magnitude()
+                        < 1e-6
+                );
+                for size in [0.5, 1.0, 1.5] {
+                    let fit = GloveFit {
+                        side_cm: 2.0,
+                        up_cm: 3.0,
+                        size,
+                        ..baseline
+                    };
+                    let transformed = fit.transform(pose, side);
+                    let delta = (transformed.transform_point(origin)
+                        - base.transform_point(origin))
+                        * crate::METERS_PER_WORLD_UNIT;
+                    let expected = pose
+                        .rotation
+                        .rotate_vector(side.mirror_point(vec3(0.02, 0.03, 0.0)));
+                    assert!((delta - expected).magnitude() < 1e-6);
+                    let length = (transformed.transform_point(sample)
+                        - transformed.transform_point(origin))
+                    .magnitude();
+                    assert!((length - (sample - origin).magnitude() * size).abs() < 1e-6);
+                }
+            }
+        }
+    }
+}

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -1038,7 +1038,10 @@ impl PlayerInteraction for VrInteraction {
                     "tracked_palm": self.grip_kinematics.as_ref().map(|rig| self.hand_poses()[1-i].point(rig[1-i].palm)),
                     "pressed": self.support_pressed, "blocked": self.support_blocked, "step_dt": self.step_dt,
                     "socket_position": c.model_pose.point(c.anchor),
-                    "controller_position": c.hand_pose.position,
+                    // The support solver returns a calibrated hand origin. Tools
+                    // placing raw tracked input need the inverse calibration.
+                    "controller_position": c.hand_pose.position - crate::glove_fit::forward_translation(
+                        c.hand_pose.rotation, crate::dev_params::get(crate::dev_params::GLOVE_FORWARD_CM)),
                     "controller_rotation": c.hand_pose.rotation,
                     "model_position": c.model_pose.position, "model_rotation": c.model_pose.rotation,
                     "primary_palm": c.primary_palm, "primary_anchor": c.primary_anchor,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -23,6 +23,7 @@ pub mod death_camera;
 pub mod dev_params;
 mod flat_player_controller;
 pub mod free_camera;
+mod glove_fit;
 mod gui;
 mod hand_feedback;
 mod hand_glove;
@@ -1406,6 +1407,13 @@ impl Game {
         input_context: &input_context::InputContext,
         actions: &mut input::InputActionState,
     ) {
+        let calibrated_input = glove_fit::calibrated_input(
+            input_context,
+            self.options.presentation_mode,
+            self.active_game_scene.scene_name() == "debug_gloves",
+            dev_params::get(dev_params::GLOVE_FORWARD_CM),
+        );
+        let input_context = &calibrated_input;
         let span = span!(Level::INFO, "update");
         let _enter = span.enter();
         let delta_time = time.elapsed.as_secs_f32();
@@ -1988,6 +1996,14 @@ impl Game {
                 }
             }
             GlobalEffect::TestReload => {
+                let level_name = self.active_game_scene.scene_name().to_string();
+                if scenes::debug_scene_names().any(|name| name.eq_ignore_ascii_case(&level_name)) {
+                    // Generated scenes have no .mis to parse. Reuse the
+                    // Developer launcher's reset path instead of sending their
+                    // names to the background mission loader.
+                    self.handle_global_effect(GlobalEffect::LaunchDebugScene { name: level_name });
+                    return;
+                }
                 let (position, rotation) = match self.player_standing_transform() {
                     Ok(transform) => transform,
                     Err(error) => {
@@ -1995,7 +2011,6 @@ impl Game {
                         return;
                     }
                 };
-                let level_name = self.active_game_scene.scene_name().to_string();
                 let spawn_loc = SpawnLocation::PositionRotation(position, rotation);
                 self.begin_transition(
                     level_name,
@@ -2383,9 +2398,12 @@ impl Game {
             scene.push(ring);
         }
 
-        let mut pause_objects =
-            self.pause_menu
-                .render(&mut self.asset_cache, &self.options, pawn_to_world);
+        let mut pause_objects = self.pause_menu.render(
+            &mut self.asset_cache,
+            &self.options,
+            pawn_to_world,
+            self.active_game_scene.scene_name() == "debug_gloves",
+        );
         for object in &mut pause_objects {
             object.set_render_layer(RenderLayer::SystemOverlay);
         }
@@ -2936,6 +2954,13 @@ impl MissingAssets {
 
     fn update(&mut self, time: &Time, input_context: &input_context::InputContext) {
         use crate::game_scene::GameScene;
+        let calibrated_input = glove_fit::calibrated_input(
+            input_context,
+            self.options.presentation_mode,
+            false,
+            dev_params::get(dev_params::GLOVE_FORWARD_CM),
+        );
+        let input_context = &calibrated_input;
         self.scene.update(
             time,
             input_context,

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -585,10 +585,13 @@ impl PauseMenu {
         asset_cache: &mut AssetCache,
         options: &GameOptions,
         pawn_to_world: Matrix4<f32>,
+        glove_fit_scene: bool,
     ) -> Vec<SceneObject> {
         if !self.open {
             return Vec::new();
         }
+        self.menu
+            .set_glove_fit(glove_fit_scene.then(crate::glove_fit::GloveFit::current));
         FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_world_space(
             || {
                 let panel = self.menu.panel();

--- a/shock2vr/src/scenes/debug_gloves.rs
+++ b/shock2vr/src/scenes/debug_gloves.rs
@@ -1,181 +1,112 @@
-use std::rc::Rc;
-
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, point3, vec3};
-use dark::{glb_model::GlbModel, importers::GLB_MODELS_IMPORTER};
-use engine::{
-    assets::asset_cache::AssetCache,
-    audio::AudioContext,
-    scene::{SceneObject, SkinnedMaterial, color_material},
-};
+//! Controller-to-glove fit check. Quest supplies passthrough underneath this
+//! scene; desktop/debug show the identical gloves against transparent black.
+use cgmath::{Quaternion, Rotation3, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
 use shipyard::EntityId;
-use tracing::info;
 
+use super::debug_common::{
+    DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+};
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    hand_pose::{self, HandPoseRetarget, Pose},
-    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
-    scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
-    },
+    glove_fit::GloveFit,
+    hand_glove::{GloveRenderer, HandLight},
+    input_context::InputContext,
+    mission::{GlobalContext, mission_core::MissionCore},
+    time::Time,
+    vr_config::Handedness,
+    vr_support::GripPose,
 };
 
-const GLOVE_POSITION: Point3<f32> = point3(0.0, 3.3, 1.0);
-const GLOVE_SPACING: f32 = 0.28;
-const ROW_SPACING: f32 = 0.45;
-
-/// A glove with a pose baked into its skinning matrices, plus debug cubes at
-/// the posed joint positions. Both are in model space; `after_render` places
-/// them in the world.
-struct PosedGlove {
-    objects: Vec<SceneObject>,
-    debug_cubes: Vec<SceneObject>,
+struct GloveFitHooks {
+    renderer: Option<GloveRenderer>,
+    input: InputContext,
 }
 
-struct GloveHooks {
-    /// Rows of gloves, top to bottom. Row 1 (reference poses) reads bind,
-    /// open, point, fist left to right; row 2 (blends) reads open->fist at
-    /// 25/50/75%, then an index-only half-pull (trigger).
-    rows: Vec<Vec<PosedGlove>>,
-    /// Everything needed to re-pose the animated glove each frame
-    animation: GloveAnimation,
-}
-
-/// A glove cycling open->fist over time, rendered at the end of the blend row.
-struct GloveAnimation {
-    model: Rc<GlbModel>,
-    retarget: HandPoseRetarget,
-    texture: Option<Rc<dyn engine::texture::TextureTrait>>,
-    open: Pose,
-    fist: Pose,
-    total_time: f32,
-}
-
-impl GloveAnimation {
-    const CYCLE_SECONDS: f32 = 3.0;
-
-    fn current_glove(&self) -> PosedGlove {
-        let phase = self.total_time * std::f32::consts::TAU / Self::CYCLE_SECONDS;
-        let amount = 0.5 - 0.5 * phase.cos();
-        let pose = self.open.blend(&self.fist, amount);
-        build_posed_glove(
-            &self.model,
-            &self.retarget,
-            Some(&pose),
-            self.texture.as_ref(),
-        )
-    }
-}
-
-impl DebugSceneHooks for GloveHooks {
+impl DebugSceneHooks for GloveFitHooks {
     fn before_update(
         &mut self,
         _core: &mut MissionCore,
-        time: &crate::time::Time,
-        _input_context: &crate::input_context::InputContext,
-        _asset_cache: &mut AssetCache,
-        _game_options: &GameOptions,
+        _time: &Time,
+        input: &InputContext,
+        _assets: &mut AssetCache,
+        _options: &GameOptions,
     ) {
-        self.animation.total_time = time.total.as_secs_f32();
+        self.input = input.clone();
     }
 
     fn after_render(
         &mut self,
-        _core: &mut MissionCore,
-        scene_objects: &mut Vec<SceneObject>,
-        _camera_position: &mut Vector3<f32>,
-        _camera_rotation: &mut Quaternion<f32>,
-        _asset_cache: &mut AssetCache,
+        core: &mut MissionCore,
+        objects: &mut Vec<SceneObject>,
+        camera_position: &mut Vector3<f32>,
+        camera_rotation: &mut Quaternion<f32>,
+        _assets: &mut AssetCache,
         _options: &GameOptions,
     ) {
-        // The animated glove joins the end of the blend row (row 1)
-        let animated = self.animation.current_glove();
-        for (row_index, row) in self.rows.iter().enumerate() {
-            let animated_glove = (row_index == 1).then_some(&animated);
-            let count = (row.len() + animated_glove.map_or(0, |_| 1)) as f32;
-            let y = GLOVE_POSITION.y - row_index as f32 * ROW_SPACING;
-            for (index, glove) in row.iter().chain(animated_glove).enumerate() {
-                // Negated so each row reads left to right on screen (the
-                // camera looks along -X toward the gloves)
-                let offset = ((count - 1.0) / 2.0 - index as f32) * GLOVE_SPACING;
-                // Fingers point up, palm toward the camera
-                let world =
-                    Matrix4::from_translation(vec3(GLOVE_POSITION.x + offset, y, GLOVE_POSITION.z))
-                        * Matrix4::from_angle_y(Deg(90.0))
-                        * Matrix4::from_angle_x(Deg(-90.0));
-                scene_objects.extend(clone_with_transform(&glove.objects, world));
-                scene_objects.extend(glove.debug_cubes.iter().map(|cube| {
-                    let mut clone = cube.clone();
-                    clone.set_transform(world * cube.get_transform());
-                    clone
-                }));
-            }
+        // Keep the normal physics/camera rig, but strip the gallery, body gear,
+        // wrist readouts and rays so only the hand silhouette covers the room.
+        objects.clear();
+        let fit = GloveFit::current();
+        if !fit.visible {
+            return;
         }
-    }
-}
-
-/// Bake `pose` (or the bind pose, for `None`) into a copy of the glove model
-/// and return its render objects plus per-joint debug cubes.
-fn build_posed_glove(
-    model: &GlbModel,
-    retarget: &HandPoseRetarget,
-    pose: Option<&Pose>,
-    texture: Option<&Rc<dyn engine::texture::TextureTrait>>,
-) -> PosedGlove {
-    let mut posed_model = model.clone();
-    if let Some(pose) = pose {
-        retarget.apply(pose, &mut posed_model);
-    }
-
-    let mut objects = posed_model.to_scene_objects_with_skinning();
-    for object in objects.iter_mut() {
-        if let Some(texture) = texture {
-            *object.material.borrow_mut() = SkinnedMaterial::create(texture.clone(), 1.0, 0.0);
-        }
-        object.set_transform(Matrix4::identity());
-    }
-
-    let debug_cubes = create_skeleton_debug_cubes(&mut posed_model, 0.005);
-
-    PosedGlove {
-        objects,
-        debug_cubes,
-    }
-}
-
-/// Small white cubes at every skin joint's posed position (model space).
-fn create_skeleton_debug_cubes(glb_model: &mut GlbModel, cube_size: f32) -> Vec<SceneObject> {
-    let mut debug_cubes = Vec::new();
-
-    for joint in 0..glb_model.skeleton().joint_count() {
-        let Some(node_index) = glb_model.skeleton().node_index_for_joint(joint) else {
-            continue;
+        let Some(renderer) = self.renderer.as_mut() else {
+            return;
         };
-        if let Some(global_transform) = glb_model.get_global_transform(node_index) {
-            let bone_position = global_transform.w.truncate();
-
-            let cube_material = color_material::create(vec3(1.0, 1.0, 1.0));
-            let mut bone_cube =
-                SceneObject::new(cube_material, Box::new(engine::scene::cube::create()));
-            bone_cube.set_transform(
-                Matrix4::from_translation(bone_position) * Matrix4::from_scale(cube_size),
+        // MissionCore may have changed stance since before_update. Match the
+        // same rebase used by the production hands and the runtime's two eyes.
+        let crouched = core.player_tracking_is_crouched();
+        crate::vr_tracking::TrackingTransform::rebase_input(
+            &mut self.input,
+            crate::physics::player_center_above_floor(crouched),
+            crate::physics::player_eye_cap_above_center(crouched),
+        );
+        for (index, (input, side)) in [
+            (&self.input.left_hand, Handedness::Left),
+            (&self.input.right_hand, Handedness::Right),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let pose = GripPose {
+                position: crate::virtual_hand::hand_world_position(
+                    *camera_position,
+                    *camera_rotation,
+                    input.position,
+                ),
+                rotation: *camera_rotation * input.rotation,
+            };
+            if !pose.is_tracked()
+                || self
+                    .input
+                    .pose_tracking
+                    .is_some_and(|tracking| !tracking.hands[index])
+            {
+                continue;
+            }
+            // Production geometry, retargeting, analog curls and handedness.
+            // Only this scene's outer transform is adjustable: baked weapon
+            // grips and cached wrist frames elsewhere remain coherent.
+            let mut hand = renderer.render_hand(
+                vec3(0.0, 0.0, 0.0),
+                Quaternion::from_angle_y(cgmath::Deg(0.0)),
+                side,
+                input.trigger_value,
+                input.squeeze_value,
+                false,
+                None,
+                HandLight::Off,
             );
-            debug_cubes.push(bone_cube);
+            let transform = fit.transform(pose, side);
+            for object in &mut hand {
+                object.set_transform(transform * object.get_transform());
+            }
+            crate::util::tag_render_source(&mut hand, crate::util::render_source::PLAYER_HANDS);
+            objects.extend(hand);
         }
     }
-
-    debug_cubes
-}
-
-fn clone_with_transform(template: &[SceneObject], transform: Matrix4<f32>) -> Vec<SceneObject> {
-    template
-        .iter()
-        .map(|object| {
-            let mut clone = object.clone();
-            clone.set_transform(transform);
-            clone
-        })
-        .collect()
 }
 
 pub struct DebugGlovesScene;
@@ -187,80 +118,23 @@ impl DebugGlovesScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Box<dyn GameScene> {
-        let builder = DebugSceneBuilder::new("debug_gloves")
+        let renderer = GloveRenderer::new(asset_cache);
+        // Invisible support keeps the pawn from falling. The scene hook removes
+        // its picture, not its collider; physical head/hand tracking stays live.
+        let core = DebugSceneBuilder::new("debug_gloves")
             .with_default_floor()
-            // Far enough back that the whole two-row line-up fits the FOV
-            .with_spawn_location(SpawnLocation::PositionRotation(
-                vec3(0.0, 2.5, -0.8),
-                Quaternion::from_angle_y(Deg(90.0)),
-            ));
-
-        let build_options = DebugSceneBuildOptions {
-            global_context,
-            game_options,
-            asset_cache,
-            audio_context,
-        };
-
-        let core = builder.build_core(build_options);
-
-        let glove_model = asset_cache.get(&GLB_MODELS_IMPORTER, "vr_glove_model.glb");
-        // The same texture the production hands use, so this scene can't show a
-        // different hand from the one the player wears.
-        let texture = crate::hand_glove::load_glove_texture(asset_cache);
-        let retarget = HandPoseRetarget::for_right_glove(glove_model.skeleton());
-
-        let open = hand_pose::open_right_hand();
-        let fist = hand_pose::fist_right_hand();
-
-        // Row 1: the reference poses
-        let reference_poses: [Option<Pose>; 4] = [
-            None, // bind pose
-            Some(open.clone()),
-            Some(hand_pose::point_right_hand()),
-            Some(fist.clone()),
-        ];
-        // Row 2: intermediate states - open->fist blends, then a trigger
-        // half-pull (only the index finger curls)
-        let blend_poses: [Option<Pose>; 4] = [
-            Some(open.blend(&fist, 0.25)),
-            Some(open.blend(&fist, 0.5)),
-            Some(open.blend(&fist, 0.75)),
-            Some(open.blend_per_finger(
-                &fist,
-                &hand_pose::FingerAmounts {
-                    index: 0.5,
-                    ..Default::default()
-                },
-            )),
-        ];
-
-        let rows = [reference_poses, blend_poses]
-            .iter()
-            .map(|row| {
-                row.iter()
-                    .map(|pose| {
-                        build_posed_glove(&glove_model, &retarget, pose.as_ref(), texture.as_ref())
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
-        info!(
-            "Created debug gloves scene: row 1 bind/open/point/fist, row 2 open->fist blends + trigger half-pull + animated blend"
-        );
-
-        let animation = GloveAnimation {
-            model: glove_model,
-            retarget,
-            texture,
-            open,
-            fist,
-            total_time: 0.0,
-        };
-
-        let hooks = GloveHooks { rows, animation };
-
-        Box::new(HookedDebugScene::new(core, hooks))
+            .build_core(DebugSceneBuildOptions {
+                global_context,
+                game_options,
+                asset_cache,
+                audio_context,
+            });
+        Box::new(HookedDebugScene::new(
+            core,
+            GloveFitHooks {
+                renderer,
+                input: InputContext::default(),
+            },
+        ))
     }
 }

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -282,10 +282,12 @@ fn scroll_rects(rects: PanelRects) -> Option<(Rect, Rect)> {
 
 /// The value readout: floats as `{:.2}`, the format the step grids are
 /// declared in.
-fn format_value(kind: &DevParamKind, value: f32) -> String {
+fn format_value(kind: &DevParamKind, value: f32, bool_labels: Option<[&str; 2]>) -> String {
     match kind {
         DevParamKind::Float { .. } => format!("{value:.2}"),
-        DevParamKind::Bool => if value != 0.0 { "On" } else { "Off" }.to_owned(),
+        DevParamKind::Bool => {
+            bool_labels.unwrap_or(["Off", "On"])[usize::from(value != 0.0)].to_owned()
+        }
     }
 }
 
@@ -382,7 +384,7 @@ pub fn draw(
         canvas
             .text_native(
                 row.value,
-                &format_value(&param.kind, dev_params::get(id)),
+                &format_value(&param.kind, dev_params::get(id), param.bool_labels),
                 ROW_FONT,
                 HAlign::Center,
                 VAlign::Middle,
@@ -751,15 +753,15 @@ mod tests {
             max: 1.0,
             step: 0.02,
         };
-        assert_eq!(format_value(&kind, 0.72), "0.72");
+        assert_eq!(format_value(&kind, 0.72, None), "0.72");
         // The snap grid's f32 wobble (0.71999997) must not leak into the UI.
-        assert_eq!(format_value(&kind, 0.719_999_97), "0.72");
-        assert_eq!(format_value(&kind, 2.0), "2.00");
+        assert_eq!(format_value(&kind, 0.719_999_97, None), "0.72");
+        assert_eq!(format_value(&kind, 2.0, None), "2.00");
     }
 
     #[test]
     fn bools_format_as_on_and_off() {
-        assert_eq!(format_value(&DevParamKind::Bool, 1.0), "On");
-        assert_eq!(format_value(&DevParamKind::Bool, 0.0), "Off");
+        assert_eq!(format_value(&DevParamKind::Bool, 1.0, None), "On");
+        assert_eq!(format_value(&DevParamKind::Bool, 0.0, None), "Off");
     }
 }

--- a/shock2vr/src/ui/frontend_menu.rs
+++ b/shock2vr/src/ui/frontend_menu.rs
@@ -300,6 +300,10 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
         })
     }
 
+    pub(crate) fn set_glove_fit(&mut self, fit: Option<crate::glove_fit::GloveFit>) {
+        self.vr_pointer_visuals.glove_fit = fit;
+    }
+
     pub fn panel(&self) -> WorldPanel {
         self.panel_anchor.panel()
     }

--- a/shock2vr/src/ui/pointer_visual.rs
+++ b/shock2vr/src/ui/pointer_visual.rs
@@ -223,6 +223,7 @@ fn beam_objects(start: Vector3<f32>, along: Vector3<f32>, length: f32) -> Vec<Sc
 pub struct PointerVisuals {
     /// `None` = not tried yet; `Some(None)` = tried and the model is missing.
     glove: Option<Option<GloveRenderer>>,
+    pub(crate) glove_fit: Option<crate::glove_fit::GloveFit>,
 }
 
 impl PointerVisuals {
@@ -250,7 +251,15 @@ impl PointerVisuals {
             .glove
             .get_or_insert_with(|| GloveRenderer::new(asset_cache))
             .as_mut();
-        let mut objects = render_pointer_rays(glove, true, pass, canvas_size, panel, panel_layers);
+        let mut objects = render_pointer_rays(
+            glove,
+            true,
+            pass,
+            canvas_size,
+            panel,
+            panel_layers,
+            self.glove_fit,
+        );
         // The one pair of hands a frontend screen shows. Labelled so a check
         // can assert *both* halves of issue #1018's fix: the scene's hands are
         // gone, and these are still there.
@@ -273,7 +282,8 @@ pub fn pointer_beams(
     panel: &WorldPanel,
     panel_layers: usize,
 ) -> Vec<SceneObject> {
-    let mut objects = render_pointer_rays(None, false, pass, canvas_size, panel, panel_layers);
+    let mut objects =
+        render_pointer_rays(None, false, pass, canvas_size, panel, panel_layers, None);
     crate::util::tag_render_source(&mut objects, crate::util::render_source::USE_MODE_POINTER);
     objects
 }
@@ -289,6 +299,7 @@ fn render_pointer_rays(
     canvas_size: Vector2<f32>,
     panel: &WorldPanel,
     panel_layers: usize,
+    glove_fit: Option<crate::glove_fit::GloveFit>,
 ) -> Vec<SceneObject> {
     let mut objects = Vec::new();
     for (index, ray) in pass.rays.iter().enumerate() {
@@ -305,6 +316,7 @@ fn render_pointer_rays(
             objects.extend(beam_objects(geometry.start, along, length));
         }
 
+        let hand_start = objects.len();
         match glove.as_deref_mut().filter(|_| draw_hand) {
             Some(glove) => objects.extend(glove.render_static_hand(
                 geometry.start,
@@ -321,6 +333,25 @@ fn render_pointer_rays(
                 CONTROLLER_COLOR,
             )),
             None => {}
+        }
+
+        if let Some(fit) = glove_fit {
+            // Calibrate only the mesh. Hover, clicks, beam and dot retain the
+            // single tracked aim pass, so tuning cannot move the menu target.
+            let pose = crate::vr_support::GripPose {
+                position: geometry.start,
+                rotation: ray.rotation,
+            };
+            let original = Matrix4::from_translation(pose.position) * Matrix4::from(pose.rotation);
+            let adjustment = fit.transform(pose, ray.handedness)
+                * cgmath::SquareMatrix::invert(&original).expect("tracked hand pose is invertible");
+            if fit.visible {
+                for object in &mut objects[hand_start..] {
+                    object.set_transform(adjustment * object.get_transform());
+                }
+            } else {
+                objects.truncate(hand_start);
+            }
         }
 
         if let Some(dot) = geometry.dot {
@@ -419,7 +450,9 @@ mod tests {
         };
         let pass = pass(untracked.clone(), untracked);
         assert!(pass.rays.is_empty());
-        assert!(render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS).is_empty());
+        assert!(
+            render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS, None).is_empty()
+        );
     }
 
     #[test]
@@ -442,9 +475,53 @@ mod tests {
         // Each hand: a proxy plus its beam segments; the right hand also the
         // one dot.
         assert_eq!(
-            render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS).len(),
+            render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS, None).len(),
             2 * (BEAM_SEGMENTS + 1) + 1
         );
+    }
+
+    #[test]
+    fn fit_moves_only_menu_hands_and_visibility_preserves_pointer_feedback() {
+        let pass = pass(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_away(0.0),
+        );
+        let panel = test_panel();
+        let fit = crate::glove_fit::GloveFit {
+            side_cm: 2.0,
+            up_cm: 3.0,
+            size: 1.2,
+            visible: true,
+        };
+        let base = render_pointer_rays(None, true, &pass, CANVAS, &panel, LAYERS, None);
+        let adjusted = render_pointer_rays(None, true, &pass, CANVAS, &panel, LAYERS, Some(fit));
+        assert_eq!(base.len(), adjusted.len());
+        // All beam segments and the hit dot keep their exact transforms;
+        // exactly the two glove proxies change.
+        assert_eq!(
+            base.iter()
+                .zip(&adjusted)
+                .filter(|(a, b)| a.get_transform() != b.get_transform())
+                .count(),
+            2
+        );
+        let hidden = render_pointer_rays(
+            None,
+            true,
+            &pass,
+            CANVAS,
+            &panel,
+            LAYERS,
+            Some(crate::glove_fit::GloveFit {
+                visible: false,
+                ..fit
+            }),
+        );
+        let beams = render_pointer_rays(None, false, &pass, CANVAS, &panel, LAYERS, None);
+        assert_eq!(hidden.len(), beams.len());
+        for (actual, expected) in hidden.iter().zip(beams) {
+            assert_eq!(actual.get_transform(), expected.get_transform());
+        }
     }
 
     #[test]
@@ -478,7 +555,7 @@ mod tests {
             hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
             hand_aimed_away(0.0),
         );
-        let objects = render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS);
+        let objects = render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS, None);
         let translucent: Vec<_> = objects
             .iter()
             .filter(|object| object.effective_transparency().is_some_and(|t| t > 0.0))
@@ -516,7 +593,7 @@ mod tests {
                 ..Hand::default()
             },
         );
-        let objects = render_pointer_rays(None, true, &pass, CANVAS, &panel, LAYERS);
+        let objects = render_pointer_rays(None, true, &pass, CANVAS, &panel, LAYERS, None);
         assert!(
             objects
                 .iter()

--- a/tools/shock2-sdk/test/debug-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-reload.e2e.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+for (const mission of ["debug_gloves", "debug_minimal"]) {
+  test(
+    `${mission}: reload resets the scene with shipping transition behavior`,
+    { skip: !enabled, timeout: 300_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission,
+        // Exercise Game's reload dispatch, not the debug runtime's usual
+        // immediate-transition shortcut. Quest exposed this parser crash.
+        debugFlags: ["--vr", "--defer-transitions"],
+      });
+      await game.step({ frames: 2 });
+      const spawn = await game.player.position();
+      for (let cycle = 0; cycle < 3; cycle++) {
+        await game.player.teleport({
+          x: spawn.x + 4,
+          y: spawn.y,
+          z: spawn.z + 3,
+        });
+        await game.input.trigger("DebugReloadLevel");
+        await game.step({ frames: 5 });
+        assert.equal((await game.info()).mission, mission);
+        const position = await game.player.position();
+        assert.ok(Math.abs(position.x - spawn.x) < 0.01);
+        assert.ok(Math.abs(position.z - spawn.z) < 0.01);
+        // Continue beyond the deferred loader's checkpoints: a parser-thread
+        // panic must not be hidden by checking only its first loading frame.
+        await game.step({ frames: 90 });
+        assert.equal((await game.info()).mission, mission);
+      }
+    },
+  );
+}

--- a/tools/shock2-sdk/test/helpers/vr-climb.ts
+++ b/tools/shock2-sdk/test/helpers/vr-climb.ts
@@ -1,7 +1,7 @@
 import type { GameServer } from "../../src/index.js";
 import type { Vec3 } from "../../src/types.js";
 
-import { add, quatConjugate, quatRotate, scale, sub } from "./vr-hand.js";
+import { add, quatConjugate, quatRotate, scale, sub, type Hand, type Quat } from "./vr-hand.js";
 
 /**
  * A world point as a hand channel value.
@@ -16,9 +16,16 @@ import { add, quatConjugate, quatRotate, scale, sub } from "./vr-hand.js";
 export async function vrHandLocal(
   game: GameServer,
   world: Vec3,
+  hand: Hand = "right",
 ): Promise<Vec3> {
-  const { player } = await game.info();
-  return quatRotate(quatConjugate(player.rotation), sub(world, player.position));
+  const { player, inputs } = await game.info();
+  const local = quatRotate(quatConjugate(player.rotation), sub(world, player.position));
+  const raw = inputs as { hands: Record<Hand, { rotation: Quat }> };
+  const forward = (await game.devParams.list()).params.find(p => p.key === "glove_forward_cm")!.value;
+  // A requested hold is a calibrated hand point; input channels accept the
+  // raw controller pose. Undo the physical offset (0.3048 meters/foot * SCALE_FACTOR 2.5).
+  const offset = quatRotate(raw.hands[hand].rotation, [0, 0, -forward * 0.01 / 0.762]);
+  return sub(local, offset);
 }
 
 /** A world-space displacement in pawn space (rotation only). */
@@ -62,7 +69,7 @@ export async function vrClimbPull(
   },
 ): Promise<VrClimbPullResult> {
   const before = (await game.info()).player.position;
-  const atGrab = await vrHandLocal(game, grabAt);
+  const atGrab = await vrHandLocal(game, grabAt, hand);
   const pullLocal = await vrHandLocalDelta(game, pull);
 
   // Reach out with an OPEN hand first: the grab is a squeeze edge, so the

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -112,14 +112,15 @@ export async function aimVrHandAtCanvas(
 /** Aim one production VR hand's ray at a world point without direct entity
  * messages. Pass `squeeze = 1` to preserve an already-held item while aiming,
  * and `trigger = 1` to keep a pull in flight across the re-aim (releasing it
- * would end the gesture, which matters wherever a latch spans the movement). */
+ * would end the gesture, which matters wherever a latch spans the movement).
+ * Set `lookAtTarget: false` to reach without turning the head/body-slot frame. */
 export async function aimVrHandAt(
   game: GameServer,
   target: Vec3,
   standOff = 0.45,
   squeeze = 0,
   trigger = 0,
-  { hand = "right" }: { hand?: Hand } = {},
+  { hand = "right", lookAtTarget = true }: { hand?: Hand; lookAtTarget?: boolean } = {},
 ): Promise<{ start: Vec3; target: Vec3; local: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
@@ -137,9 +138,11 @@ export async function aimVrHandAt(
     quatMultiply(inversePawn, worldHandRotation),
   );
 
-  await game.input.lookAtWorldPoint(target, {
-    eyeHeight: snapshot.player.camera_offset[1],
-  });
+  if (lookAtTarget) {
+    await game.input.lookAtWorldPoint(target, {
+      eyeHeight: snapshot.player.camera_offset[1],
+    });
+  }
   await game.input.set(`${hand}_hand.position`, localHand);
   await game.input.set(`${hand}_hand.rotation`, localHandRotation);
   await game.input.set(`${hand}_hand.trigger`, trigger);

--- a/tools/shock2-sdk/test/vr-climb.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-climb.e2e.test.ts
@@ -92,7 +92,7 @@ test(
     await game.input.set("right_hand.position", await vrHandLocal(game, rightHold));
     await game.input.set("right_hand.squeeze", 1);
     await game.step({ frames: 1 });
-    const leftAtGrab = await vrHandLocal(game, leftHold);
+    const leftAtGrab = await vrHandLocal(game, leftHold, "left");
     await game.input.set("left_hand.position", leftAtGrab);
     await game.input.set("left_hand.squeeze", 1);
     await game.step({ frames: 1 });

--- a/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
@@ -15,9 +15,12 @@ for (const [model, template] of [["atek_h",-17],["ar15_h",-18],["sg_h",-19]] as 
       skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
     }, async () => {
       await using game = await GameServer.launch({mission:"debug_weapons",debugFlags:model === "ar15_h" ? ["--vr","--experimental","physical_held_items"] : ["--vr"]});
+      await game.input.set("head.rotation",[0,0,0,1]);
       await game.step({frames:30});
       const weapon = await cycleToWeapon(game,e=>e.template_id === template);
-      await aimVrHandAt(game,weapon.position,.2,1,0,{hand:primary});
+      // Keep the head facing forward: the pickup target is off to the side,
+      // and turning toward it puts the support fixture in a shoulder bag.
+      await aimVrHandAt(game,weapon.position,.2,1,0,{hand:primary, lookAtTarget:false});
       const other = primary === "left" ? "right" : "left";
       const owner = primary === "left" ? "wielded_entity_id" : "right_hand_entity_id";
       const empty = primary === "left" ? "right_hand_entity_id" : "wielded_entity_id";

--- a/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
@@ -12,13 +12,16 @@ for (const primary of ["right", "left"] as const) {
   test(`wrench support (${primary} primary): near grab, rigid steering, release and separation break`,
     { skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000 }, async () => {
       await using game = await GameServer.launch({mission:"debug_interactions", debugFlags:["--vr"]});
+      await game.input.set("head.rotation",[0,0,0,1]);
       await game.step({frames:90});
       const wrench = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
       const other = primary === "right" ? "left" : "right";
       const owned = primary === "right" ? "right_hand_entity_id" : "wielded_entity_id";
       const empty = primary === "right" ? "wielded_entity_id" : "right_hand_entity_id";
       await game.player.teleport({x:wrench.position[0],y:1,z:0});
-      await aimVrHandAt(game, wrench.position, .2, 1, 0, {hand:primary});
+      // Keep the head facing forward: the pickup target is off to the side,
+      // and turning toward it puts the support fixture in a shoulder bag.
+      await aimVrHandAt(game, wrench.position, .2, 1, 0, {hand:primary, lookAtTarget:false});
       await game.input.set(`${primary}_hand.position`, [0,1,-.5]);
       await game.input.set(`${primary}_hand.rotation`, [0,0,0,1]);
       await game.input.set(`${other}_hand.squeeze`, 0);
@@ -106,11 +109,13 @@ test("physical wrench glove stays attached during walking and wall contact", {
   skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
 }, async () => {
   await using game = await GameServer.launch({mission:"debug_melee",debugFlags:["--vr"]});
+  await game.input.set("head.rotation",[0,0,0,1]);
   await game.step({frames:90});
   const wrench = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
-  await aimVrHandAt(game,wrench.position,.2,1);
+  await aimVrHandAt(game,wrench.position,.2,1,0,{lookAtTarget:false});
   await game.player.teleport({x:-11,y:1,z:0});
-  await game.input.set("right_hand.position",[0,1,0]);
+  // Hold in front of the torso while sweeping into the wall along X.
+  await game.input.set("right_hand.position",[0,1,-.5]);
   await game.input.set("right_hand.rotation",[0,0,0,1]);
   await game.step({frames:90});
   const check = async () => {
@@ -127,7 +132,7 @@ test("physical wrench glove stays attached during walking and wall contact", {
   await game.step({frames:30});
   // The debug_melee back wall is x=-13. Sweep the held controller through it.
   for (let frame=0;frame<30;frame++) {
-    await game.input.set("right_hand.position",[-3*frame/29,1,0]);
+    await game.input.set("right_hand.position",[-3*frame/29,1,-.5]);
     await game.step({frames:1});
     await check();
   }
@@ -158,7 +163,7 @@ test("physical wrench glove stays attached during walking and wall contact", {
     const moving = await check();
     assert.equal(moving.support!.attached,true,"physical contact feedback is not a support-release gesture");
   }
-  await game.input.set("right_hand.position",[-2.98,1,0]);
+  await game.input.set("right_hand.position",[-2.98,1,-.5]);
   await game.step({frames:8});
   const shifted = await check();
   assert.equal(shifted.support!.attached,true);


### PR DESCRIPTION
VR gloves sat ahead of the wearer’s real hands, and fit-scene adjustments disappeared when opening a menu. This replaces the old `debug_gloves` pose gallery with a passthrough fit check and applies a default **−15 cm forward offset** across VR gameplay and menus.

- Render Quest room passthrough behind the production controller-driven gloves, with an opaque fallback when unsupported. Preserve framebuffer alpha for composition and release passthrough resources on scene/session exit.
- Expose forward, mirrored side, local up, size, visibility, passthrough, and **Hand pose: Aim / Grip** controls. Aim remains the default; side/up/size/reference selection stay experimental and scoped to the fit scene.
- Apply global forward calibration once before input consumers diverge, keeping gloves, wrist UI, held items, and interactions in the same frame. Keep raw tracking and head/eye poses unchanged; normal flatscreen gameplay is unaffected.
- Reload generated debug scenes through their launcher instead of trying to parse them as `.mis` files. Update support diagnostics and test placement helpers for calibrated hands, and document the fit/device workflow.

### Validation

- Warning-free `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; formatting and TypeScript compilation passed.
- 234 focused Rust tests, 18 VR integration scenarios (climbing, support, firing, release, and physical wrench wall contact), and two generated-scene reload scenarios passed.
- Actual-render checks measured exactly 15 cm across main menu, gameplay, pause, and fit scenes, with matching wrist movement and no double offset. Flat/VR fit rendering and the Aim/Grip labels were checked.
- Release APK built, installed, and launched on Quest 3. The wearer confirmed passthrough and chose −15 cm after comparing real and virtual hands.

The wearer still observed a smaller orientation-dependent fit error; side/up controls support further tuning. Repeated Home/reopen cycles can stall at XR `IDLE`, also observed in `debug_minimal` without passthrough. A fresh launch recovers; this PR does not claim to fix that behavior. Fit controls are process-local, and passthrough does not implement optical hand tracking.

### Review

Codex correctness/simplicity/visual review found no actionable issues. The duplication review prompted one cleanup: read fit settings once for both hands. Lexical, clone, index, and source checks completed (31 queries / 9,912 candidates; 699 clone pairs, none introduced by this change). Claude’s separate correctness review could not complete because its account session limit was reached.

### Visual evidence

![Glove fit scene animation](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/d945e1c66cd4df74c6156feda15e9d9b7be6014a/after.gif)

The fit scene replaces the pose gallery with production gloves. Synthetic debug-runtime capture; physical room passthrough is verified separately on Quest.

![Pose gallery before and fit scene after](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/eec18e8f765dc71987cf128cd680bc695d3d8568/before-after.png)

![Global hand offset before and after](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/a8dd601ebf7c598b8bd28dc50f740b1a158e7feb/global-forward-before-after.png)

![Global hand offset toggled between 0 and -15 cm](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/59c5699eb825a63b8077f5d7ccd2161d61a98110/global-forward-toggle.gif)

The final default moves VR hands and their wrist UI back 15 cm across gameplay and menus. The toggle shows 0 versus -15 cm with identical controller poses.

![Hand pose label before and after](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/0ee989e51569661d22e2f57e1bcc0e915d75a9bd/hand-pose-before-after.png)

![Hand pose toggled between Aim and Grip](https://gist.githubusercontent.com/tommy-xr/82ea32ecb22eafc06e7f2ed35418127c/raw/20583dba54befe43df48f6050e909f3bef41dbee/hand-pose-toggle-vr.gif)

The Developer control now displays **Hand pose: Aim / Grip**.
