### PR TITLE
feat(ai): express stalled combat with per-mode frustration cooldowns

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -3958,13 +3958,16 @@ mod tests {
     #[test]
     fn turning_in_place_does_not_hide_stalled_combat() {
         let (mut world, entity) = world_with_monster_and_player(Deg(0.0));
-        world.add_component(entity, dark::properties::Links {
-            to_links: vec![dark::properties::ToLink {
-                to_template_id: -1,
-                to_entity_id: None,
-                link: dark::properties::Link::Weapon,
-            }],
-        });
+        world.add_component(
+            entity,
+            dark::properties::Links {
+                to_links: vec![dark::properties::ToLink {
+                    to_template_id: -1,
+                    to_entity_id: None,
+                    link: dark::properties::Link::Weapon,
+                }],
+            },
+        );
         let physics = PhysicsWorld::new();
         let mut monster = AnimatedMonsterAI::new();
         monster.alertness.current_level = AIAlertLevel::High;
@@ -3976,11 +3979,15 @@ mod tests {
         assert!(!monster.combat_frustration.allows(CombatMode::Melee));
         assert!(monster.combat_frustration.allows(CombatMode::Ranged));
         monster.turn_clip = None;
-        tell(&mut monster, &world, entity, MessagePayload::AnimationCompleted);
+        tell(
+            &mut monster,
+            &world,
+            entity,
+            MessagePayload::AnimationCompleted,
+        );
         assert!(monster.current_behavior.borrow().is_combat_frustration());
         monster.update_combat_frustration(&world, &physics, entity, true, 2.1);
         assert!(!monster.current_behavior.borrow().is_combat_frustration());
         assert!(!monster.combat_frustration.allows(CombatMode::Melee));
     }
-
 }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -323,6 +323,7 @@ pub struct AnimatedMonsterAI {
     door_wait: Option<(EntityId, f32)>,
     /// Seconds left before this AI may show frustration again
     frustration_cooldown: f32,
+    combat_frustration: CombatFrustration,
     /// Pinned alertness (DebugForceChase): treated as permanent sight of the
     /// player - no decay, live target position - until cleared
     alertness_pinned: bool,
@@ -357,6 +358,7 @@ impl AnimatedMonsterAI {
             door_cooldown: 0.0,
             door_wait: None,
             frustration_cooldown: 0.0,
+            combat_frustration: CombatFrustration::default(),
             turn_clip: None,
             turn_cooldown: 0.0,
             turn_token: 0,
@@ -386,6 +388,7 @@ impl AnimatedMonsterAI {
             door_cooldown: 0.0,
             door_wait: None,
             frustration_cooldown: 0.0,
+            combat_frustration: CombatFrustration::default(),
             turn_clip: None,
             turn_cooldown: 0.0,
             turn_token: 0,
@@ -459,9 +462,92 @@ impl AnimatedMonsterAI {
                 // an attack on arrival via the same shared helper). Without
                 // the range check, a far-away High AI stood still swinging.
                 physics
-                    .and_then(|physics| attack_behavior_for_distance(world, physics, entity_id))
+                    .and_then(|physics| self.available_attack(world, physics, entity_id))
                     .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new())))
             }
+        }
+    }
+
+    fn available_attack(
+        &self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity: EntityId,
+    ) -> Option<Box<RefCell<dyn Behavior>>> {
+        attack_behavior_with_modes(
+            world,
+            physics,
+            entity,
+            self.combat_frustration.allows(CombatMode::Melee),
+            self.combat_frustration.allows(CombatMode::Ranged),
+        )
+    }
+
+    fn update_combat_frustration(
+        &mut self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity: EntityId,
+        visible: bool,
+        dt: f32,
+    ) -> Effect {
+        self.combat_frustration.tick(dt);
+        if self.current_behavior.borrow().is_combat_frustration() {
+            if self.combat_frustration.gesture_remaining > 0.0 {
+                return Effect::NoEffect;
+            }
+            self.current_behavior = self.behavior_for_alertness(world, Some(physics), entity);
+        } else {
+            // Turning in place is not pursuit progress. Let the stall timer
+            // span pivots; replacing their clip reports cancellation normally.
+            let eligible = self.door_wait.is_none()
+                && self.current_behavior.borrow().scripted_state() == ScriptedState::NotScripted
+                && matches!(
+                    self.alertness.current_level,
+                    AIAlertLevel::Moderate | AIAlertLevel::High
+                )
+                && !is_self_destructing(world, entity);
+            if !eligible {
+                self.combat_frustration
+                    .observe(None, vec3(0.0, 0.0, 0.0), 0.0);
+                return Effect::NoEffect;
+            }
+            let melee = melee_weapon_template(world, entity).is_some();
+            let ranged = has_ranged_weapon(world, entity);
+            let distance = chase_target_distance(world, entity).unwrap_or(f32::MAX);
+            let mode = if melee && distance < MELEE_ATTACK_RANGE {
+                Some(CombatMode::Melee)
+            } else if ranged {
+                Some(CombatMode::Ranged)
+            } else if melee {
+                Some(CombatMode::Melee)
+            } else {
+                None
+            };
+            let lost_at_goal =
+                !visible && self.published_awareness.is_some() && distance < MELEE_ATTACK_RANGE;
+            let no_attack = self.available_attack(world, physics, entity).is_none();
+            let failed = if lost_at_goal || no_attack {
+                mode
+            } else {
+                None
+            };
+            let positions = world.borrow::<View<PropPosition>>().unwrap();
+            let Ok(position) = positions.get(entity) else {
+                return Effect::NoEffect;
+            };
+            if !self
+                .combat_frustration
+                .observe(failed, position.position, dt)
+            {
+                return Effect::NoEffect;
+            }
+            self.current_behavior = Box::new(RefCell::new(FrustrationBehavior));
+        }
+        Effect::PlayAnimationBySchema {
+            entity_id: entity,
+            motion_queries: self.current_behavior.borrow().animation_queries(),
+            selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
         }
     }
 
