### PR TITLE
fix(ai): execute scripted metaproperty responses against the live player

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -107,6 +107,7 @@ use serde::{
 };
 
 use std::{
+    any::TypeId,
     collections::HashMap,
     convert::identity,
     fmt,
@@ -2449,6 +2450,14 @@ where
     fn initialize(&self, world: &mut World, entity: EntityId) {
         world.add_component(entity, self.clone());
     }
+
+    fn component_type_id(&self) -> TypeId {
+        TypeId::of::<C>()
+    }
+
+    fn remove(&self, world: &mut World, entity: EntityId) {
+        world.delete_component::<C>(entity);
+    }
 }
 
 #[derive(Debug)]
@@ -2484,6 +2493,14 @@ where
         drop(view);
         world.add_component(entity, value_to_set);
     }
+
+    fn component_type_id(&self) -> TypeId {
+        TypeId::of::<C>()
+    }
+
+    fn remove(&self, world: &mut World, entity: EntityId) {
+        world.delete_component::<C>(entity);
+    }
 }
 
 // `Send + Sync` is required so the level parse (which builds `Vec<Arc<Box<dyn Property>>>`)
@@ -2491,6 +2508,8 @@ where
 // for free: both blanket impls below already require `C: Send + Sync`.
 pub trait Property: fmt::Debug + Send + Sync {
     fn initialize(&self, world: &mut World, entity: EntityId);
+    fn component_type_id(&self) -> TypeId;
+    fn remove(&self, world: &mut World, entity: EntityId);
 }
 
 // `Send + Sync` so the shared `GlobalContext` (which holds these definition objects)

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -47,7 +47,7 @@ use dark::{
         PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
         PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropSymName,
-        PropTeleported, PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState,
+        PropTeleported, PropTemplateId, PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState,
         PropTweqModelConfig, PropertyDefinition, RenderType, TeleportSource, ToLink, TripFlags,
         TweqAnimationState, WrappedEntityId,
     },
