### PR TITLE
feat(ai): honor authored ranged retreat preferences

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -8,6 +8,7 @@ mod prop_ai_device;
 mod prop_ai_grub;
 mod prop_ai_hearing;
 mod prop_ai_mode;
+mod prop_ai_ranged_combat;
 mod prop_ai_swarm;
 mod prop_ambient_hacked;
 mod prop_anim_light;
@@ -59,6 +60,7 @@ pub use prop_ai_device::*;
 pub use prop_ai_grub::*;
 pub use prop_ai_hearing::*;
 pub use prop_ai_mode::*;
+pub use prop_ai_ranged_combat::*;
 pub use prop_ai_swarm::*;
 pub use prop_ambient_hacked::*;
 pub use prop_anim_light::*;
@@ -2242,6 +2244,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$JointPos",
             PropJointPositions::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AIRCProp",
+            PropAIRangedCombat::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AIRCRange",
+            PropAIRangedRanges::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_ai_ranged_combat.rs
+++ b/dark/src/properties/prop_ai_ranged_combat.rs
@@ -1,0 +1,145 @@
+use std::io::{self, SeekFrom};
+
+use shipyard::Component;
+
+use crate::ss2_common::{read_i32, read_single};
+
+use serde::{Deserialize, Serialize};
+
+/// `P$AIRCProp` - how a ranged AI wants to stand off from its target, in
+/// on-disk field order (7 four-byte fields, 28 bytes).
+///
+/// Distances are stored as Dark-unit integers. They score candidate standing
+/// positions; the minimum is not a prohibition on firing at a nearby target.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropAIRangedCombat {
+    /// Closest desirable standing distance, in Dark units.
+    pub minimum_distance: i32,
+    /// The range the AI manoeuvres toward.
+    pub ideal_distance: i32,
+    /// Seconds it waits before loosing a shot.
+    pub firing_delay: f32,
+    /// How strongly it prefers to shoot from cover.
+    pub cover_desire: i32,
+    pub decay_speed: f32,
+    /// Authored moving-fire preference (0..5), not a boolean.
+    pub fire_while_moving: i32,
+    pub contain_projectile: i32,
+}
+
+impl PropAIRangedCombat {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropAIRangedCombat {
+        // Take each field only if the record is long enough to hold it, then
+        // snap to the end of the chunk, so a short mission override parses.
+        let start = reader.stream_position().unwrap();
+        let minimum_distance = if len >= 4 { read_i32(reader) } else { 0 };
+        let ideal_distance = if len >= 8 { read_i32(reader) } else { 0 };
+        let firing_delay = if len >= 12 { read_single(reader) } else { 0.0 };
+        let cover_desire = if len >= 16 { read_i32(reader) } else { 0 };
+        let decay_speed = if len >= 20 { read_single(reader) } else { 0.0 };
+        let fire_while_moving = if len >= 24 { read_i32(reader) } else { 0 };
+        let contain_projectile = if len >= 28 { read_i32(reader) } else { 0 };
+        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
+        PropAIRangedCombat {
+            minimum_distance,
+            ideal_distance,
+            firing_delay,
+            cover_desire,
+            decay_speed,
+            fire_while_moving,
+            contain_projectile,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn read(hex: &str) -> PropAIRangedCombat {
+        let bytes: Vec<u8> = (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect();
+        let mut cursor = Cursor::new(bytes.clone());
+        let prop = PropAIRangedCombat::read(&mut cursor, bytes.len() as u32);
+        // The reader must land exactly on the end of the record.
+        assert_eq!(cursor.position(), bytes.len() as u64);
+        prop
+    }
+
+    /// A full 28-byte record: distances are plain ints, the delays floats.
+    #[test]
+    fn parses_a_full_record() {
+        let prop = read("0a000000280000000000004003000000000080400100000000000000");
+        assert_eq!(prop.minimum_distance, 10);
+        assert_eq!(prop.ideal_distance, 40);
+        assert_eq!(prop.firing_delay, 2.0);
+        assert_eq!(prop.cover_desire, 3);
+        assert_eq!(prop.decay_speed, 4.0);
+        assert_eq!(prop.fire_while_moving, 1);
+    }
+
+    /// A record too short for the tail still parses, leaving the rest zeroed.
+    #[test]
+    fn parses_a_truncated_record() {
+        let prop = read("0a00000028000000");
+        assert_eq!(prop.minimum_distance, 10);
+        assert_eq!(prop.ideal_distance, 40);
+        assert_eq!(prop.firing_delay, 0.0);
+    }
+}
+
+/// `P$AIRCRange`: boundaries between very-short, short, ideal, long and
+/// very-long range. Runtime units, like other parsed AI movement distances.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropAIRangedRanges(pub [f32; 4]);
+impl Default for PropAIRangedRanges {
+    fn default() -> Self {
+        Self([
+            0.0,
+            10.0 / crate::SCALE_FACTOR,
+            30.0 / crate::SCALE_FACTOR,
+            f32::MAX / crate::SCALE_FACTOR,
+        ])
+    }
+}
+impl PropAIRangedRanges {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        let start = reader.stream_position().unwrap();
+        let mut ranges = Self::default();
+        for (i, range) in ranges.0.iter_mut().enumerate() {
+            if len >= (i as u32 + 1) * 4 {
+                *range = read_single(reader) / crate::SCALE_FACTOR;
+            }
+        }
+        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
+        ranges
+    }
+}
+
+#[cfg(test)]
+mod range_tests {
+    use super::*;
+    #[test]
+    fn authored_range_bands_convert_once_and_consume_the_record() {
+        let bytes: Vec<_> = [5.0f32, 10.0, 15.0, 30.0]
+            .into_iter()
+            .flat_map(f32::to_le_bytes)
+            .collect();
+        let mut input = std::io::Cursor::new(bytes);
+        assert_eq!(
+            PropAIRangedRanges::read(&mut input, 16).0,
+            [2.0, 4.0, 6.0, 12.0]
+        );
+        assert_eq!(input.position(), 16);
+    }
+    #[test]
+    fn short_range_records_retain_defaults_for_absent_fields() {
+        let mut input = std::io::Cursor::new(5.0f32.to_le_bytes());
+        let range = PropAIRangedRanges::read(&mut input, 4);
+        assert_eq!(range.0[0], 2.0);
+        assert_eq!(range.0[1..], PropAIRangedRanges::default().0[1..]);
+    }
+}

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1528,7 +1528,7 @@ impl Script for AnimatedMonsterAI {
             steering_output,
             time,
             entity_id,
-            door_wait_seconds.is_some(),
+            door_wait_seconds.is_some() || self.current_behavior.borrow().holds_position(),
             heading_held,
         );
 

--- a/shock2vr/src/scripts/ai/behavior/back_off_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/back_off_behavior.rs
@@ -1,0 +1,352 @@
+use std::cell::RefCell;
+
+use cgmath::{Deg, InnerSpace, Point3, Quaternion, Rotation3, Vector3};
+use dark::{
+    SCALE_FACTOR,
+    motion::MotionQueryItem,
+    properties::{PropAIRangedCombat, PropAIRangedRanges, PropPosition},
+};
+use shipyard::{EntityId, Get, View, World};
+
+use super::{Behavior, ChaseBehavior, NextBehavior, RangedAttackBehavior};
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    scripts::{
+        Effect,
+        ai::{
+            ai_util,
+            steering::{ChasePlayerSteeringStrategy, SteeringOutput, SteeringStrategy},
+        },
+    },
+    time::Time,
+};
+
+#[derive(Clone, Copy)]
+pub(super) struct StandOff {
+    pub trigger: f32,
+    pub ideal: f32,
+    firing_delay: f32,
+    moving_fire: i32,
+}
+
+pub(super) fn authored_stand_off(world: &World, entity: EntityId) -> Option<StandOff> {
+    let props = world.borrow::<View<PropAIRangedCombat>>().ok()?;
+    let prop = props.get(entity).ok()?;
+    let ideal = (prop.ideal_distance.max(prop.minimum_distance) as f32 / SCALE_FACTOR)
+        .min(super::RANGED_MAX_ATTACK_DISTANCE - 0.2);
+    if ideal <= 0.0 {
+        return None;
+    }
+    let short = world
+        .borrow::<View<PropAIRangedRanges>>()
+        .ok()
+        .and_then(|ranges| ranges.get(entity).ok().copied())
+        .unwrap_or_default()
+        .0[1];
+    Some(StandOff {
+        // The grenade hybrid's AIRCProp minimum is zero. Its companion
+        // AIRCRange short band still calls for giving ground near a target.
+        trigger: (prop.minimum_distance.max(0) as f32 / SCALE_FACTOR)
+            .max(short)
+            .min(ideal),
+        ideal,
+        firing_delay: prop.firing_delay.max(0.0),
+        moving_fire: prop.fire_while_moving.clamp(0, 5),
+    })
+}
+
+/// A short reverse stride must have both body clearance and continuous floor
+/// support. Physical collision remains authoritative; these probes prevent a
+/// blind retreat off a ledge or into an already-obstructed corridor.
+pub(super) fn can_back_off(world: &World, physics: &PhysicsWorld, entity: EntityId) -> bool {
+    let positions = world.borrow::<View<PropPosition>>().unwrap();
+    let Ok(position) = positions.get(entity) else {
+        return false;
+    };
+    let origin = Point3::new(
+        position.position.x,
+        position.position.y,
+        position.position.z,
+    );
+    let backwards =
+        -(Quaternion::from_angle_y(ai_util::current_yaw(entity, world)) * Vector3::unit_z());
+    const STRIDE: f32 = 1.2;
+    if physics.projectile_spawn_distance(origin, backwards, STRIDE, 0.45, &|other| other != entity)
+        < STRIDE - 0.02
+    {
+        return false;
+    }
+    let floor = |point: Point3<f32>| {
+        physics
+            .ray_cast2_as_actor(
+                point,
+                -Vector3::unit_y(),
+                3.0,
+                InternalCollisionGroups::WORLD | InternalCollisionGroups::ENTITY,
+                Some(entity),
+                true,
+            )
+            .filter(|hit| hit.hit_normal.y > 0.55)
+            .map(|hit| hit.hit_point.y)
+    };
+    let Some(start_floor) = floor(origin) else {
+        return false;
+    };
+    [0.3, 0.6, 0.9, STRIDE].into_iter().all(|distance| {
+        floor(origin + backwards * distance)
+            .is_some_and(|height| (height - start_floor).abs() < 0.35)
+    })
+}
+
+pub struct BackOffBehavior {
+    stand_off: StandOff,
+    remaining_delay: f32,
+    stopped: bool,
+    clip_start: Option<Vector3<f32>>,
+}
+impl BackOffBehavior {
+    pub(super) fn new(stand_off: StandOff) -> Self {
+        Self {
+            stand_off,
+            remaining_delay: stand_off.firing_delay,
+            stopped: false,
+            clip_start: None,
+        }
+    }
+}
+impl Behavior for BackOffBehavior {
+    fn name(&self) -> &'static str {
+        "BackOff"
+    }
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        // Required direction: falling back to a forward walk would close
+        // the distance while the behavior claims to retreat.
+        vec![
+            MotionQueryItem::new("locomote"),
+            MotionQueryItem::with_value("direction", 4),
+        ]
+    }
+    fn is_locomotion(&self) -> bool {
+        true
+    }
+    fn holds_position(&self) -> bool {
+        self.stopped
+    }
+    fn steer(
+        &mut self,
+        heading: Deg<f32>,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity: EntityId,
+        time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        if self.clip_start.is_none() {
+            self.clip_start = world
+                .borrow::<View<PropPosition>>()
+                .ok()
+                .and_then(|positions| positions.get(entity).ok().map(|p| p.position));
+        }
+        self.remaining_delay = (self.remaining_delay - time.elapsed.as_secs_f32()).max(0.0);
+        self.stopped = ai_util::chase_target_distance(world, entity)
+            .is_none_or(|distance| distance >= self.stand_off.ideal)
+            || !can_back_off(world, physics, entity);
+        ChasePlayerSteeringStrategy.steer(heading, world, physics, entity, time)
+    }
+    fn next_behavior(
+        &mut self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity: EntityId,
+    ) -> NextBehavior {
+        let target = ai_util::chase_target(world, entity);
+        let clear =
+            target.is_some_and(|target| ai_util::has_line_of_fire(entity, world, physics, target));
+        if self.stopped || !clear {
+            return NextBehavior::Next(
+                super::attack_behavior_for_distance(world, physics, entity)
+                    .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new()))),
+            );
+        }
+        let position = world
+            .borrow::<View<PropPosition>>()
+            .unwrap()
+            .get(entity)
+            .ok()
+            .map(|p| p.position);
+        let progressed = self
+            .clip_start
+            .zip(position)
+            .is_some_and(|(start, end)| (end - start).magnitude2() > 0.0025);
+        self.clip_start = position;
+        // A missing reverse clip or an obstructed stride must not trap the
+        // actor retrying a movement that cannot happen. It can still shoot.
+        if !progressed {
+            return NextBehavior::Next(Box::new(RefCell::new(RangedAttackBehavior)));
+        }
+
+        // Dark's moving-fire preference is a squared chance, not a boolean.
+        // It pauses travel for an authored attack clip rather than inventing
+        // a projectile timer or firing without a weapon animation.
+        use rand::Rng;
+        if self.remaining_delay <= 0.0
+            && rand::thread_rng().gen_range(0..=50) < self.stand_off.moving_fire.pow(2)
+        {
+            return NextBehavior::Next(Box::new(RefCell::new(RangedAttackBehavior)));
+        }
+        NextBehavior::Stay
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{mission::PlayerInfo, physics::CollisionGroup};
+    use cgmath::vec3;
+    use dark::properties::{
+        AIProjectileOptions, AITargetMethod, Link, Links, PropHitPoints, ToLink,
+    };
+
+    fn fixture(
+        melee: bool,
+        minimum: i32,
+        ideal: i32,
+        floor: bool,
+    ) -> (World, PhysicsWorld, EntityId) {
+        let mut world = World::new();
+        let mut links = vec![ToLink {
+            to_template_id: -1,
+            to_entity_id: None,
+            link: Link::AIProjectile(AIProjectileOptions {
+                targeting_method: AITargetMethod::StraightLine,
+                delay: 0.0,
+                should_lead_target: false,
+                ammo: 0,
+                accuracy: 0,
+                select_time: 0.0,
+                joint: 0,
+                vhot: 0,
+            }),
+        }];
+        if melee {
+            links.push(ToLink {
+                to_template_id: -2,
+                to_entity_id: None,
+                link: Link::Weapon,
+            });
+        }
+        let entity = world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 1.0, 0.0),
+                rotation: Quaternion::from_angle_y(Deg(0.0)),
+                cell: 0,
+            },
+            PropHitPoints { hit_points: 15 },
+            Links { to_links: links },
+            PropAIRangedCombat {
+                minimum_distance: minimum,
+                ideal_distance: ideal,
+                firing_delay: 0.0,
+                cover_desire: 0,
+                decay_speed: 0.8,
+                fire_while_moving: 0,
+                contain_projectile: 0,
+            },
+        ));
+        world.add_component(
+            entity,
+            crate::runtime_props::RuntimePropTransform(cgmath::Matrix4::from_translation(vec3(
+                0.0, 1.0, 0.0,
+            ))),
+        );
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 1.0, 1.0),
+            rotation: Quaternion::from_angle_y(Deg(0.0)),
+            entity_id: EntityId::dead(),
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: EntityId::dead(),
+        });
+        let mut physics = PhysicsWorld::new();
+        if floor {
+            let ground = world.add_entity(());
+            physics.add_kinematic(
+                ground,
+                vec3(0.0, -0.5, 0.0),
+                Quaternion::from_angle_y(Deg(0.0)),
+                Vector3::zero(),
+                vec3(20.0, 1.0, 20.0),
+                CollisionGroup::entity(),
+                false,
+            );
+        }
+        let mut player = physics.create_player(vec3(30.0, 1.0, 30.0), EntityId::dead());
+        physics.update(Vector3::zero(), &mut player);
+        (world, physics, entity)
+    }
+    use cgmath::Zero;
+
+    #[test]
+    fn gun_only_creatures_back_off_but_cornered_and_melee_creatures_still_attack() {
+        for (melee, minimum, ideal, floor, expected) in [
+            (false, 10, 40, true, "BackOff"),
+            (false, 0, 20, true, "BackOff"),
+            (false, 10, 40, false, "RangedAttack"),
+            (true, 10, 40, true, "MeleeAttack"),
+        ] {
+            let (world, physics, entity) = fixture(melee, minimum, ideal, floor);
+            let selected =
+                super::super::attack_behavior_for_distance(&world, &physics, entity).unwrap();
+            assert_eq!(selected.borrow().name(), expected);
+        }
+    }
+
+    #[test]
+    fn reverse_clearance_rejects_walls_and_missing_support() {
+        let (mut world, mut physics, entity) = fixture(false, 10, 40, true);
+        assert!(can_back_off(&world, &physics, entity));
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 1.0, -1.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+            Vector3::zero(),
+            vec3(3.0, 4.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = physics.create_player(vec3(30.0, 1.0, 30.0), EntityId::dead());
+        physics.update(Vector3::zero(), &mut player);
+        assert!(!can_back_off(&world, &physics, entity));
+        let (world, physics, entity) = fixture(false, 10, 40, false);
+        assert!(!can_back_off(&world, &physics, entity));
+    }
+
+    #[test]
+    fn reverse_stride_rejects_a_ledge_even_when_the_actor_has_floor() {
+        let (mut world, mut physics, entity) = fixture(false, 10, 40, false);
+        let platform = world.add_entity(());
+        physics.add_kinematic(
+            platform,
+            vec3(0.0, -0.5, 1.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+            Vector3::zero(),
+            vec3(10.0, 1.0, 3.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = physics.create_player(vec3(30.0, 1.0, 30.0), EntityId::dead());
+        physics.update(Vector3::zero(), &mut player);
+        assert!(!can_back_off(&world, &physics, entity));
+    }
+
+    #[test]
+    fn missing_or_stalled_reverse_motion_falls_back_to_firing() {
+        let (world, physics, entity) = fixture(false, 10, 40, true);
+        let mut behavior = BackOffBehavior::new(authored_stand_off(&world, entity).unwrap());
+        behavior.clip_start = Some(vec3(0.0, 1.0, 0.0));
+        let NextBehavior::Next(next) = behavior.next_behavior(&world, &physics, entity) else {
+            panic!("must not stall");
+        };
+        assert_eq!(next.borrow().name(), "RangedAttack");
+    }
+}

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -93,6 +93,11 @@ pub trait Behavior {
         Effect::NoEffect
     }
 
+    /// Stop root-motion travel while retaining the current pose/heading.
+    fn holds_position(&self) -> bool {
+        false
+    }
+
     fn is_locomotion(&self) -> bool {
         false
     }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -1,3 +1,4 @@
+mod back_off_behavior;
 mod behavior;
 mod chase_behavior;
 mod dead_behavior;
@@ -11,6 +12,7 @@ mod search_behavior;
 mod self_destruct_behavior;
 mod wander_behavior;
 
+pub use back_off_behavior::BackOffBehavior;
 pub use behavior::*;
 pub use chase_behavior::*;
 pub use dead_behavior::*;
@@ -40,6 +42,8 @@ use crate::{
 /// melee swing - the detonation IS its melee attack (see
 /// `SelfDestructBehavior`) - but named separately so tuning the blast's
 /// trigger doesn't move every creature's melee range.
+pub(super) const RANGED_MAX_ATTACK_DISTANCE: f32 = 40.0 / SCALE_FACTOR;
+
 pub const PROTOCOL_DETONATION_RANGE: f32 = crate::scripts::ai::ai_util::MELEE_ATTACK_RANGE;
 
 /// The attack behavior for the current distance to the player, or None when
@@ -60,7 +64,7 @@ pub fn attack_behavior_for_distance(
     let target = chase_target(world, entity_id)?;
     let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
-    let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
+    let ranged_max_attack_distance = RANGED_MAX_ATTACK_DISTANCE;
 
     // Melee damage is the swing weapon's contact stims, so an AI with no
     // Weapon link cannot land a blow at all. The shotgun and grenade
@@ -89,6 +93,21 @@ pub fn attack_behavior_for_distance(
     // its self-destruct instead of a melee attack.
     if distance < PROTOCOL_DETONATION_RANGE && is_self_destructing(world, entity_id) {
         return Some(Box::new(RefCell::new(SelfDestructBehavior::new())));
+    }
+
+    // Standing distance is a movement preference, never a firing prohibition:
+    // a cornered gun-only creature must still shoot when it cannot retreat.
+    if (gives_up_melee || distance >= melee_attack_distance)
+        && has_ranged_weapon(world, entity_id)
+        && has_line_of_fire(entity_id, world, physics, target)
+    {
+        if let Some(stand_off) = back_off_behavior::authored_stand_off(world, entity_id) {
+            if distance < stand_off.trigger
+                && back_off_behavior::can_back_off(world, physics, entity_id)
+            {
+                return Some(Box::new(RefCell::new(BackOffBehavior::new(stand_off))));
+            }
+        }
     }
 
     // Only ranged-armed AIs stop to shoot; melee AIs must keep chasing or

--- a/tools/shock2-sdk/test/ranged-standoff.e2e.test.ts
+++ b/tools/shock2-sdk/test/ranged-standoff.e2e.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+for (const [mission, template, name] of [
+  ["eng1.mis", 728, "OG-Shotgun"],
+  ["ops2.mis", 66, "OG-Grenade"],
+] as const) {
+  test(`${name} gives ground when approached along a clear walkway`, {
+    skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000,
+  }, async () => {
+    await using game = await GameServer.launch({ mission });
+    const [hybrid] = await game.entities.byTemplate(template);
+    assert.ok(hybrid?.name.includes(name));
+    const [x, y, z] = hybrid.position;
+    await game.player.teleport({ x: x! - 1.1, y: y!, z: z! });
+    // Controlled aggro isolates combat positioning from peripheral vision.
+    await game.entities.sendMessage(hybrid.id, { type: "Damage", amount: 1 });
+    let backoffs = 0;
+    let greatestDistance = 0;
+    for (let i = 0; i < 24; i++) {
+      await game.step({ frames: 30 });
+      const actor = await game.entities.detail(hybrid.id);
+      const player = await game.player.position();
+      greatestDistance = Math.max(greatestDistance,
+        Math.hypot(actor.position[0]! - player.x, actor.position[2]! - player.z));
+      if (actor.properties.find(p => p.name === "AIBehavior")?.value.includes("BackOff")) backoffs++;
+    }
+    assert.ok(backoffs > 0, "must select an authored reverse locomotion clip");
+    assert.ok(greatestDistance > 3, `must gain separation, reached ${greatestDistance}`);
+  });
+}


### PR DESCRIPTION
Ranged hybrids now give ground when the player crowds them and a supported reverse stride is available. This wires the previously unparsed `AIRCProp` and `AIRCRange` preferences into a `BackOff` behavior using the authored `Locomote, Direction 4` motion. The grenade hybrid's zero minimum no longer hides its companion short-range preference.

Retreat keeps facing the target, checks body clearance and floor support, and stops at an obstruction or ledge. A missing/stalled reverse motion falls back to shooting. The minimum is a standing preference, so cornered enemies still fire. Moving-fire preference can interrupt travel with an actual attack clip after the authored delay. Preferred distance is bounded by the existing firing range; cover scoring, decay and projectile containment remain outside this change.

Fixes #1506.

Validation:
- New SDK scenarios fail on the base (neither shotgun nor grenade selects BackOff) and pass with the change, gaining more than 3 units of separation.
- Parser tests cover full/short records and distance conversion; AI tests cover gun-only versus dual-armed selection, obstructed reverse travel, floor support and missing-motion fallback.
- Warning-free checks for core, desktop and debug runtimes.
- Matched 20-second grenade replay against #1536: self-damage falls from 7 HP to 0 HP; both actors survive. This reduces close-range splash exposure, not all self-damage. Cornered actors still fire.

The capture uses eng1 mission object 728, places the player alongside the walkway, and sends one Damage point to establish aggro consistently. Same setup and fixed simulation steps on base and change. Base advances/stays close; change walks backward along the walkway (about 1.2 to 5.0 units separation). Depends on #1536: its attack reselection prevents an interrupted retreat from inserting a forward Chase clip. Media compares that parent against this change.

![Before/after retreat](https://gist.githubusercontent.com/tommy-xr/59821e479fd8ef5f951d4fadeaebc111/raw/backoff.gif?v=stack)

![Matched still](https://gist.githubusercontent.com/tommy-xr/59821e479fd8ef5f951d4fadeaebc111/raw/before-after.png?v=stack)

Combined AI-pass verification (all five PRs applied to baseline `a5d8cd54`):
- All newly added gameplay scenarios and all 23 mission loads passed; core unit tests and warning-free core/desktop/debug checks passed.
- Full SDK suite completed with four concurrent test files: **644 passed, 97 failed, 12 skipped**. Every one of the 97 failing test cases also failed on the unchanged baseline. The intermittent SHODAN corpse drift required baseline repeats and reproduced the exact same drift/positions.
- Full-suite verification found a missing BaseMonster restore dispatch for the new combat state; #1540 now includes the fix, a negative-first wrapper regression, and whole-mission save/load verification. The final full run uses that correction.

The full suite is therefore not green, but all reported failures have baseline reproductions. No PR has been merged.