@@ -1186,6 +1272,31 @@ impl AnimatedMonsterAI {
 }
 
 impl Script for AnimatedMonsterAI {
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some("shock2vr.animated_combat")
+    }
+    fn save_state(&self) -> Result<crate::scripts::ScriptState, crate::scripts::ScriptStateError> {
+        crate::scripts::ScriptState::encode(1, &self.combat_frustration, "shock2vr.animated_combat")
+    }
+    fn restore_state(
+        &mut self,
+        saved: &crate::scripts::ScriptState,
+        _: &crate::scripts::ScriptRestoreContext<'_>,
+    ) -> Result<(), crate::scripts::ScriptStateError> {
+        self.combat_frustration = saved.decode(1, "shock2vr.animated_combat")?;
+        Ok(())
+    }
+    fn initialize_after_hydration(
+        &mut self,
+        entity: EntityId,
+        world: &World,
+        _hydrated: bool,
+    ) -> Effect {
+        // Only combat lockouts are persisted here; reconstruct the same
+        // configuration/awareness/initial pose as before this state existed.
+        self.initialize(entity, world)
+    }
+
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         self.current_heading = current_yaw(entity_id, world);
 
@@ -1589,6 +1700,13 @@ impl Script for AnimatedMonsterAI {
             &FovDebugConfig::monster(),
         );
 
+        let combat_effect = self.update_combat_frustration(
+            world,
+            physics,
+            entity_id,
+            is_visible,
+            time.elapsed.as_secs_f32(),
+        );
         let behavior_publish_effect = self.publish_behavior(entity_id);
 
         // Open a door blocking the pursuit (or give up at a locked one)
@@ -1608,6 +1726,7 @@ impl Script for AnimatedMonsterAI {
             door_effect,
             frustration_effect,
             turn_clip_effect,
+            combat_effect,
         ])
     }
 
@@ -1920,7 +2039,16 @@ impl Script for AnimatedMonsterAI {
                         NextBehavior::NoOpinion => (),
                         NextBehavior::Stay => (),
                         NextBehavior::Next(behavior) => {
-                            self.current_behavior = behavior;
+                            self.current_behavior = if behavior
+                                .borrow()
+                                .combat_mode()
+                                .is_some_and(|mode| !self.combat_frustration.allows(mode))
+                            {
+                                self.available_attack(world, physics, entity_id)
+                                    .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new())))
+                            } else {
+                                behavior
+                            };
                         }
                     };
 
@@ -3801,4 +3929,58 @@ mod tests {
 
         assert!(sound_queries(&effect).is_empty());
     }