@@ -93,9 +93,9 @@ use crate::{
     runtime_props::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropShotCooldown, RuntimePropShotModifiers, RuntimePropTransform, RuntimePropVhots,
-        RuntimePropVrGripOffset,
+        RuntimePropLaunchedProjectile, RuntimePropMetaProperties, RuntimePropReloading,
+        RuntimePropSelectedAmmo, RuntimePropShotCooldown, RuntimePropShotModifiers,
+        RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -2064,6 +2064,259 @@ impl GlobalTemplateHierarchy {
     /// Whether `template_id` is `class_template_id` or inherits from it.
     pub fn is_or_descends_from(&self, template_id: i32, class_template_id: i32) -> bool {
         template_is_or_descends_from(&self.0, template_id, class_template_id)
+    }
+}
+
+fn template_lineage_excluding(
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    template_id: i32,
+    excluded: &HashSet<i32>,
+) -> Vec<i32> {
+    fn visit(
+        hierarchy: &HashMap<i32, Vec<i32>>,
+        parents: Option<&Vec<i32>>,
+        excluded: &HashSet<i32>,
+        visited: &mut HashSet<i32>,
+        out: &mut Vec<i32>,
+    ) {
+        let Some(parents) = parents else { return };
+        for parent in parents {
+            if !excluded.contains(parent) && visited.insert(*parent) {
+                out.push(*parent);
+            }
+        }
+        for parent in parents {
+            if !excluded.contains(parent) {
+                visit(hierarchy, hierarchy.get(parent), excluded, visited, out);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    visit(
+        hierarchy,
+        hierarchy.get(&template_id),
+        excluded,
+        &mut HashSet::new(),
+        &mut out,
+    );
+    out.dedup();
+    out.reverse();
+    out
+}
+
+/// Apply one runtime metaproperty relation change without rebuilding unrelated
+/// live state. Only component types contributed by the changed branch are
+/// removed and then recomposed from the remaining authored/dynamic ancestry.
+fn apply_meta_property_relation(
+    world: &mut World,
+    entity_info: &SystemShock2EntityInfo,
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    entity_id: EntityId,
+    meta_template_id: i32,
+    add: bool,
+) -> bool {
+    let entity_template_id = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|templates| templates.get(entity_id).ok().map(|id| id.template_id));
+    let Some(entity_template_id) = entity_template_id else {
+        return false;
+    };
+
+    let mut state = world
+        .borrow::<View<RuntimePropMetaProperties>>()
+        .ok()
+        .and_then(|states| states.get(entity_id).ok().cloned())
+        .unwrap_or_default();
+    let statically_inherited = dark::ss2_entity_info::get_ancestors(hierarchy, &entity_template_id)
+        .contains(&meta_template_id);
+    let present = state.added.contains(&meta_template_id)
+        || (statically_inherited && !state.removed.contains(&meta_template_id));
+    // Adding an existing relation (or removing an absent one) is a no-op.
+    // Recomposition here would overwrite subsequent live property changes.
+    if add == present {
+        return true;
+    }
+    if add {
+        state.removed.retain(|id| *id != meta_template_id);
+        if !statically_inherited && !state.added.contains(&meta_template_id) {
+            state.added.push(meta_template_id);
+        }
+    } else {
+        state.added.retain(|id| *id != meta_template_id);
+        if !state.removed.contains(&meta_template_id) {
+            state.removed.push(meta_template_id);
+        }
+    }
+
+    let no_exclusions = HashSet::new();
+    let mut affected_templates =
+        template_lineage_excluding(hierarchy, meta_template_id, &no_exclusions);
+    affected_templates.push(meta_template_id);
+    let affected_properties = affected_templates
+        .iter()
+        .filter_map(|template| entity_info.entity_to_properties.get(template))
+        .flat_map(|properties| properties.iter().cloned())
+        .collect::<Vec<_>>();
+    let affected_types = affected_properties
+        .iter()
+        .map(|property| property.component_type_id())
+        .collect::<HashSet<_>>();
+
+    // Delete each affected component type once. The representative property
+    // knows its concrete Shipyard component despite this layer being erased.
+    let mut removed_types = HashSet::new();
+    for property in &affected_properties {
+        if removed_types.insert(property.component_type_id()) {
+            property.remove(world, entity_id);
+        }
+    }
+
+    let excluded = state.removed.iter().copied().collect::<HashSet<_>>();
+    let mut effective_templates =
+        template_lineage_excluding(hierarchy, entity_template_id, &excluded);
+    effective_templates.push(entity_template_id);
+    for added in &state.added {
+        for template in template_lineage_excluding(hierarchy, *added, &excluded) {
+            if !effective_templates.contains(&template) {
+                effective_templates.push(template);
+            }
+        }
+        if !effective_templates.contains(added) {
+            effective_templates.push(*added);
+        }
+    }
+
+    for template in effective_templates {
+        if let Some(properties) = entity_info.entity_to_properties.get(&template) {
+            for property in properties {
+                if affected_types.contains(&property.component_type_id()) {
+                    property.initialize(world, entity_id);
+                }
+            }
+        }
+    }
+    world.add_component(entity_id, state);
+    true
+}
+
+#[cfg(test)]
+mod meta_property_tests {
+    use super::*;
+    use dark::properties::{AIAlertLevel, PropAIAlertCap, Property};
+    use std::sync::Arc;
+
+    fn boxed_property<T: Property + 'static>(property: T) -> Arc<Box<dyn Property>> {
+        Arc::new(Box::new(property))
+    }
+
+    #[test]
+    fn removing_and_adding_meta_recomposes_only_its_component_types() {
+        const BASE: i32 = -10;
+        const DOCILE: i32 = -20;
+        const ENTITY_TEMPLATE: i32 = 30;
+        let ordinary_cap = PropAIAlertCap {
+            max_level: AIAlertLevel::High,
+            min_level: AIAlertLevel::Lowest,
+            min_relax: AIAlertLevel::Low,
+        };
+        let docile_cap = PropAIAlertCap {
+            max_level: AIAlertLevel::Lowest,
+            min_level: AIAlertLevel::Lowest,
+            min_relax: AIAlertLevel::Lowest,
+        };
+        // Dark stores direct parents derived-first; traversal reverses them to
+        // initialize base first and let Docile override its alert cap.
+        let hierarchy = HashMap::from([(ENTITY_TEMPLATE, vec![DOCILE, BASE])]);
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        entity_info
+            .entity_to_properties
+            .insert(BASE, vec![boxed_property(ordinary_cap.clone())]);
+        entity_info
+            .entity_to_properties
+            .insert(DOCILE, vec![boxed_property(docile_cap.clone())]);
+
+        let mut world = World::new();
+        let entity = world.add_entity((
+            PropTemplateId {
+                template_id: ENTITY_TEMPLATE,
+            },
+            docile_cap,
+            PropHitPoints { hit_points: 73 },
+        ));
+
+        assert!(apply_meta_property_relation(
+            &mut world,
+            &entity_info,
+            &hierarchy,
+            entity,
+            DOCILE,
+            false,
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropAIAlertCap>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .max_level,
+            AIAlertLevel::High
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropHitPoints>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .hit_points,
+            73,
+            "unrelated live state must not be rebuilt"
+        );
+
+        assert!(apply_meta_property_relation(
+            &mut world,
+            &entity_info,
+            &hierarchy,
+            entity,
+            DOCILE,
+            true,
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropAIAlertCap>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .max_level,
+            AIAlertLevel::Lowest
+        );
+        {
+            let states = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
+            let state = states.get(entity).unwrap();
+            assert!(state.added.is_empty());
+            assert!(state.removed.is_empty());
+        }
+        // Repeating Add must not undo an explicit live override made since
+        // the first Add (the relation itself has not changed).
+        world.add_component(entity, ordinary_cap);
+        assert!(apply_meta_property_relation(
+            &mut world,
+            &entity_info,
+            &hierarchy,
+            entity,
+            DOCILE,
+            true
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropAIAlertCap>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .max_level,
+            AIAlertLevel::High
+        );
     }
 }
 
@@ -10260,6 +10513,50 @@ impl MissionCore {
                                 );
                             }
                         }
+                    }
+                }
+
+                Effect::SetMetaProperty {
+                    entity_id,
+                    name,
+                    add,
+                } => {
+                    let template_id = self
+                        .template_name_to_template_id
+                        .get(&name.to_ascii_lowercase())
+                        .map(|metadata| metadata.template_id);
+                    let hierarchy = self
+                        .world
+                        .borrow::<UniqueView<GlobalTemplateHierarchy>>()
+                        .ok()
+                        .map(|hierarchy| hierarchy.0.clone());
+                    let applied =
+                        template_id
+                            .zip(hierarchy)
+                            .is_some_and(|(template_id, hierarchy)| {
+                                apply_meta_property_relation(
+                                    &mut self.world,
+                                    &self.entity_info,
+                                    &hierarchy,
+                                    entity_id,
+                                    template_id,
+                                    add,
+                                )
+                            });
+                    if applied {
+                        effects.push_front(Effect::Send {
+                            msg: Message {
+                                to: entity_id,
+                                payload: MessagePayload::RefreshAIProperties,
+                            },
+                        });
+                    } else {
+                        warn!(
+                            "scripted metaproperty {} '{}' could not be applied to {:?}",
+                            if add { "Add" } else { "Remove" },
+                            name,
+                            entity_id
+                        );
                     }
                 }
                 Effect::SetAICurrentPatrol { entity_id, target } => {

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -52,6 +52,18 @@ pub struct RuntimePropAITargetAwareness {
 #[derive(Component, Clone, Copy)]
 pub struct RuntimePropLocomotionScale(pub f32);
 
+/// Runtime changes to an object's authored metaproperty relations.
+///
+/// The effective Dark properties themselves are saved through the ordinary
+/// property registry. This relation delta is persisted separately by
+/// `EntitySaveData` so a later scripted Add/Remove can still recompose only
+/// the affected component types after a load.
+#[derive(Component, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RuntimePropMetaProperties {
+    pub added: Vec<i32>,
+    pub removed: Vec<i32>,
+}
+
 #[derive(Component)]
 pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
 

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -7,7 +7,7 @@ use shipyard::{EntityId, World};
 
 use crate::runtime_props::{
     RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropLaunchedProjectile,
-    RuntimePropPlayerFiredProjectile, RuntimePropSelectedAmmo,
+    RuntimePropMetaProperties, RuntimePropPlayerFiredProjectile, RuntimePropSelectedAmmo,
 };
 use crate::scripts::SavedScriptState;
 
@@ -56,6 +56,11 @@ pub struct EntitySaveData {
     pub player_fired_projectiles: Vec<u64 /* entity id */>,
     #[serde(default)]
     pub projectile_velocities: HashMap<u64, cgmath::Vector3<f32>>,
+    /// Runtime Add/Remove metaproperty relation deltas. The resulting Dark
+    /// components are already in `properties`; this preserves enough relation
+    /// state for a later scripted metaproperty action to recompose correctly.
+    #[serde(default)]
+    pub meta_properties: HashMap<u64 /* entity id */, RuntimePropMetaProperties>,
     /// Opt-in private state owned by scripts on these entities. Registered ECS
     /// properties and links remain in their existing fields above; this is only
     /// for runtime modes, timers, latches, and similar script internals.
@@ -80,6 +85,7 @@ impl EntitySaveData {
             launched_projectiles: Vec::new(),
             player_fired_projectiles: Vec::new(),
             projectile_velocities: HashMap::new(),
+            meta_properties: HashMap::new(),
             script_states: Vec::new(),
         }
     }
@@ -190,6 +196,12 @@ impl EntitySaveData {
             let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
             if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
                 world.add_component(*new_entity_id, RuntimePropPlayerFiredProjectile);
+            }
+        }
+        for (old_entity_id, meta_properties) in &self.meta_properties {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, meta_properties.clone());
             }
         }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
