### PR TITLE
fix(ai): reselect attacks without an intervening chase clip

### DIFF
--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -237,4 +237,45 @@ mod tests {
             .map(|behavior| behavior.borrow().name().to_owned());
         assert_eq!(name.as_deref(), Some("SelfDestruct"));
     }
+    #[test]
+    fn ranged_clip_completion_reselects_the_available_attack() {
+        for (links, distance, expected) in [
+            (vec![ai_projectile()], 1.0, "RangedAttack"),
+            (vec![ai_projectile()], 8.0, "RangedAttack"),
+            (vec![ai_projectile()], 20.0, "Chase"),
+            (vec![Link::Weapon, ai_projectile()], 1.0, "MeleeAttack"),
+        ] {
+            let (world, entity) = world_with_armed_ai(links, distance);
+            let physics = PhysicsWorld::new();
+            let NextBehavior::Next(next) =
+                RangedAttackBehavior.next_behavior(&world, &physics, entity)
+            else {
+                panic!("completion must re-evaluate attack range and line of fire");
+            };
+            assert_eq!(next.borrow().name(), expected);
+        }
+    }
+
+    #[test]
+    fn ranged_clip_completion_chases_when_cover_blocks_the_shot() {
+        let (mut world, entity) = world_with_armed_ai(vec![ai_projectile()], 8.0);
+        let mut physics = PhysicsWorld::new();
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 4.0),
+            Quaternion::from_angle_y(cgmath::Deg(0.0)),
+            vec3(0.0, 0.0, 0.0),
+            vec3(10.0, 10.0, 0.5),
+            crate::physics::CollisionGroup::entity(),
+            false,
+        );
+        let mut player = physics.create_player(vec3(20.0, 20.0, 20.0), EntityId::dead());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        let NextBehavior::Next(next) = RangedAttackBehavior.next_behavior(&world, &physics, entity)
+        else {
+            panic!("blocked fire must select chase");
+        };
+        assert_eq!(next.borrow().name(), "Chase");
+    }
 }

--- a/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
@@ -44,10 +44,16 @@ impl Behavior for RangedAttackBehavior {
 
     fn next_behavior(
         &mut self,
-        _world: &World,
-        _physics: &PhysicsWorld,
-        _entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
     ) -> NextBehavior {
-        NextBehavior::Next(Box::new(RefCell::new(ChaseBehavior::new())))
+        // A completed shot is not a reason to walk. Recheck the same range,
+        // weapon and line-of-fire gates used when entering combat; chase
+        // only when no attack is available now.
+        NextBehavior::Next(
+            super::attack_behavior_for_distance(world, physics, entity_id)
+                .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new()))),
+        )
     }
 }

--- a/tools/shock2-sdk/test/ranged-attack-cycle.e2e.test.ts
+++ b/tools/shock2-sdk/test/ranged-attack-cycle.e2e.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+test("a shotgun hybrid repeats shots without a chase clip while the target remains reachable", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "eng1.mis" });
+  // Mission object 728 is an ordinary corridor encounter, unlike the
+  // off-map staging hybrids in MedSci. Discover its runtime ID on every run.
+  const [hybrid] = await game.entities.byTemplate(728);
+  assert.ok(hybrid && hybrid.name.includes("OG-Shotgun"));
+  const [x, y, z] = hybrid.position;
+  await game.player.teleport({ x: x!, y: y!, z: z! + 1.1 });
+  const hp = (await game.info()).player.hit_points!;
+  let attacks = 0;
+  let chases = 0;
+  for (let i = 0; i < 40; i++) {
+    await game.step({ frames: 30 });
+    const actor = await game.entities.detail(hybrid.id);
+    // Allow initial perception/alertness to settle before checking the cycle.
+    if (i < 10) continue;
+    const behavior = actor.properties.find(p => p.name === "AIBehavior")?.value ?? "";
+    if (behavior.includes("RangedAttack")) attacks++;
+    if (behavior.includes("Chase")) chases++;
+  }
+  assert.ok(attacks >= 20, `expected sustained firing, got ${attacks} ranged samples`);
+  assert.equal(chases, 0, "a completed firing clip must not insert a walk cycle");
+  assert.ok((await game.info()).player.hit_points! < hp, "the repeated shots must actually hit");
+});


### PR DESCRIPTION
A completed ranged attack previously forced every shooter into Chase, even with a target still in range and a clear line of fire. The next clip now reselects the available attack through the shared combat gates; lost line of fire or range still selects Chase, and dual-armed creatures can switch to melee.

An ordinary Engineering shotgun hybrid (mission object 728) reproduces the problem without injected alertness. Over the same 20-second sequence, the base samples 28 RangedAttack and 9 Chase states; the fix samples 37 RangedAttack and no Chase states. Player HP changes from 35 to 19 on base and 35 to 7 on the fix. This fixes the unconditional transition; it does not claim that every possible close-range line-of-fire problem is resolved.

Validation:

- New unit regression fails on base; fixed matrix covers contact range, normal firing range, distant targets, dual-armed melee, and blocked line of fire.
- Durable Engineering runtime regression fails on base with 9 unwanted Chase samples, then passes on the fix.
- Warning-free core, desktop, and debug-runtime checks; SDK build and formatting checks.
- Deterministic before/after visual capture attached below.

Fixes #1499


## Visual verification

![Ranged attack continuity](https://gist.githubusercontent.com/tommy-xr/5ca1f43bcf0c58ad7d331acf30d4fc07/raw/ranged-cycle.gif?v=2)

Identical eng1 encounter, captured headlessly with fixed 60 Hz stepping. Previously the shotgun hybrid repeatedly switched to Chase; now it continues firing while its target remains valid. The clip covers simulation seconds 4–16, with behavior and health labels from runtime snapshots.

### Before → after

![Before and after](https://gist.githubusercontent.com/tommy-xr/5ca1f43bcf0c58ad7d331acf30d4fc07/raw/before-after.png)

Combined AI-pass verification (all five PRs applied to baseline `a5d8cd54`):
- All newly added gameplay scenarios and all 23 mission loads passed; core unit tests and warning-free core/desktop/debug checks passed.
- Full SDK suite completed with four concurrent test files: **644 passed, 97 failed, 12 skipped**. Every one of the 97 failing test cases also failed on the unchanged baseline. The intermittent SHODAN corpse drift required baseline repeats and reproduced the exact same drift/positions.
- Full-suite verification found a missing BaseMonster restore dispatch for the new combat state; #1540 now includes the fix, a negative-first wrapper regression, and whole-mission save/load verification. The final full run uses that correction.

The full suite is therefore not green, but all reported failures have baseline reproductions. No PR has been merged.