+    #[test]
+    fn combat_lockouts_survive_hydration_without_replaying_the_gesture() {
+        let (world, entity) = world_with_monster_and_player(Deg(0.0));
+        let mut monster = AnimatedMonsterAI::new();
+        assert!(monster.combat_frustration.observe(
+            Some(CombatMode::Ranged),
+            vec3(0.0, 0.0, 0.0),
+            2.0
+        ));
+        monster.combat_frustration.tick(3.0);
+        let saved = monster.save_state().unwrap();
+        let mut restored = AnimatedMonsterAI::new();
+        restored
+            .restore_state(
+                &saved,
+                &crate::scripts::ScriptRestoreContext::new(&std::collections::HashMap::new()),
+            )
+            .unwrap();
+        restored.initialize_after_hydration(entity, &world, true);
+        assert_eq!(saved, restored.save_state().unwrap());
+        assert!(!restored.combat_frustration.allows(CombatMode::Ranged));
+        assert!(restored.combat_frustration.allows(CombatMode::Melee));
+        assert!(!restored.current_behavior.borrow().is_combat_frustration());
+        restored.combat_frustration.tick(7.0);
+        assert!(restored.combat_frustration.allows(CombatMode::Ranged));
+    }
+    #[test]
+    fn turning_in_place_does_not_hide_stalled_combat() {
+        let (mut world, entity) = world_with_monster_and_player(Deg(0.0));
+        world.add_component(entity, dark::properties::Links {
+            to_links: vec![dark::properties::ToLink {
+                to_template_id: -1,
+                to_entity_id: None,
+                link: dark::properties::Link::Weapon,
+            }],
+        });
+        let physics = PhysicsWorld::new();
+        let mut monster = AnimatedMonsterAI::new();
+        monster.alertness.current_level = AIAlertLevel::High;
+        monster.turn_clip = Some(TurnClip::Requested { token: 1 });
+        for _ in 0..21 {
+            monster.update_combat_frustration(&world, &physics, entity, true, 0.1);
+        }
+        assert!(monster.current_behavior.borrow().is_combat_frustration());
+        assert!(!monster.combat_frustration.allows(CombatMode::Melee));
+        assert!(monster.combat_frustration.allows(CombatMode::Ranged));
+        monster.turn_clip = None;
+        tell(&mut monster, &world, entity, MessagePayload::AnimationCompleted);
+        assert!(monster.current_behavior.borrow().is_combat_frustration());
+        monster.update_combat_frustration(&world, &physics, entity, true, 2.1);
+        assert!(!monster.current_behavior.borrow().is_combat_frustration());
+        assert!(!monster.combat_frustration.allows(CombatMode::Melee));
+    }
+
 }

--- a/shock2vr/src/scripts/ai/behavior/back_off_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/back_off_behavior.rs
@@ -118,6 +118,9 @@ impl Behavior for BackOffBehavior {
     fn name(&self) -> &'static str {
         "BackOff"
     }