@@ -332,6 +344,33 @@ mod tests {
         .unwrap();
 
         assert!(save.death_poses.is_empty());
+        assert!(save.meta_properties.is_empty());
+    }
+
+    #[test]
+    fn instantiate_restores_runtime_metaproperty_relations() {
+        let old_entity = EntityId::new_from_index_and_gen(22, 1);
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(old_entity.inner());
+        data.meta_properties.insert(
+            old_entity.inner(),
+            RuntimePropMetaProperties {
+                added: vec![-40],
+                removed: vec![-1073],
+            },
+        );
+
+        let mut world = World::new();
+        let (_, remap) = data.instantiate(&mut world);
+        let restored = remap[&old_entity];
+        let states = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
+        assert_eq!(
+            states.get(restored).unwrap(),
+            &RuntimePropMetaProperties {
+                added: vec![-40],
+                removed: vec![-1073],
+            }
+        );
     }
 
     #[test]

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -24,7 +24,8 @@ use crate::{
     mission::{GlobalTemplateIdMap, PlayerInfo},
     runtime_props::{
         RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropDoNotSerialize,
-        RuntimePropLaunchedProjectile, RuntimePropPlayerFiredProjectile, RuntimePropSelectedAmmo,
+        RuntimePropLaunchedProjectile, RuntimePropMetaProperties, RuntimePropPlayerFiredProjectile,
+        RuntimePropSelectedAmmo,
     },
     scripts::{ScriptWorld, script_util},
     util::partition_map,
@@ -143,6 +144,7 @@ pub fn to_save_data_with_scripts(
     let v_launched_projectiles = world
         .borrow::<View<RuntimePropLaunchedProjectile>>()
         .unwrap();
+    let v_meta_properties = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
     let v_entities = world.borrow::<EntitiesView>().unwrap();
 
     let (all_properties, _, _) = dark::properties::get::<File>();
@@ -280,6 +282,16 @@ pub fn to_save_data_with_scripts(
         .map(|(id, velocity)| (id.inner(), velocity.0))
         .filter(|(id, _)| !entities_to_filter.contains(id))
         .partition(|(id, _)| held_entities.contains(id));
+    let raw_meta_properties: HashMap<u64, RuntimePropMetaProperties> = v_meta_properties
+        .iter()
+        .with_id()
+        .filter(|(entity_id, _)| !entities_to_filter.contains(&entity_id.inner()))
+        .map(|(entity_id, state)| (entity_id.inner(), state.clone()))
+        .collect();
+    let (held_meta_properties, world_meta_properties) =
+        partition_map(raw_meta_properties, |entity_id| {
+            held_entities.contains(entity_id)
+        });
     let world_entity_data = EntitySaveData {
         security_alarm: Some(crate::security_alarm::status(world)),
         properties: world_serialized_properties,
@@ -295,6 +307,7 @@ pub fn to_save_data_with_scripts(
         launched_projectiles: world_launched_projectiles,
         player_fired_projectiles: world_player_fired_projectiles,
         projectile_velocities: world_velocities.into_iter().collect(),
+        meta_properties: world_meta_properties,
         script_states: world_script_states,
     };
 
@@ -313,6 +326,7 @@ pub fn to_save_data_with_scripts(
         launched_projectiles: held_launched_projectiles,
         player_fired_projectiles: held_player_fired_projectiles,
         projectile_velocities: held_velocities.into_iter().collect(),
+        meta_properties: held_meta_properties,
         script_states: held_script_states,
     };
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1766,6 +1766,10 @@ impl Script for AnimatedMonsterAI {
                     Effect::NoEffect
                 }
             }
+            MessagePayload::RefreshAIProperties => {
+                self.config = Self::build_config(world, entity_id);
+                Effect::NoEffect
+            }
             MessagePayload::SetAlertness { level, pin } => {
                 // Dead AIs stay dead - a corpse keeps a live script, and the
                 // broadcast (DebugAlertAll) reaches every creature

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -4,9 +4,9 @@ use cgmath::{Deg, InnerSpace, vec3};
 use dark::{
     SCALE_FACTOR,
     motion::MotionQueryItem,
-    properties::{AIScriptedAction, AIScriptedActionType, PropPosition},
+    properties::{AIScriptedAction, AIScriptedActionType, PropLocalPlayer, PropPosition},
 };
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 
 use crate::{
     physics::PhysicsWorld,
@@ -114,6 +114,10 @@ impl Behavior for ScriptedSequenceBehavior {
 
     fn turn_speed(&self) -> Deg<f32> {
         self.current_scripted_action.borrow().turn_speed()
+    }
+
+    fn is_locomotion(&self) -> bool {
+        self.current_scripted_action.borrow().is_locomotion()
     }
 
     fn steer(
@@ -236,12 +240,35 @@ fn get_behavior_from_action(
             speed: _, // TODO: Incorporate speed
         } => Box::new(RefCell::new(GotoScriptedAction::new(world, &waypoint_name))),
 
+        AIScriptedActionType::MetaProperty {
+            action_type,
+            arg1,
+            arg2: _,
+        } => Box::new(RefCell::new(MetaPropertyScriptedAction::new(
+            owner,
+            action_type,
+            arg1,
+        ))),
+
         AIScriptedActionType::Wait(duration) => {
             Box::new(RefCell::new(WaitScriptedAction::new(*duration)))
         }
         _ => Box::new(RefCell::new(NoopScriptedAction)),
     };
     current_behavior
+}
+
+/// Dark scripted actions reserve `player` as a target name. The runtime
+/// player is synthetic and intentionally has no `PropSymName`, so ordinary
+/// by-name lookup cannot resolve it.
+fn resolve_scripted_target(world: &World, entity_name: &str) -> Option<EntityId> {
+    if entity_name.eq_ignore_ascii_case("player") {
+        return world
+            .borrow::<View<PropLocalPlayer>>()
+            .ok()
+            .and_then(|players| players.iter().with_id().next().map(|(id, _)| id));
+    }
+    script_util::get_first_entity_by_name(world, entity_name)
 }
 
 /// ScriptedAction
@@ -265,6 +292,10 @@ trait ScriptedAction {
 
     fn completion_effect(&self) -> Effect {
         Effect::NoEffect
+    }
+
+    fn is_locomotion(&self) -> bool {
+        false
     }
 
     /// Called when the entity's current animation clip finishes (also fires
@@ -390,7 +421,7 @@ pub struct SendSignalScriptedAction {
 impl SendSignalScriptedAction {
     pub fn new(world: &World, entity_name: &str, signal: String) -> SendSignalScriptedAction {
         SendSignalScriptedAction {
-            target: script_util::get_first_entity_by_name(world, entity_name),
+            target: resolve_scripted_target(world, entity_name),
             signal,
         }
     }
@@ -422,6 +453,45 @@ impl ScriptedAction for NoopScriptedAction {
     fn animation(self: &NoopScriptedAction) -> Vec<MotionQueryItem> {
         // vec![MotionQueryItem::with_value("cs", 2)]
         vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+}
+
+pub struct MetaPropertyScriptedAction {
+    owner: EntityId,
+    name: String,
+    add: Option<bool>,
+}
+
+impl MetaPropertyScriptedAction {
+    fn new(owner: EntityId, action_type: &str, name: &str) -> Self {
+        let add = if action_type.eq_ignore_ascii_case("add") {
+            Some(true)
+        } else if action_type.eq_ignore_ascii_case("remove") {
+            Some(false)
+        } else {
+            None
+        };
+        Self {
+            owner,
+            name: name.to_owned(),
+            add,
+        }
+    }
+}
+
+impl ScriptedAction for MetaPropertyScriptedAction {
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+
+    fn initial_effect(&self) -> Effect {
+        self.add
+            .map(|add| Effect::SetMetaProperty {
+                entity_id: self.owner,
+                name: self.name.clone(),
+                add,
+            })
+            .unwrap_or(Effect::NoEffect)
     }
 }
 
@@ -463,7 +533,7 @@ pub struct FrobScriptedAction(Option<EntityId>);
 
 impl FrobScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> FrobScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
+        let maybe_entity = resolve_scripted_target(world, entity_name);
         FrobScriptedAction(maybe_entity)
     }
 }
@@ -488,31 +558,76 @@ impl ScriptedAction for FrobScriptedAction {
 }
 
 pub struct GotoScriptedAction {
-    target_id: Option<EntityId>,
+    target: GotoTarget,
     steering_strategy: Box<dyn SteeringStrategy>,
+}
+
+enum GotoTarget {
+    Player,
+    Entity(EntityId),
+    Missing,
+}
+
+/// A script orders travel to the live player, independently of combat memory.
+struct ScriptedPlayerSteering;
+
+fn scripted_player_position(world: &World) -> Option<cgmath::Vector3<f32>> {
+    world
+        .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
+        .ok()
+        .map(|player| player.pos)
+}
+
+impl SteeringStrategy for ScriptedPlayerSteering {
+    fn steer(
+        &mut self,
+        _heading: Deg<f32>,
+        world: &World,
+        _physics: &PhysicsWorld,
+        entity: EntityId,
+        _time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        let target = scripted_player_position(world)?;
+        let positions = world.borrow::<View<PropPosition>>().ok()?;
+        let position = positions.get(entity).ok()?.position;
+        Some((
+            Steering::turn_to_point(
+                crate::util::vec3_to_point3(position),
+                crate::util::vec3_to_point3(target),
+            ),
+            Effect::NoEffect,
+        ))
+    }
 }
 
 impl GotoScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> GotoScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
-
         let mut steering_strategies: Vec<Box<dyn SteeringStrategy>> = vec![Box::new(
             CollisionAvoidanceSteeringStrategy::conservative(), /* conservative so we can focus on the chase */
         )];
 
-        if let Some(ent) = maybe_entity {
-            steering_strategies.push(Box::new(ChaseEntitySteeringStrategy::new(ent)))
-            //steering_strategies.push(Box::new(ChasePlayerSteeringStrategy))
-        }
+        let target = if entity_name.eq_ignore_ascii_case("player") {
+            steering_strategies.push(Box::new(ScriptedPlayerSteering));
+            GotoTarget::Player
+        } else if let Some(entity) = resolve_scripted_target(world, entity_name) {
+            steering_strategies.push(Box::new(ChaseEntitySteeringStrategy::new(entity)));
+            GotoTarget::Entity(entity)
+        } else {
+            GotoTarget::Missing
+        };
 
         GotoScriptedAction {
-            target_id: maybe_entity,
+            target,
             steering_strategy: steering::chained(steering_strategies),
         }
     }
 }
 
 impl ScriptedAction for GotoScriptedAction {
+    fn is_locomotion(&self) -> bool {
+        true
+    }
+
     fn turn_speed(&self) -> Deg<f32> {
         Deg(540.0)
     }
@@ -536,22 +651,31 @@ impl ScriptedAction for GotoScriptedAction {
     }
 
     fn is_complete(&self, entity_id: EntityId, world: &World) -> bool {
-        let v_prop_pos = world.borrow::<View<PropPosition>>().unwrap();
-        if let Some(target_entity_id) = self.target_id {
-            if let Ok(target_pos) = v_prop_pos.get(target_entity_id) {
-                if let Ok(entity_pos) = v_prop_pos.get(entity_id) {
-                    let from = vec3(entity_pos.position.x, 0.0, entity_pos.position.z);
-                    let to = vec3(target_pos.position.x, 0.0, target_pos.position.z);
-                    let distance = (from - to).magnitude();
+        match self.target {
+            GotoTarget::Player => scripted_player_position(world).is_none_or(|target| {
+                let positions = world.borrow::<View<PropPosition>>().unwrap();
+                positions.get(entity_id).is_ok_and(|position| {
+                    let delta = target - position.position;
+                    vec3(delta.x, 0.0, delta.z).magnitude() < (3.0 / SCALE_FACTOR)
+                })
+            }),
+            GotoTarget::Entity(target_entity_id) => {
+                let v_prop_pos = world.borrow::<View<PropPosition>>().unwrap();
+                if let Ok(target_pos) = v_prop_pos.get(target_entity_id) {
+                    if let Ok(entity_pos) = v_prop_pos.get(entity_id) {
+                        let from = vec3(entity_pos.position.x, 0.0, entity_pos.position.z);
+                        let to = vec3(target_pos.position.x, 0.0, target_pos.position.z);
+                        let distance = (from - to).magnitude();
 
-                    // HACK: This is an arbitrary value that I just tested with some sequences
-                    // (ie, in rec1). I'm not sure the best criteria for this step yet.
-                    return distance < (3.0 / SCALE_FACTOR);
+                        // HACK: This is an arbitrary value that I just tested with some sequences
+                        // (ie, in rec1). I'm not sure the best criteria for this step yet.
+                        return distance < (3.0 / SCALE_FACTOR);
+                    }
                 }
+                true
             }
+            GotoTarget::Missing => true,
         }
-
-        true
     }
 }
 
@@ -562,7 +686,7 @@ pub struct FaceScriptedAction {
 
 impl FaceScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> FaceScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
+        let maybe_entity = resolve_scripted_target(world, entity_name);
 
         let mut steering_strategies: Vec<Box<dyn SteeringStrategy>> = vec![];
 
@@ -613,5 +737,97 @@ impl ScriptedAction for FaceScriptedAction {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::PlayerInfo;
+    use cgmath::{One, Quaternion};
+    use dark::properties::PropSymName;
+
+    #[test]
+    fn reserved_player_target_resolves_without_a_symbolic_name() {
+        let mut world = World::new();
+        let player = world.add_entity(PropLocalPlayer {});
+        let named = world.add_entity(PropSymName("Waypoint".to_owned()));
+
+        assert_eq!(resolve_scripted_target(&world, "PLAYER"), Some(player));
+        assert_eq!(resolve_scripted_target(&world, "waypoint"), Some(named));
+    }
+
+    #[test]
+    fn metaproperty_action_emits_a_pure_world_effect() {
+        let mut world = World::new();
+        let owner = world.add_entity(());
+        let action = AIScriptedAction {
+            action_type: AIScriptedActionType::MetaProperty {
+                action_type: "Remove".to_owned(),
+                arg1: "Docile".to_owned(),
+                arg2: String::new(),
+            },
+        };
+
+        let behavior = get_behavior_from_action(&world, owner, &action);
+        assert!(matches!(
+            behavior.borrow().initial_effect(),
+            Effect::SetMetaProperty {
+                entity_id,
+                ref name,
+                add: false,
+            } if entity_id == owner && name == "Docile"
+        ));
+    }
+
+    #[test]
+    fn goto_player_uses_live_player_position_and_requests_locomotion() {
+        let mut world = World::new();
+        let owner = world.add_entity(PropPosition {
+            position: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::one(),
+            cell: 0,
+        });
+        let player = world.add_entity(PropLocalPlayer {});
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 10.0),
+            rotation: Quaternion::one(),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let action = GotoScriptedAction::new(&world, "player");
+        assert!(action.is_locomotion());
+        assert!(!action.is_complete(owner, &world));
+        // Scripted orders target the live player even when combat awareness
+        // still points to the actor's own position.
+        world.add_component(
+            owner,
+            crate::runtime_props::RuntimePropAITargetAwareness {
+                last_known_pos: vec3(0.0, 0.0, 0.0),
+                has_line_of_sight: false,
+            },
+        );
+        assert!(
+            !action.is_complete(owner, &world),
+            "stale combat memory must not complete Goto player"
+        );
+        let (steering, _) = ScriptedPlayerSteering
+            .steer(
+                Deg(90.0),
+                &world,
+                &PhysicsWorld::new(),
+                owner,
+                &Time::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            steering.desired_heading,
+            Deg(0.0),
+            "face the live player, not remembered combat position"
+        );
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -1002,6 +1002,14 @@ pub enum Effect {
         update: AIPropertyUpdate,
     },
 
+    /// Add or remove one named Dark metaproperty and recompose only the
+    /// component types contributed by that metaproperty's inheritance branch.
+    SetMetaProperty {
+        entity_id: EntityId,
+        name: String,
+        add: bool,
+    },
+
     /// Replace Dark's runtime-only `AICurrentPatrol` relation for one AI.
     /// `None` removes the relation when patrol stops or gives up.
     SetAICurrentPatrol {

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -347,6 +347,10 @@ pub enum MessagePayload {
         name: String,
     },
 
+    /// A metaproperty mutation changed authored AI configuration components;
+    /// rebuild the script's cached view after the effect applier updates ECS.
+    RefreshAIProperties,
+
     // Debug: force an AI's alertness level (clamped by its alert cap).
     // `pin` holds it against decay (and tracks the live player) until a
     // non-pinned SetAlertness clears it.

--- a/tools/shock2-sdk/test/ops4-scripted-droid.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-scripted-droid.e2e.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const port = Number(process.env.SHOCK2_E2E_PORT ?? 8398);
+
+const TRIPWIRE = 519;
+const SIGNAL_TRAP = 1315;
+const SECURITY_DROID = 325;
+const DOORS = [514, 515] as const;
+
+test(
+  "ops4: IRobot response removes Docile and clears the Command Center entrance (#1108)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [tripwire] = await game.entities.byTemplate(TRIPWIRE);
+    const [signalTrap] = await game.entities.byTemplate(SIGNAL_TRAP);
+    const [droid] = await game.entities.byTemplate(SECURITY_DROID);
+    assert.ok(tripwire, `expected Ops4 tripwire ${TRIPWIRE}`);
+    assert.ok(signalTrap, `expected Ops4 AI Signal Trap ${SIGNAL_TRAP}`);
+    assert.ok(droid, `expected Ops4 Security Droid ${SECURITY_DROID}`);
+    const initialDroid = await game.entities.detail(droid.id);
+
+    // Spatial setup stays north of the tripwire. Enter it with the bounded,
+    // collision-valid player movement path that drives production sensors.
+    await game.player.teleport({ x: 66.0, y: -9.556, z: -87.0 });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 5 });
+    const move = async (stick: [number, number], frames: number) => {
+      await game.input.set("right_hand.thumbstick", stick);
+      await game.step({ frames });
+    };
+    await move([0, 1], 30);
+    await move([0, 0], 60);
+
+    const trace = (await game.messages.recent()).messages;
+    assert.ok(
+      trace.some(
+        (message) =>
+          message.payload === "TurnOn" &&
+          message.from?.template_id === TRIPWIRE &&
+          message.to.template_id === SIGNAL_TRAP,
+      ),
+      `tripwire must activate the authored signal trap: ${JSON.stringify(trace)}`,
+    );
+    assert.ok(
+      trace.some(
+        (message) =>
+          message.payload === "Signal" &&
+          message.to.template_id === SECURITY_DROID,
+      ),
+      `signal trap must deliver IRobot to the droid: ${JSON.stringify(trace)}`,
+    );
+
+    const openedDoors = await Promise.all(
+      DOORS.map(async (template) => (await game.entities.byTemplate(template))[0]),
+    );
+    assert.ok(openedDoors.every(Boolean), "expected both Command Center door leaves");
+    assert.ok(
+      openedDoors[0].position[0] < 63 && openedDoors[1].position[0] > 69,
+      `tripwire should fully spread both door leaves: ${JSON.stringify(openedDoors)}`,
+    );
+
+    // Draw the scripted Goto target away from the 3.2-unit opening. Before
+    // the fix the droid remains near z=-93.5 in Idle, filling the doorway.
+    await move([0, -1], 40);
+    await move([0, 0], 600);
+    const movedDroid = await game.entities.detail(droid.id);
+    assert.ok(
+      movedDroid.position[2] > -90.5,
+      `IRobot droid must leave the doorway toward the player; got ${JSON.stringify(movedDroid)}`,
+    );
+    assert.ok(
+      movedDroid.position[2] - initialDroid.position[2] > 3,
+      `the droid's full collider must clear its authored doorway position: ` +
+        `${JSON.stringify(initialDroid.position)} -> ${JSON.stringify(movedDroid.position)}`,
+    );
+    // Walk around the advancing droid and through the actual opening. No
+    // teleport, direct moveTo, or injected script message after initial setup.
+    await move([-1, 0], 8);
+    await move([0, 1], 120);
+    // Avoid relying on incidental collision deflection to align us with
+    // the narrow doorway. Steer from observed position if its jamb catches us.
+    for (let attempt = 0; attempt < 60; attempt++) {
+      const p = await game.player.position();
+      if (p.z < -96) break;
+      const dx = 66 - p.x;
+      const dz = -98 - p.z;
+      const length = Math.hypot(dx, dz);
+      await move(p.z < -90.5 && Math.abs(dx) > 0.2
+        ? [-Math.sign(dx) * 0.35, 0]
+        : [-dx / length, -dz / length], 6);
+    }
+    await move([0, 0], 10);
+    const player = (await game.info()).player;
+    assert.ok(player.position[2]! < -96, `must enter the Command Center: ${JSON.stringify(player.position)}`);
+  },
+);


### PR DESCRIPTION
Ops4’s IRobot response now removes the droid’s Docile metaproperty and executes Goto player through ordinary AI locomotion. The real entrance tripwire/signal chain moves the droid about 3.7 units away from its starting doorway position; a runtime regression then walks into the Command Center using ordinary input.

This refreshes the AI-only commit from #1112 onto current main, without its old loot-transfer stack. Review found and fixed two gaps: scripted player travel used stale combat awareness instead of the live player, and repeating an unchanged metaproperty relation could reapply properties over later live changes. Both have focused regressions. Reserved player targets resolve without a symbolic name; metaproperty effects recompose affected component types and preserve relation deltas through save/load.

The original issue overstated the physical blockage: a side approach also squeezes past the unfixed droid. The confirmed defect is the missing authored response. The test separately requires the droid to advance and the player to pass, rather than claiming every base route is impassable.

Validation:

- Stale-awareness regression fails with the old PR implementation and passes with live-player targeting.
- Repeated-Add regression fails without the idempotence guard and passes with it.
- Base production replay fails on the stationary droid; fixed replay passes using tripwire 519, signal trap 1315, droid 325, and ordinary locomotion after initial nearby setup.
- 1,800 library tests passed, 2 ignored; focused metaproperty/targeting tests and warning-free core/runtime checks passed.
- Before/after VR GIF and stills attached below.

Supersedes #1112. Fixes #1108.


### Visual verification

![Ops4 authored IRobot response before and after](https://gist.githubusercontent.com/tommy-xr/551fad4989d799902e1dc98c564c423f/raw/ops4-doorway.gif)

The same VR input sequence activates the authored tripwire, retreats, waits, then walks around the droid into the Command Center. After the fix, the droid follows the scripted signal about 3.7 world units out of its entrance position toward the player. Both builds can skirt the doorway in this capture; the demonstrated correction is the authored scripted response, not a claim that every baseline approach is blocked. Captured headlessly with fixed 60 Hz stepping; only the initial nearby setup uses teleportation.

![Before and after the scripted pursuit](https://gist.githubusercontent.com/tommy-xr/551fad4989d799902e1dc98c564c423f/raw/before-after.png)

![Both builds after ordinary locomotion through the entrance](https://gist.githubusercontent.com/tommy-xr/551fad4989d799902e1dc98c564c423f/raw/passage.png)

Combined AI-pass verification (all five PRs applied to baseline `a5d8cd54`):
- All newly added gameplay scenarios and all 23 mission loads passed; core unit tests and warning-free core/desktop/debug checks passed.
- Full SDK suite completed with four concurrent test files: **644 passed, 97 failed, 12 skipped**. Every one of the 97 failing test cases also failed on the unchanged baseline. The intermittent SHODAN corpse drift required baseline repeats and reproduced the exact same drift/positions.
- Full-suite verification found a missing BaseMonster restore dispatch for the new combat state; #1540 now includes the fix, a negative-first wrapper regression, and whole-mission save/load verification. The final full run uses that correction.

The full suite is therefore not green, but all reported failures have baseline reproductions. No PR has been merged.