+    fn combat_mode(&self) -> Option<super::CombatMode> {
+        Some(super::CombatMode::Ranged)
+    }
     fn animation(&self) -> Vec<MotionQueryItem> {
         // Required direction: falling back to a forward walk would close
         // the distance while the behavior claims to retreat.
@@ -337,6 +340,20 @@ mod tests {
         let mut player = physics.create_player(vec3(30.0, 1.0, 30.0), EntityId::dead());
         physics.update(Vector3::zero(), &mut player);
         assert!(!can_back_off(&world, &physics, entity));
+    }
+
+    #[test]
+    fn ranged_lockout_also_suppresses_retreat_that_could_fire() {
+        let (world, physics, entity) = fixture(false, 10, 40, true);
+        assert!(
+            super::super::attack_behavior_with_modes(&world, &physics, entity, true, false,)
+                .is_none()
+        );
+        let behavior = BackOffBehavior::new(authored_stand_off(&world, entity).unwrap());
+        assert_eq!(
+            behavior.combat_mode(),
+            Some(super::super::CombatMode::Ranged)
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -37,6 +37,13 @@ pub trait Behavior {
     /// Short stable name for debug introspection (e.g. "Chase", "Wander")
     fn name(&self) -> &'static str;
 
+    fn combat_mode(&self) -> Option<super::CombatMode> {
+        None
+    }
+    fn is_combat_frustration(&self) -> bool {
+        false
+    }
+
     fn scripted_state(&self) -> ScriptedState {
         ScriptedState::NotScripted
     }

--- a/shock2vr/src/scripts/ai/behavior/frustration_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/frustration_behavior.rs
@@ -1,0 +1,131 @@
+use super::{Behavior, NextBehavior};
+use crate::physics::PhysicsWorld;
+use cgmath::{InnerSpace, Vector3};
+use dark::motion::MotionQueryItem;
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, World};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CombatMode {
+    Melee,
+    Ranged,
+}
+
+/// Private AI state: no ECS mirrors, and no target entity IDs to remap.
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CombatFrustration {
+    lockouts: [f32; 2],
+    failed_mode: Option<CombatMode>,
+    stalled_seconds: f32,
+    progress_anchor: Option<Vector3<f32>>,
+    pub gesture_remaining: f32,
+}
+impl CombatFrustration {
+    pub fn allows(&self, mode: CombatMode) -> bool {
+        self.lockouts[mode as usize] <= 0.0
+    }
+    pub fn tick(&mut self, dt: f32) {
+        for remaining in &mut self.lockouts {
+            *remaining = (*remaining - dt).max(0.0);
+        }
+        self.gesture_remaining = (self.gesture_remaining - dt).max(0.0);
+    }
+    /// A blocked ray alone is not a failure: walking toward an opening is
+    /// useful progress. Wait for two seconds of actual stalled combat.
+    pub fn observe(&mut self, failed: Option<CombatMode>, position: Vector3<f32>, dt: f32) -> bool {
+        let failed = failed.filter(|mode| self.allows(*mode));
+        let progressed = self
+            .progress_anchor
+            .is_none_or(|anchor| (position - anchor).magnitude2() > 0.0625);
+        if failed != self.failed_mode || progressed || failed.is_none() {
+            self.stalled_seconds = 0.0;
+            self.progress_anchor = Some(position);
+            self.failed_mode = failed;
+        }
+        let Some(mode) = failed else {
+            return false;
+        };
+        self.stalled_seconds += dt;
+        if self.stalled_seconds < 2.0 {
+            return false;
+        }
+        self.lockouts[mode as usize] = 10.0;
+        self.gesture_remaining = 2.0;
+        self.stalled_seconds = 0.0;
+        self.failed_mode = None;
+        true
+    }
+}
+
+pub struct FrustrationBehavior;
+impl Behavior for FrustrationBehavior {
+    fn name(&self) -> &'static str {
+        "Frustration"
+    }
+    fn is_combat_frustration(&self) -> bool {
+        true
+    }
+    fn preempted_by_alertness(&self) -> bool {
+        false
+    }
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        vec![
+            MotionQueryItem::new("discover"),
+            MotionQueryItem::new("thwarted"),
+        ]
+    }
+    fn animation_queries(&self) -> Vec<Vec<MotionQueryItem>> {
+        // Shotgun hybrids author a challenge but no thwarted performance.
+        // Keep the actual frustration gesture first for pipe hybrids and
+        // other creatures that have it.
+        vec![
+            self.animation(),
+            vec![
+                MotionQueryItem::new("discover"),
+                MotionQueryItem::new("challenge"),
+            ],
+        ]
+    }
+    fn next_behavior(
+        &mut self,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _entity: EntityId,
+    ) -> NextBehavior {
+        // Completion from the displaced attack/turn clip can arrive on the
+        // next frame. The parent owns the bounded two-second hold, including
+        // the fallback when this creature has no authored gesture.
+        NextBehavior::Stay
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec3;
+    #[test]
+    fn progress_prevents_frustration_and_lockouts_are_per_mode() {
+        let mut state = CombatFrustration::default();
+        for i in 0..30 {
+            assert!(!state.observe(Some(CombatMode::Ranged), vec3(i as f32, 0.0, 0.0), 0.1));
+        }
+        for _ in 0..18 {
+            assert!(!state.observe(Some(CombatMode::Ranged), vec3(29.0, 0.0, 0.0), 0.1));
+        }
+        assert!(state.observe(Some(CombatMode::Ranged), vec3(29.0, 0.0, 0.0), 0.2));
+        assert!(!state.allows(CombatMode::Ranged));
+        assert!(state.allows(CombatMode::Melee));
+        state.tick(9.0);
+        assert!(!state.allows(CombatMode::Ranged));
+        state.tick(1.0);
+        assert!(state.allows(CombatMode::Ranged));
+    }
+    #[test]
+    fn recovering_an_attack_resets_pending_frustration() {
+        let mut state = CombatFrustration::default();
+        let pos = vec3(0.0, 0.0, 0.0);
+        assert!(!state.observe(Some(CombatMode::Melee), pos, 1.5));
+        assert!(!state.observe(None, pos, 0.1));
+        assert!(!state.observe(Some(CombatMode::Melee), pos, 1.5));
+    }
+}

--- a/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
@@ -19,6 +19,10 @@ use super::{Behavior, ChaseBehavior, NextBehavior};
 pub struct MeleeAttackBehavior;
 
 impl Behavior for MeleeAttackBehavior {
+    fn combat_mode(&self) -> Option<super::CombatMode> {
+        Some(super::CombatMode::Melee)
+    }
+
     fn name(&self) -> &'static str {
         "MeleeAttack"
     }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -2,6 +2,7 @@ mod back_off_behavior;
 mod behavior;
 mod chase_behavior;
 mod dead_behavior;
+mod frustration_behavior;
 mod idle_behavior;
 mod melee_attack_behavior;
 mod noop_behavior;
@@ -16,6 +17,7 @@ pub use back_off_behavior::BackOffBehavior;
 pub use behavior::*;
 pub use chase_behavior::*;
 pub use dead_behavior::*;
+pub use frustration_behavior::*;
 pub use idle_behavior::*;
 pub use melee_attack_behavior::*;
 pub use patrol_behavior::*;
@@ -56,6 +58,16 @@ pub fn attack_behavior_for_distance(
     physics: &PhysicsWorld,
     entity_id: EntityId,
 ) -> Option<Box<RefCell<dyn Behavior>>> {
+    attack_behavior_with_modes(world, physics, entity_id, true, true)
+}
+
+pub fn attack_behavior_with_modes(
+    world: &World,
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+    allow_melee: bool,
+    allow_ranged: bool,
+) -> Option<Box<RefCell<dyn Behavior>>> {
     // Distance and line of fire both gate against the AI's KNOWN target
     // (the last-known position when awareness is published, the player's
     // true position otherwise) - the same point chase steering faces and
@@ -64,7 +76,6 @@ pub fn attack_behavior_for_distance(
     let target = chase_target(world, entity_id)?;
     let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
-    let ranged_max_attack_distance = RANGED_MAX_ATTACK_DISTANCE;
 
     // Melee damage is the swing weapon's contact stims, so an AI with no
     // Weapon link cannot land a blow at all. The shotgun and grenade
@@ -83,7 +94,7 @@ pub fn attack_behavior_for_distance(
     // A gun AI with nothing to swing keeps shooting all the way in to
     // contact rather than standing off, so being cornered by one hurts:
     // retail hybrids fire point-blank instead of closing to swing.
-    let ranged_min_attack_distance = if gives_up_melee {
+    let ranged_min_attack_distance = if gives_up_melee || !allow_melee {
         0.0
     } else {
         15.0 / SCALE_FACTOR
@@ -97,7 +108,8 @@ pub fn attack_behavior_for_distance(
 
     // Standing distance is a movement preference, never a firing prohibition:
     // a cornered gun-only creature must still shoot when it cannot retreat.
-    if (gives_up_melee || distance >= melee_attack_distance)
+    if allow_ranged
+        && (gives_up_melee || !allow_melee || distance >= melee_attack_distance)
         && has_ranged_weapon(world, entity_id)
         && has_line_of_fire(entity_id, world, physics, target)
     {
@@ -117,13 +129,14 @@ pub fn attack_behavior_for_distance(
     // another floor) must be chased, or the AI stands rooted firing into
     // geometry for as long as its alertness holds - permanently under a
     // pinned alert (issue #481's stand-and-shoot freeze).
-    if distance > ranged_min_attack_distance
-        && distance < ranged_max_attack_distance
+    if allow_ranged
+        && distance > ranged_min_attack_distance
+        && distance < RANGED_MAX_ATTACK_DISTANCE
         && has_ranged_weapon(world, entity_id)
         && has_line_of_fire(entity_id, world, physics, target)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
-    } else if distance < melee_attack_distance && !gives_up_melee {
+    } else if allow_melee && distance < melee_attack_distance && !gives_up_melee {
         Some(Box::new(RefCell::new(MeleeAttackBehavior)))
     } else {
         None
@@ -296,5 +309,16 @@ mod tests {
             panic!("blocked fire must select chase");
         };
         assert_eq!(next.borrow().name(), "Chase");
+    }
+
+    #[test]
+    fn frustrated_melee_can_hand_off_to_a_real_ranged_weapon_at_contact() {
+        let (world, entity) = world_with_armed_ai(vec![Link::Weapon, ai_projectile()], 1.0);
+        let physics = PhysicsWorld::new();
+        let attack = attack_behavior_with_modes(&world, &physics, entity, false, true).unwrap();
+        assert_eq!(attack.borrow().name(), "RangedAttack");
+        assert!(attack_behavior_with_modes(&world, &physics, entity, false, false).is_none());
+        let attack = attack_behavior_with_modes(&world, &physics, entity, true, false).unwrap();
+        assert_eq!(attack.borrow().name(), "MeleeAttack");
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
@@ -19,6 +19,10 @@ use super::{Behavior, ChaseBehavior, NextBehavior};
 pub struct RangedAttackBehavior;
 
 impl Behavior for RangedAttackBehavior {
+    fn combat_mode(&self) -> Option<super::CombatMode> {
+        Some(super::CombatMode::Ranged)
+    }
+
     fn name(&self) -> &'static str {
         "RangedAttack"
     }

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -53,6 +53,7 @@ impl Script for BaseMonster {
         self.hydrated_ai = false;
         if let Some((key, saved)) = child {
             self.ai = match key.as_str() {
+                "shock2vr.animated_combat" => Box::new(AnimatedMonsterAI::new()),
                 "shock2vr.grub_ai" => Box::new(GrubAI::new()),
                 "shock2vr.swarmer_ai" => Box::new(SwarmerAI::new()),
                 "shock2vr.turret" => Box::new(TurretAI::new()),
@@ -223,6 +224,25 @@ mod tests {
             self.0.set(self.0.get() + 1);
             Effect::NoEffect
         }
+    }
+
+    #[test]
+    fn animated_combat_state_round_trips_through_the_monster_wrapper() {
+        let original = BaseMonster {
+            ai: Box::new(AnimatedMonsterAI::new()),
+            stasis: None,
+            hydrated_ai: false,
+        };
+        let saved = original.save_state().unwrap();
+        let mut restored = BaseMonster::new();
+        restored
+            .restore_state(
+                &saved,
+                &super::super::ScriptRestoreContext::new(&std::collections::HashMap::new()),
+            )
+            .unwrap();
+        assert!(restored.hydrated_ai);
+        assert_eq!(restored.save_state().unwrap(), saved);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/combat-frustration.e2e.test.ts
+++ b/tools/shock2-sdk/test/combat-frustration.e2e.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+test("an unreachable target causes a bounded gesture and a combat-mode cooldown", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "eng1.mis" });
+  await game.step({ frames: 5 });
+  const [hybrid] = await game.entities.byTemplate(728);
+  assert.ok(hybrid?.name.includes("OG-Shotgun"));
+  // The player is on the lower floor, separated from the balcony by solid
+  // geometry. Pin awareness so this tests combat failure, not forgetting.
+  await game.player.teleport({ x: 41.3, y: -20, z: -18.5 });
+  await game.input.trigger("DebugForceChase");
+  const episodes: number[] = [];
+  let active = false;
+  let longestHold = 0;
+  let hold = 0;
+  for (let i = 0; i < 80; i++) {
+    await game.step({ frames: 15 });
+    const actor = await game.entities.detail(hybrid.id);
+    const frustrated = actor.properties.find(p => p.name === "AIBehavior")?.value.includes("Frustration") ?? false;
+    if (frustrated && !active) episodes.push((i + 1) / 4);
+    hold = frustrated ? hold + 0.25 : 0;
+    longestHold = Math.max(longestHold, hold);
+    active = frustrated;
+  }
+  assert.ok(episodes.length > 0, "a stalled combatant must express frustration");
+  assert.ok(longestHold >= 1 && longestHold <= 2.5,
+    `gesture should persist briefly, observed ${longestHold}s`);
+  for (let i = 1; i < episodes.length; i++) {
+    assert.ok(episodes[i]! - episodes[i - 1]! >= 9.5,
+      `must not repeat during lockout: ${episodes}`);
+  }
+});

--- a/tools/shock2-sdk/test/combat-frustration.e2e.test.ts
+++ b/tools/shock2-sdk/test/combat-frustration.e2e.test.ts
@@ -29,6 +29,17 @@ test("an unreachable target causes a bounded gesture and a combat-mode cooldown"
   assert.ok(episodes.length > 0, "a stalled combatant must express frustration");
   assert.ok(longestHold >= 1 && longestHold <= 2.5,
     `gesture should persist briefly, observed ${longestHold}s`);
+  // Exercise the BaseMonster wrapper's nested state dispatch, not only the
+  // child AI serializer: every armed monster in the mission uses this path.
+  const save = `combat_frustration_e2e_${Date.now()}`;
+  assert.equal((await game.save(save)).success, true);
+  assert.equal((await game.load(save)).success, true);
+  const [restored] = await game.entities.byTemplate(728);
+  assert.ok(restored);
+  await game.step({ frames: 30 });
+  assert.ok(!(await game.entities.detail(restored.id)).properties
+    .find(p => p.name === "AIBehavior")?.value.includes("Frustration"),
+    "loading a cooldown must not replay its completed gesture");
   for (let i = 1; i < episodes.length; i++) {
     assert.ok(episodes[i]! - episodes[i - 1]! >= 9.5,
       `must not repeat during lockout: ${episodes}`);


### PR DESCRIPTION
An armed creature that cannot attack and makes no movement progress for two seconds now performs a brief frustration gesture, then pursues again with the failed combat mode locked out for ten seconds. This covers blocked fire, an empty last-known target position, and stalled pursuit. Meaningful movement or an available attack clears the pending failure; permanently unarmed and self-destruct creatures do not enter this round trip.

Melee/ranged cooldowns belong to script-private saved state. Attack selection skips the locked mode, allows a dual-armed creature to use its other weapon, and applies the same gate to BackOff (which can fire). The gesture prefers authored `discover/thwarted`, with `discover/challenge` as a fallback for shotgun hybrids. A bounded two-second hold survives stale animation-completion messages and terminates even when neither motion exists.

Fixes #1493. Depends on #1538 and #1536 so combat selection, retreat and mode lockouts remain coherent.

Validation:
- Negative-first SDK scenario: eng1 shotgun 728 on the balcony, player on the lower floor behind geometry, DebugForceChase pins awareness. Base never frustrates; fixed holds the gesture for about two seconds, resumes Chase and does not spam it during cooldown.
- AI tests cover progress/reset behavior, independent mode timers, dual-armed handoff, lockout save/hydration, turning in place, stale clip completion and ranged-retreat suppression.
- Warning-free core, desktop and debug checks.

The failure trigger is deliberately a sustained failed attack without movement progress, rather than treating every blocked ray during a useful pursuit as frustration. This does not implement the original engine's entire combat planner.


### Visual verification

![Combat frustration before and after](https://gist.githubusercontent.com/tommy-xr/f0ae63a9afabb656d7c08c15d0607018/raw/fef8bd8189f7cae971c53ffc18dd2e2f05c8841c/combat-frustration.gif)

Controlled eng1 comparison against the stacked base: shotgun hybrid 728 remains on its balcony while the player stands on the lower floor across the railing. `DebugForceChase` pins awareness to isolate failed combat from alertness decay. Both builds use the same placement and fixed 60 Hz input sequence. The fix plays the authored challenge fallback (shotgun hybrids lack `discover/thwarted`), then resumes Chase. This test does not claim to make the lower-floor target reachable.

The 18-second trace records no Frustration on the base. The integrated fix holds Frustration at 2.1–4.0 seconds and 14.1–16.0 seconds, returning to Chase between them: a bounded gesture and 12 seconds between entries, consistent with the ten-second mode lockout plus a fresh two-second failure window.

![Before and after at three simulated seconds](https://gist.githubusercontent.com/tommy-xr/f0ae63a9afabb656d7c08c15d0607018/raw/fef8bd8189f7cae971c53ffc18dd2e2f05c8841c/before-after.png)

Combined AI-pass verification (all five PRs applied to baseline `a5d8cd54`):
- All newly added gameplay scenarios and all 23 mission loads passed; core unit tests and warning-free core/desktop/debug checks passed.
- Full SDK suite completed with four concurrent test files: **644 passed, 97 failed, 12 skipped**. Every one of the 97 failing test cases also failed on the unchanged baseline. The intermittent SHODAN corpse drift required baseline repeats and reproduced the exact same drift/positions.
- Full-suite verification found a missing BaseMonster restore dispatch for the new combat state; #1540 now includes the fix, a negative-first wrapper regression, and whole-mission save/load verification. The final full run uses that correction.

The full suite is therefore not green, but all reported failures have baseline reproductions. No PR has been merged.
